### PR TITLE
fix: relax NZB validation to allow missing groups element

### DIFF
--- a/backend/internal/importer/parser.go
+++ b/backend/internal/importer/parser.go
@@ -638,9 +638,8 @@ func (p *Parser) ValidateNzb(parsed *ParsedNzb) error {
 			return NewNonRetryableError(fmt.Sprintf("invalid NZB: file %d has invalid size", i), nil)
 		}
 
-		if len(file.Groups) == 0 {
-			return NewNonRetryableError(fmt.Sprintf("invalid NZB: file %d has no groups", i), nil)
-		}
+		// Note: groups are optional — many indexers (Zyclops, NZBHydra) omit them.
+		// Segment article IDs are globally unique, so groups aren't needed for downloading.
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Many indexers generate NZBs without the `<groups>` element
- NNTP segment article IDs are globally unique across all groups, so the groups field is metadata only — not required for downloading
- The strict validation rejected these NZBs with `file 0 has no groups`, causing playback failures for content that downloads fine in SABnzbd and other NZB clients

## Test plan
- [ ] Test with NZBs that have `<groups>` elements (should still work)
- [ ] Test with NZBs that omit `<groups>` elements (should no longer fail validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)