### PR TITLE
feat: adaptive download worker cap based on provider connections

### DIFF
--- a/backend/config/adapter.go
+++ b/backend/config/adapter.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/javi11/nntppool"
+	"novastream/internal/usenet"
 )
 
 // AltMountConfig represents the subset of configuration needed by altmount packages
@@ -89,13 +90,38 @@ func (ca *ConfigAdapter) GetConfig() *AltMountConfig {
 		}
 	}
 
+	// Dynamically cap download workers based on provider connection limits
+	// and the number of active usenet readers (concurrent streams).
+	// Each stream gets an equal share of available connections minus headroom.
+	maxWorkers := settings.Streaming.MaxDownloadWorkers
+	totalConns := 0
+	for _, u := range settings.Usenet {
+		if u.Enabled && u.Host != "" {
+			totalConns += u.Connections
+		}
+	}
+	if totalConns > 0 {
+		const headroom = 2 // reserve for STAT commands / health checks
+		readers := int(usenet.ActiveReaders())
+		if readers < 1 {
+			readers = 1
+		}
+		perStreamCap := (totalConns - headroom) / readers
+		if perStreamCap < 4 {
+			perStreamCap = 4 // floor: at least 4 workers per stream
+		}
+		if maxWorkers > perStreamCap {
+			maxWorkers = perStreamCap
+		}
+	}
+
 	return &AltMountConfig{
 		RClone: RCloneConfig{
 			Password: "", // Not used in NovaStream
 			Salt:     "", // Not used in NovaStream
 		},
 		Streaming: StreamingConfig{
-			MaxDownloadWorkers: settings.Streaming.MaxDownloadWorkers,
+			MaxDownloadWorkers: maxWorkers,
 			MaxCacheSizeMB:     settings.Streaming.MaxCacheSizeMB,
 		},
 		Import: ImportConfig{
@@ -125,8 +151,9 @@ func (ca *ConfigAdapter) GetConfigGetter() ConfigGetter {
 
 // ToNNTPProviders converts NovaStream usenet settings to NNTP provider configs
 const (
-	// Close idle sockets aggressively so providers with short idle limits don't reset them out from under us.
-	defaultMaxConnectionIdleTimeSeconds = 120
+	// Close idle sockets quickly so connections are freed promptly after playback stops,
+	// leaving headroom for new streams without hitting provider connection limits.
+	defaultMaxConnectionIdleTimeSeconds = 10
 	// Give each connection a reasonable upper bound before we recycle it even if it stays active.
 	defaultMaxConnectionTTLSeconds = 900
 )

--- a/backend/internal/usenet/usenet_reader.go
+++ b/backend/internal/usenet/usenet_reader.go
@@ -23,6 +23,11 @@ var (
 
 const defaultDownloadWorkers = 15
 
+// ActiveReaders returns the current number of active usenet readers.
+func ActiveReaders() int64 {
+	return atomic.LoadInt64(&activeReaders)
+}
+
 var (
 	_ io.ReadCloser = &usenetReader{}
 )


### PR DESCRIPTION
## Summary
- Dynamically caps `MaxDownloadWorkers` per stream based on the usenet provider's connection limit and the number of currently active streams
- Formula: `effectiveWorkers = min(MaxDownloadWorkers, (totalConns - headroom) / activeReaders)`
- Reduces idle connection timeout from 120s to 10s so connections free promptly after playback stops
- Exports `ActiveReaders()` from the usenet package for use by the config adapter

## Problem
Users with limited provider connections (e.g. 20) hit 482 errors when starting a new stream while another is playing or recently stopped. The default 15 download workers per stream plus 120s idle timeout means connections aren't released fast enough.

## Behavior with 20 provider connections

| Active streams | Workers per stream |
|---------------|-------------------|
| 1 | 15 (default max) |
| 2 | 9 |
| 3 | 6 |
| Floor | 4 (minimum) |

## Test plan
- [ ] Single 4K stream plays smoothly with full worker allocation
- [ ] Starting a second stream doesn't cause 482 errors
- [ ] Stopping a stream frees connections within ~10s
- [ ] Users with high connection limits (200+) see no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)