### PR TITLE
fix: increase indexer HTTP connection pool for parallel queries

### DIFF
--- a/backend/services/indexer/service.go
+++ b/backend/services/indexer/service.go
@@ -123,7 +123,14 @@ func NewService(cfg *config.Manager, metadataSvc metadataSearchService, debridSv
 	}
 	return &Service{
 		cfg:            cfg,
-		httpc:          &http.Client{Timeout: 20 * time.Second},
+		httpc: &http.Client{
+			Timeout: 20 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 16,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
 		debrid:         debridSvc,
 		debridPlayback: debrid.NewPlaybackService(cfg, nil),
 		metadata:       metadataSvc,


### PR DESCRIPTION
## Summary
- The indexer's HTTP client uses Go's default transport which limits `MaxIdleConnsPerHost` to 2
- When searching with multiple alternate titles in parallel (7+ queries to the same indexer host), connections queue up and serialize, causing 20+ second search times instead of ~1s
- Sets `MaxIdleConnsPerHost: 16` to allow full parallelism, matching the debrid streaming/proxy services which already use custom transports

## Test plan
- [ ] Search for a movie with many alternate titles (e.g. "Zootopia 2" which has 5+ localized titles)
- [ ] Verify all parallel indexer queries complete within ~1-2s instead of 20+s
- [ ] Check `[prequeue] TIMING: split usenet search complete` log for reduced elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)