### PR TITLE
feat(library): add setting to hide shows without local files

### DIFF
--- a/backend/handlers/account_templates/settings.html
+++ b/backend/handlers/account_templates/settings.html
@@ -510,6 +510,18 @@ function renderSettings() {
                         </select>
                     </div>
                 </div>
+                <div class="setting-row">
+                    <div class="setting-label">
+                        <h4>Hide Shows Without Local Files</h4>
+                        <p>Only show content that has files available in your local library on disk</p>
+                    </div>
+                    <div class="setting-control">
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="hideShowsWithoutLocalFiles" ${s.filtering.hideShowsWithoutLocalFiles ? 'checked' : ''} onchange="markChanged()">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
                 <div class="setting-row" style="flex-direction: column; align-items: flex-start;">
                     <div class="setting-label" style="margin-bottom: 0.5rem;">
                         <h4>Excluded Terms</h4>
@@ -585,6 +597,7 @@ function collectSettings() {
             prioritizeHdr: document.getElementById('prioritizeHdr').checked,
             hdrDvPolicy: document.getElementById('hdrDvPolicy').value,
             filterOutTerms: currentSettings.filtering.filterOutTerms || [],
+            hideShowsWithoutLocalFiles: document.getElementById('hideShowsWithoutLocalFiles').checked,
         },
         liveTV: currentSettings.liveTV || { hiddenChannels: [], favoriteChannels: [], selectedCategories: [] },
     };

--- a/backend/handlers/metadata.go
+++ b/backend/handlers/metadata.go
@@ -118,6 +118,7 @@ func (h *MetadataHandler) DiscoverNew(w http.ResponseWriter, r *http.Request) {
 	userID := strings.TrimSpace(r.URL.Query().Get("userId"))
 	hideUnreleased := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("hideUnreleased"))) == "true"
 	hideWatched := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("hideWatched"))) == "true"
+	hideNonLocal := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("hideNonLocal"))) == "true"
 	// Parse optional pagination parameters
 	limit := 0
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
@@ -151,6 +152,12 @@ func (h *MetadataHandler) DiscoverNew(w http.ResponseWriter, r *http.Request) {
 	// Apply watched filter if requested (requires userID and history service)
 	if hideWatched && userID != "" && h.HistoryService != nil {
 		items = filterWatchedItems(items, userID, h.HistoryService)
+	}
+
+	// Apply local library filter if requested
+	// TODO: Wire to local file index when disk playback feature is implemented
+	if hideNonLocal {
+		items = filterNonLocalItems(items)
 	}
 
 	// Apply kids rating filter if user is a kids profile
@@ -752,6 +759,13 @@ func filterUnreleasedItems(items []models.TrendingItem) []models.TrendingItem {
 	}
 	log.Printf("[hideUnreleased] filter result: %d/%d items kept (filtered %d)", len(result), len(items), filteredCount)
 	return result
+}
+
+// filterNonLocalItems removes items that don't have associated local files on disk.
+// TODO: Implement when local disk playback feature is added — query the local file index
+// and filter out items with no matching local files.
+func filterNonLocalItems(items []models.TrendingItem) []models.TrendingItem {
+	return items
 }
 
 // filterWatchedItems removes items that have been fully watched by the user.

--- a/backend/models/user_settings.go
+++ b/backend/models/user_settings.go
@@ -253,6 +253,7 @@ type FilterSettings struct {
 	PreferredTerms                   []string    `json:"preferredTerms,omitempty"`                   // Terms to prioritize in results (case-insensitive match in title)
 	NonPreferredTerms                []string    `json:"nonPreferredTerms,omitempty"`                // Terms to derank in results (case-insensitive match in title, ranked lower but not removed)
 	BypassFilteringForAIOStreamsOnly *bool       `json:"bypassFilteringForAioStreamsOnly,omitempty"` // Skip mediastorm filtering/ranking when AIOStreams is the only enabled scraper
+	HideShowsWithoutLocalFiles      *bool       `json:"hideShowsWithoutLocalFiles,omitempty"`       // Hide shows that don't have any files in the local library on disk
 }
 
 // AnimeFilteringSettings controls anime-specific language preferences (per-user overrides).


### PR DESCRIPTION
## Summary

- Adds a `hideShowsWithoutLocalFiles` boolean to `FilterSettings` in user settings, stored per-profile in `user_settings.json`
- Adds a toggle in the Profile Settings UI under the **Content Filtering** section
- Wires a `hideNonLocal` query param into the `DiscoverNew` endpoint with a stub `filterNonLocalItems()` function ready to connect to the local file index when disk playback ships

## Notes

This is a forward-looking companion feature for the upcoming local disk playback support. The setting is fully functional end-to-end (saves, loads, and is passed to the backend) but the filter itself is a no-op stub until the local file index exists. The `TODO` comment in `filterNonLocalItems()` marks the integration point.

## Test plan

- [ ] Toggle renders in Profile Settings → Content Filtering section
- [ ] Toggling and saving persists the value (verify via GET `/api/users/{id}/settings`)
- [ ] `hideNonLocal=true` query param accepted by `GET /api/discover/new` without error
- [ ] Setting defaults to off (no change in behavior for existing users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)