### PR TITLE
fix(stream-pool): file a pooled body under the offset upstream actually served

### DIFF
--- a/backend/handlers/stream_pool.go
+++ b/backend/handlers/stream_pool.go
@@ -856,6 +856,32 @@ func (p *streamPool) getOrCreateInternal(waitCtx context.Context, path string, r
 		totalSize = parseTotalSizeFromContentRange(contentRange)
 	}
 
+	// Trust the offset the upstream actually served, never the one we asked for.
+	// The debrid layer can legitimately shift a window (RAR offset rewriting,
+	// parallel-fetch realignment) and a provider may ignore Range entirely. Filing
+	// the body under reqPos regardless leaves every reader of this slot reading
+	// shifted data while the response advertises the requested range — the client
+	// sees a corrupt container, which is exactly how this surfaced on a renderer.
+	servedStart := reqPos
+	if contentRange != "" {
+		if parsed, ok := parseContentRangeStart(contentRange); ok {
+			servedStart = parsed
+		}
+	} else if resp.Status == http.StatusOK {
+		// A 200 for "bytes=N-" means the range was ignored: the body starts at 0.
+		servedStart = 0
+	}
+	if servedStart > reqPos {
+		// The buffer would begin past what this reader needs, so it can never be
+		// satisfied from this slot. Refuse to pool and let the caller fall back to
+		// a direct stream rather than serve bytes from the wrong place.
+		log.Printf("[stream-pool] refusing slot: upstream served bytes from %d but %d was requested path=%q range=%q",
+			servedStart, reqPos, path, contentRange)
+		cancel()
+		_ = resp.Close()
+		return nil, 0, fmt.Errorf("upstream served offset %d for requested %d", servedStart, reqPos)
+	}
+
 	contentType := resp.Headers.Get("Content-Type")
 	if contentType == "" {
 		contentType = "video/mp4"
@@ -863,7 +889,7 @@ func (p *streamPool) getOrCreateInternal(waitCtx context.Context, path string, r
 
 	slot = &poolSlot{
 		path:          path,
-		startByte:     reqPos,
+		startByte:     servedStart,
 		data:          make([]byte, 0, 1024*1024), // start 1MB, grows as needed
 		ctx:           ctx,
 		cancel:        cancel,
@@ -1133,4 +1159,28 @@ func (p *streamPool) Stats() PoolStats {
 	}
 	stats.TotalBufferMB /= 1024 * 1024
 	return stats
+}
+
+// parseContentRangeStart reports the first byte offset an upstream actually
+// served, from a "bytes START-END/TOTAL" header. The pool must confirm this
+// matches the window it asked for: filing a body that starts somewhere else
+// under the requested offset corrupts every later read of that slot.
+func parseContentRangeStart(value string) (int64, bool) {
+	spec := strings.TrimSpace(value)
+	if !strings.HasPrefix(strings.ToLower(spec), "bytes ") {
+		return 0, false
+	}
+	spec = strings.TrimSpace(spec[len("bytes "):])
+	if slash := strings.IndexByte(spec, '/'); slash >= 0 {
+		spec = spec[:slash]
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 {
+		return 0, false
+	}
+	start, err := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
+	if err != nil || start < 0 {
+		return 0, false
+	}
+	return start, true
 }

--- a/backend/handlers/stream_pool_offset_test.go
+++ b/backend/handlers/stream_pool_offset_test.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"novastream/services/streaming"
+)
+
+// shiftingProvider serves the file from a different offset than the one asked
+// for, the way the debrid layer can after RAR-offset rewriting or parallel-fetch
+// realignment, and reports that shifted window honestly in Content-Range.
+type shiftingProvider struct {
+	data  []byte
+	shift int64
+}
+
+func (p *shiftingProvider) Stream(_ context.Context, req streaming.Request) (*streaming.Response, error) {
+	start, _, ok := parseByteRange(req.RangeHeader)
+	if !ok {
+		start = 0
+	}
+	served := start + p.shift
+	if served > int64(len(p.data)) {
+		served = int64(len(p.data))
+	}
+	total := int64(len(p.data))
+	headers := http.Header{}
+	headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", served, total-1, total))
+	headers.Set("Accept-Ranges", "bytes")
+	return &streaming.Response{
+		Status:        http.StatusPartialContent,
+		Headers:       headers,
+		ContentLength: total - served,
+		Body:          io.NopCloser(bytes.NewReader(p.data[served:])),
+		Filename:      "movie.mkv",
+	}, nil
+}
+
+// The pool used to record startByte as the offset it requested, so a shifted
+// upstream window left every reader of the slot receiving bytes from further
+// into the file while the response still advertised the requested range. A
+// renderer reading that stream sees a malformed container.
+func TestStreamPoolNeverServesBytesFromAShiftedWindow(t *testing.T) {
+	const (
+		path   = "/debrid/torbox/900/file/0/movie.mkv"
+		reqPos = int64(4 << 20)
+	)
+	data := spoolTestPayload(24 << 20)
+	// A one MiB forward shift, matching what was observed in production.
+	provider := &shiftingProvider{data: data, shift: 1 << 20}
+	pool := newStreamPool(nil)
+	defer pool.close()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream", nil)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", reqPos, reqPos+4095))
+	rec := httptest.NewRecorder()
+
+	served, err := pool.serve(
+		rec, req, path, reqPos, provider,
+		func(w http.ResponseWriter) { w.Header().Set("Accept-Ranges", "bytes") },
+		"", "",
+	)
+
+	// Refusing to pool is the correct outcome: the caller then falls back to a
+	// direct stream. What must never happen is a 206 whose body is the shifted
+	// window while its Content-Range claims the requested offset.
+	if !served {
+		return
+	}
+	if err != nil {
+		return
+	}
+	body := rec.Body.Bytes()
+	if len(body) == 0 {
+		return
+	}
+	want := data[reqPos : reqPos+int64(len(body))]
+	if !bytes.Equal(body, want) {
+		shifted := data[reqPos+provider.shift : reqPos+provider.shift+int64(len(body))]
+		if bytes.Equal(body, shifted) {
+			t.Fatalf("pool served the shifted window: requested %d but returned bytes from %d",
+				reqPos, reqPos+provider.shift)
+		}
+		t.Fatalf("pool served bytes matching neither the requested nor the shifted window at %d", reqPos)
+	}
+}
+
+// An upstream that honours the window must still be pooled and served correctly,
+// so the guard does not disable the pool.
+func TestStreamPoolServesHonouredWindowCorrectly(t *testing.T) {
+	const (
+		path   = "/debrid/torbox/901/file/0/movie.mkv"
+		reqPos = int64(4 << 20)
+		length = int64(4096)
+	)
+	data := spoolTestPayload(24 << 20)
+	provider := &shiftingProvider{data: data, shift: 0}
+	pool := newStreamPool(nil)
+	defer pool.close()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream", nil)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", reqPos, reqPos+length-1))
+	rec := httptest.NewRecorder()
+
+	served, err := pool.serve(
+		rec, req, path, reqPos, provider,
+		func(w http.ResponseWriter) { w.Header().Set("Accept-Ranges", "bytes") },
+		"", "",
+	)
+	if err != nil {
+		t.Fatalf("serve returned error: %v", err)
+	}
+	if !served {
+		t.Fatal("pool refused a window the upstream honoured")
+	}
+	body := rec.Body.Bytes()
+	if int64(len(body)) != length {
+		t.Fatalf("served %d bytes, want %d", len(body), length)
+	}
+	if !bytes.Equal(body, data[reqPos:reqPos+length]) {
+		t.Fatal("pool served the wrong bytes for an honoured window")
+	}
+}
+
+func spoolTestPayload(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
+}


### PR DESCRIPTION
`getOrCreateInternal` recorded every new slot at the offset it *requested*.
When an upstream answers a different window, the slot is indexed at the wrong
place and every reader attached to it receives bytes from somewhere else — while
the response still advertises the requested range. The client sees a corrupt
container.

Two upstreams do this legitimately:

- a provider that ignores `Range` replies `200` from byte 0;
- the debrid layer can shift a window while rewriting RAR offsets.

Both were filed under the requested position.

The served offset is now read back from `Content-Range` (or treated as 0 for a
`200`) and compared against the request. A slot that would begin *past* what the
reader needs can never satisfy it, so the pool refuses it and lets the caller
fall back to a direct stream rather than serve misaligned bytes.

`parseContentRangeStart` is added in this file rather than imported, so the pool
owns the parsing it depends on.

### Verification
Two new tests, and the first is mutation-checked — reverting only the
`stream_pool.go` change makes it fail:

```
--- FAIL: TestStreamPoolNeverServesBytesFromAShiftedWindow
    pool served bytes matching neither the requested nor the shifted window at 4194304
```

With the fix, the whole `handlers` package passes (`go test ./handlers/` ok) and
`go vet ./handlers/` is clean.