### PR TITLE
fix: skip ensureDefaultUser on PostgreSQL to prevent FK violation on fresh install

### DIFF
--- a/backend/services/users/service.go
+++ b/backend/services/users/service.go
@@ -65,15 +65,15 @@ type Service struct {
 func (s *Service) useDB() bool { return s.store != nil }
 
 // NewServiceWithStore creates a users service backed by PostgreSQL.
+// Note: ensureDefaultUser is skipped for PostgreSQL because the default
+// account ("default") may not exist yet due to foreign key constraints.
+// Profile creation is handled after accounts are initialized.
 func NewServiceWithStore(store *datastore.DataStore) (*Service, error) {
 	svc := &Service{
 		store: store,
 		users: make(map[string]models.User),
 	}
 	if err := svc.load(); err != nil {
-		return nil, err
-	}
-	if err := svc.ensureDefaultUser(); err != nil {
 		return nil, err
 	}
 	return svc, nil


### PR DESCRIPTION
## Summary
- On a fresh PostgreSQL install, `NewServiceWithStore` calls `ensureDefaultUser` which tries to INSERT a user with `account_id="default"`
- The accounts table is empty at this point — the master account hasn't been created yet by `accounts.NewServiceWithStore`
- This causes a foreign key constraint violation: `ERROR: insert or update on table "users" violates foreign key constraint "users_account_id_fkey" (SQLSTATE 23503)`
- Fix: skip `ensureDefaultUser` for the PostgreSQL path. The JSON file path retains its legacy behavior.

## Test plan
- [ ] Fresh PostgreSQL install starts without crash
- [ ] Existing PostgreSQL installs (migrated from JSON) continue to work
- [ ] JSON-only installs still create the default user on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)