### PR TITLE
feat(cast): receiver capability service and DLNA transcode output

### DIFF
--- a/backend/handlers/cast_capabilities.go
+++ b/backend/handlers/cast_capabilities.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"novastream/services/castcaps"
+)
+
+// CastCapabilitiesHandler exposes what is known about the Cast receivers on the
+// LAN. Nothing here ever plays, loads, or launches anything on a receiver:
+// every fact is either read passively over HTTP from the device itself, derived
+// from a model/firmware prior, or graded from playback the user asked for.
+type CastCapabilitiesHandler struct {
+	store *castcaps.Store
+}
+
+func NewCastCapabilitiesHandler(cacheDir string) *CastCapabilitiesHandler {
+	return &CastCapabilitiesHandler{store: castcaps.NewStore(cacheDir)}
+}
+
+// Store exposes the cache so session creation can consult it without any I/O.
+func (h *CastCapabilitiesHandler) Store() *castcaps.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// ListReceivers reports every receiver on the LAN with whatever is already
+// cached about it. Discovery is a bounded port sweep and the capability lookup
+// is cache-only, so this never blocks on a device.
+func (h *CastCapabilitiesHandler) ListReceivers(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	cidr := strings.TrimSpace(r.URL.Query().Get("cidr"))
+	if cidr == "" {
+		cidr = castcaps.LocalCIDR()
+	}
+
+	type receiverView struct {
+		castcaps.Identity
+		Capabilities *castcaps.Capabilities `json:"capabilities,omitempty"`
+	}
+	identities := castcaps.Discover(ctx, cidr)
+	views := make([]receiverView, 0, len(identities))
+	for _, identity := range identities {
+		views = append(views, receiverView{Identity: identity, Capabilities: h.store.Lookup(identity.Host)})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"cidr": cidr, "receivers": views})
+}
+
+// DescribeReceiver returns the identity and current capability verdicts for one
+// receiver. Store.Ensure reads eureka_info and the DIAL device description with
+// plain GETs and applies the model prior; it never opens a Cast channel.
+func (h *CastCapabilitiesHandler) DescribeReceiver(w http.ResponseWriter, r *http.Request) {
+	host := strings.TrimSpace(r.URL.Query().Get("host"))
+	if host == "" {
+		http.Error(w, "missing host parameter", http.StatusBadRequest)
+		return
+	}
+	if net.ParseIP(host) == nil {
+		http.Error(w, "host must be an IP address", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	caps, err := h.store.Ensure(ctx, host)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(caps)
+}

--- a/backend/handlers/dlna_headers_test.go
+++ b/backend/handlers/dlna_headers_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseContentRangeTotal(t *testing.T) {
+	cases := []struct {
+		header string
+		want   int64
+	}{
+		{"bytes 0-100/18339538491", 18339538491},
+		{"bytes 18337932262-18339538490/18339538491", 18339538491},
+		{"bytes 0-100/*", 0},
+		{"", 0},
+		{"bytes 0-100", 0},
+		{"bytes 0-100/notanumber", 0},
+		{"bytes 0-100/0", 0},
+	}
+	for _, tc := range cases {
+		if got := parseContentRangeTotal(tc.header); got != tc.want {
+			t.Errorf("parseContentRangeTotal(%q) = %d, want %d", tc.header, got, tc.want)
+		}
+	}
+}
+
+func TestParseContentRangeStart(t *testing.T) {
+	cases := []struct {
+		header string
+		want   int64
+		ok     bool
+	}{
+		{"bytes 0-100/18339538491", 0, true},
+		{"bytes 2097152-4194303/18339538491", 2097152, true},
+		{"bytes 2097152-4194303/*", 2097152, true},
+		{"", 0, false},
+		{"bytes /100", 0, false},
+		{"bytes -100/200", 0, false},
+		{"bytes abc-100/200", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseContentRangeStart(tc.header)
+		if ok != tc.ok || (tc.ok && got != tc.want) {
+			t.Errorf("parseContentRangeStart(%q) = (%d,%v), want (%d,%v)", tc.header, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// A 206 that reports "/*" leaves the renderer unable to determine file size,
+// which is what makes LG webOS abort playback. Once the total is known every
+// partial response must name it.
+func TestRangeCacheContentRangeReportsRealTotal(t *testing.T) {
+	var c rangeBlockCache
+
+	if got, want := c.contentRangeValue("/movie.mkv", 0, 100), "bytes 0-100/*"; got != want {
+		t.Fatalf("before total known: got %q, want %q", got, want)
+	}
+
+	c.setTotal("/movie.mkv", 18339538491)
+
+	if got, want := c.contentRangeValue("/movie.mkv", 0, 100), "bytes 0-100/18339538491"; got != want {
+		t.Fatalf("after total known: got %q, want %q", got, want)
+	}
+	// A different file must not inherit the total.
+	if got, want := c.contentRangeValue("/other.mkv", 0, 100), "bytes 0-100/*"; got != want {
+		t.Fatalf("unrelated path: got %q, want %q", got, want)
+	}
+}
+
+func TestRangeCacheTotalIgnoresUnknownAndDoesNotRegress(t *testing.T) {
+	var c rangeBlockCache
+
+	c.setTotal("/movie.mkv", 0)
+	if got := c.total("/movie.mkv"); got != 0 {
+		t.Fatalf("zero total should not be recorded, got %d", got)
+	}
+	c.setTotal("/movie.mkv", -5)
+	if got := c.total("/movie.mkv"); got != 0 {
+		t.Fatalf("negative total should not be recorded, got %d", got)
+	}
+
+	c.setTotal("/movie.mkv", 18339538491)
+	// A later partial-window response must not shrink the known file length.
+	c.setTotal("/movie.mkv", 4096)
+	if got, want := c.total("/movie.mkv"), int64(18339538491); got != want {
+		t.Fatalf("total regressed: got %d, want %d", got, want)
+	}
+}
+
+func TestWriteDlnaHeadersEchoesTransferMode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream", nil)
+	req.Header.Set("transferMode.dlna.org", "Interactive")
+
+	writeDlnaHeaders(rec, req)
+
+	// Keys must keep DLNA spec casing, so read the map directly rather than
+	// through Get, which canonicalizes.
+	if got := rec.Header()["transferMode.dlna.org"]; len(got) != 1 || got[0] != "Interactive" {
+		t.Fatalf("transferMode not echoed: %v", got)
+	}
+	if got := rec.Header()["contentFeatures.dlna.org"]; len(got) != 1 || got[0] != dlnaContentFeatures {
+		t.Fatalf("contentFeatures missing: %v", got)
+	}
+	if got := rec.Header().Get("Accept-Ranges"); got != "bytes" {
+		t.Fatalf("Accept-Ranges = %q, want bytes", got)
+	}
+}
+
+func TestWriteDlnaHeadersDefaultsToStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream", nil)
+
+	writeDlnaHeaders(rec, req)
+
+	if got := rec.Header()["transferMode.dlna.org"]; len(got) != 1 || got[0] != "Streaming" {
+		t.Fatalf("transferMode default: %v", got)
+	}
+}
+
+// The DIDL-Lite the app sends advertises DLNA.ORG_OP=01; the HTTP response has
+// to agree or a strict renderer treats the resource as inconsistent.
+func TestDlnaContentFeaturesAdvertisesByteSeek(t *testing.T) {
+	const want = "DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000"
+	if dlnaContentFeatures != want {
+		t.Fatalf("contentFeatures = %q, want %q", dlnaContentFeatures, want)
+	}
+}

--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"novastream/services/castcaps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -428,6 +429,7 @@ type HLSSession struct {
 	forceAAC           bool // Cached forceAAC setting for recovery restarts
 	SeekInProgress     bool // Set to true during user-initiated seek to prevent recovery logic
 	SeekGeneration     int  // Increments on each seek so regenerated segment URLs are cache-distinct
+	SegmentStartNumber int  // Logical HLS sequence number used by the current FFmpeg run
 
 	// Fatal error tracking (unplayable streams)
 	FatalError string // Set when stream is determined to be unplayable (persistent bitstream errors)
@@ -459,7 +461,32 @@ type HLSSession struct {
 	// Prequeue tracking
 	PrequeueType   string // "", "details" (details page), or "next_episode" (auto-play next)
 	CastMode       bool   // True when the session is being prepared for Chromecast-style HLS playback
+	DirectCastMode bool   // True when Cast should prefer direct/remux output over legacy compatibility transcode
 	PlaybackTarget string // Optional client target hint, e.g. "web"
+
+	// Compatibility Cast output ladder. Sessions start at 1080p; sustained slow
+	// segment delivery to the receiver drops the transcode to 720p for the rest
+	// of the session (castSlowServes counts the consecutive slow serves that
+	// trigger it).
+	CastMaxHeight  int
+	castSlowServes int
+
+	// The IP address of the Cast receiver, used to consult cached capabilities
+	// when deciding whether to copy/remux or fall back to safe transcode limits.
+	CastReceiverHost string
+
+	// Cast capability observation. castVariants is the fingerprint of what this
+	// session actually asks the receiver to decode, derived once the ffmpeg arg
+	// plan is final. The rest is the receiver's own fetch timeline, which the
+	// grader reads to turn assumptions into verdicts. castVariantsGraded caps
+	// the whole session at one recorded verdict and frees the fetch set.
+	castVariants        castVariantFingerprint
+	castPlaylistFetched bool
+	castFirstFetch      time.Time
+	castLastFetch       time.Time
+	castLastKeepalive   time.Time
+	castFetchedSegments map[int]struct{}
+	castVariantsGraded  bool
 
 	// TonemappedToSDR is set when an HDR/DV source was tone mapped down to SDR
 	// H.264 during transcode. The HLS playlist must then advertise SDR rather
@@ -546,7 +573,67 @@ const (
 	hlsBufferPauseThreshold = 30 // ~2 minutes of buffer ahead (30 * 4s segments)
 	// Resume when buffer drops to this level
 	hlsBufferResumeThreshold = 20 // ~80 seconds of buffer ahead
+	// Keep enough already-served VOD segments for receivers that re-read startup
+	// fragments after fetching the master playlist. Default Media Receiver can
+	// request segment0 twice during cast startup; deleting it after segment5 turns
+	// a healthy stream into "media failed to load".
+	hlsSegmentCleanupRetainBehind = 30
+
+	// Requests close to the current Cast transcode head can wait for sequential
+	// generation. Larger jumps restart FFmpeg at the requested logical segment.
+	castOnDemandLeadSegments = 3
 )
+
+type castSegmentRestart struct {
+	SegmentStartNumber    int
+	TranscodingOffset     float64
+	OutputTimestampOffset float64
+}
+
+func castSegmentRestartPlan(session *HLSSession, requestedSegment, highestAvailable int) (castSegmentRestart, bool) {
+	if session == nil || !session.usesStableCastTimeline() || requestedSegment < 0 {
+		return castSegmentRestart{}, false
+	}
+
+	session.mu.RLock()
+	startOffset := session.StartOffset
+	duration := session.Duration
+	currentStart := session.SegmentStartNumber
+	lastServed := session.LastSegmentServed
+	completed := session.Completed
+	session.mu.RUnlock()
+
+	// Let the current FFmpeg run satisfy nearby requests. This covers startup
+	// requests and the receiver's normal small amount of read-ahead.
+	if !completed &&
+		requestedSegment >= currentStart &&
+		requestedSegment <= currentStart+castOnDemandLeadSegments {
+		return castSegmentRestart{}, false
+	}
+	if !completed &&
+		requestedSegment > highestAvailable &&
+		requestedSegment <= highestAvailable+castOnDemandLeadSegments {
+		return castSegmentRestart{}, false
+	}
+	if !completed &&
+		lastServed >= 0 &&
+		requestedSegment > lastServed &&
+		requestedSegment <= lastServed+castOnDemandLeadSegments {
+		return castSegmentRestart{}, false
+	}
+
+	timelineOffset := float64(requestedSegment) * hlsSegmentDuration
+	transcodingOffset := startOffset + timelineOffset
+	if duration > 0 && transcodingOffset >= duration {
+		return castSegmentRestart{}, false
+	}
+
+	return castSegmentRestart{
+		SegmentStartNumber:    requestedSegment,
+		TranscodingOffset:     transcodingOffset,
+		OutputTimestampOffset: timelineOffset,
+	}, true
+}
 
 func isTextSubtitleCodec(codec string) bool {
 	switch strings.ToLower(strings.TrimSpace(codec)) {
@@ -584,6 +671,279 @@ func isBrowserCopyCompatibleVideo(probe *UnifiedProbeResult) bool {
 	}
 
 	return true
+}
+
+func parseVideoFrameRate(value string) (float64, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "0/0" {
+		return 0, false
+	}
+	numeratorText, denominatorText, hasDenominator := strings.Cut(value, "/")
+	numerator, err := strconv.ParseFloat(numeratorText, 64)
+	if err != nil || numerator <= 0 {
+		return 0, false
+	}
+	if !hasDenominator {
+		return numerator, true
+	}
+	denominator, err := strconv.ParseFloat(denominatorText, 64)
+	if err != nil || denominator <= 0 {
+		return 0, false
+	}
+	return numerator / denominator, true
+}
+
+const (
+	legacyCastMaxWidth    = 1920
+	legacyCastMaxHeight   = 1080
+	legacyCastMaxLevel    = 41
+	legacyCastHDMaxWidth  = 1280
+	legacyCastHDMaxHeight = 720
+	legacyCastMaxFPSHD    = 60
+	legacyCastMaxFPSFull  = 30
+)
+
+// isLegacyCastCopyCompatibleVideo enforces the first/second-generation
+// Chromecast H.264 envelope: Level 4.1, up to 720p60 or 1080p30.
+func isLegacyCastCopyCompatibleVideo(probe *UnifiedProbeResult) bool {
+	if !isBrowserCopyCompatibleVideo(probe) || probe.VideoWidth <= 0 || probe.VideoHeight <= 0 || probe.VideoLevel <= 0 {
+		return false
+	}
+	if probe.VideoWidth > legacyCastMaxWidth || probe.VideoHeight > legacyCastMaxHeight || probe.VideoLevel > legacyCastMaxLevel {
+		return false
+	}
+	frameRate, ok := parseVideoFrameRate(probe.AvgFrameRate)
+	if !ok {
+		return false
+	}
+	maxFrameRate := float64(legacyCastMaxFPSHD)
+	if probe.VideoWidth > legacyCastHDMaxWidth || probe.VideoHeight > legacyCastHDMaxHeight {
+		maxFrameRate = float64(legacyCastMaxFPSFull)
+	}
+	return frameRate <= maxFrameRate+0.01
+}
+
+func castVideoMustTranscode(probe *UnifiedProbeResult) bool {
+	return !isLegacyCastCopyCompatibleVideo(probe)
+}
+
+// canAttemptDirectCastCopyVideo reports whether the source may be sent to a
+// receiver without re-encoding the video. The bar is the Cast copy envelope
+// (H.264, Level 4.1, 1080p30/720p60), not merely "a codec we understand":
+// receivers accept a LOAD for 4K HEVC, fetch a few segments, and then stall
+// forever with no error, and second-generation Chromecasts cannot decode HEVC
+// at any resolution. Anything outside the envelope belongs on the
+// compatibility transcode, which every receiver tested so far plays.
+// caps widens this per receiver. Widening uses Allows, not Supports: a model
+// prior that says "this panel decodes HEVC" is worth an attempt, and the cost
+// of being wrong is one session that falls back. Everything whose failure mode
+// is a silent stall with no way back - the fMP4 container choice, AC-3
+// passthrough, multichannel AAC - still requires proven support.
+func canAttemptDirectCastCopyVideo(probe *UnifiedProbeResult, caps *castcaps.Capabilities) bool {
+	if probe == nil || strings.TrimSpace(probe.VideoCodec) == "" || IsIncompatibleVideoCodec(probe.VideoCodec) {
+		return false
+	}
+	if !castVideoMustTranscode(probe) {
+		return true
+	}
+	// Outside the legacy envelope. Widening requires an answer about the
+	// specific thing being asked for, not merely about the container:
+	// VariantFMP4 is an H.264 variant and says nothing about HEVC decode. An
+	// unidentified receiver has neither, so it stays inside the envelope.
+	if !caps.Allows(castcaps.VariantFMP4) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(probe.VideoCodec)) {
+	case "hevc", "h265", "hev1", "hvc1":
+		return caps.Allows(castcaps.VariantHEVCFMP4)
+	default:
+		// H.264 above the legacy box (4K, high level, 1080p60). No variant
+		// measures resolution, so this stays on the safe transcode.
+		return false
+	}
+}
+
+func (session *HLSSession) disableUnsafeDirectCast(caps *castcaps.Capabilities) bool {
+	if session == nil || !session.CastMode || !session.DirectCastMode || canAttemptDirectCastCopyVideo(session.ProbeData, caps) {
+		return false
+	}
+	log.Printf("[hls] session %s: cast direct video is outside the receiver copy envelope; falling back to deterministic H.264 compatibility transcode", session.ID)
+	session.DirectCastMode = false
+	if isDirectCastTarget(session.PlaybackTarget, "") {
+		session.PlaybackTarget = "web"
+	}
+	return true
+}
+
+func isDirectCastTarget(playbackTarget, castProfile string) bool {
+	switch strings.ToLower(strings.TrimSpace(castProfile)) {
+	case "direct":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(playbackTarget)) {
+	case "cast-direct", "direct-cast":
+		return true
+	default:
+		return false
+	}
+}
+
+func (session *HLSSession) usesStableCastTimeline() bool {
+	return session != nil && session.CastMode && !session.DirectCastMode
+}
+
+// legacyCastEncodeLimits returns the compatibility Cast encode box. Sessions
+// default to 1080p30 (hardware encoders keep up with a 1080p H.264 re-encode);
+// capHeight drops that to 720p after the receiver has proven the link cannot
+// sustain 1080p. 720p and smaller sources are allowed 60fps either way, and
+// the scale filter never upscales.
+func legacyCastEncodeLimits(probe *UnifiedProbeResult, capHeight int) (maxWidth, maxHeight, maxFPS int) {
+	maxWidth, maxHeight, maxFPS = legacyCastMaxWidth, legacyCastMaxHeight, legacyCastMaxFPSFull
+	if capHeight > 0 && capHeight <= legacyCastHDMaxHeight {
+		maxWidth, maxHeight = legacyCastHDMaxWidth, legacyCastHDMaxHeight
+	}
+	if probe == nil {
+		return maxWidth, maxHeight, maxFPS
+	}
+
+	if probe.VideoWidth > 0 && probe.VideoWidth <= legacyCastHDMaxWidth &&
+		probe.VideoHeight > 0 && probe.VideoHeight <= legacyCastHDMaxHeight {
+		maxFPS = legacyCastMaxFPSHD
+	}
+	return maxWidth, maxHeight, maxFPS
+}
+
+// castCanUseMpegTS reports whether a Cast copy path can be muxed into MPEG-TS.
+// H.264 is the only Cast video codec that belongs in TS; HEVC/DV need fMP4 and
+// only play on receivers that support it anyway.
+func castCanUseMpegTS(probe *UnifiedProbeResult) bool {
+	if probe == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(probe.VideoCodec)) {
+	case "h264", "avc", "avc1":
+		return true
+	default:
+		return false
+	}
+}
+
+func castPrefersMpegTS(session *HLSSession, caps *castcaps.Capabilities) bool {
+	if !castCanUseMpegTS(session.ProbeData) {
+		return false
+	}
+	// Most receivers require MPEG-TS. We only trust fMP4 if the capability probe
+	// ran and explicitly confirmed it works on this device.
+	return !caps.Supports(castcaps.VariantFMP4)
+}
+
+// selectedAudioStream returns the audio track this session will actually send.
+// A negative index means "whatever ffmpeg maps first", which is stream 0.
+func selectedAudioStream(audioStreams []audioStreamInfo, audioTrackIndex int) (audioStreamInfo, bool) {
+	if len(audioStreams) == 0 {
+		return audioStreamInfo{}, false
+	}
+	if audioTrackIndex >= 0 {
+		for _, stream := range audioStreams {
+			if stream.Index == audioTrackIndex {
+				return stream, true
+			}
+		}
+	}
+	return audioStreams[0], true
+}
+
+// directCastAudioNeedsAAC reports whether a direct Cast session must re-encode
+// its audio. Direct copy exists to skip the *video* re-encode; Dolby audio is
+// the most common reason a receiver accepts the load and then never starts
+// playing (TV-integrated receivers frequently cannot decode AC-3/E-AC-3), and
+// re-encoding audio alone is cheap. Multichannel AAC keeps surround intact.
+func directCastAudioNeedsAAC(audioStreams []audioStreamInfo, audioTrackIndex int) bool {
+	selected, ok := selectedAudioStream(audioStreams, audioTrackIndex)
+	if !ok {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(selected.Codec), "aac")
+}
+
+func isSelectedAudioDolby(audioStreams []audioStreamInfo, audioTrackIndex int) bool {
+	selected, ok := selectedAudioStream(audioStreams, audioTrackIndex)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(selected.Codec)) {
+	case "ac3", "ac-3", "eac3", "eac-3":
+		return true
+	default:
+		return false
+	}
+}
+
+const (
+	// A 2s segment must arrive in well under 2s or the receiver's buffer drains.
+	// Serves slower than this fraction of real time count as a slow link.
+	castSlowServeFraction = 0.7
+	// Consecutive slow serves before dropping the ladder. Single slow segments
+	// are normal (CDN hiccups, seeks); a streak is a sustained-bandwidth verdict.
+	castSlowServeStreak = 3
+	// Ignore the first segments of a run: startup fetches overlap the sender's
+	// warm-up and say nothing about steady-state bandwidth.
+	castSlowServeWarmupSegments = 4
+)
+
+// castShouldDropToFallbackHeight reports whether a served segment pushes a
+// compatibility Cast session over the slow-link threshold. slowStreak is the
+// count including this serve.
+func castShouldDropToFallbackHeight(slowStreak int, currentCapHeight int) bool {
+	return slowStreak >= castSlowServeStreak && currentCapHeight != legacyCastHDMaxHeight
+}
+
+// castServeIsSlow reports whether one segment took so long to deliver that the
+// receiver cannot stay ahead at the current bitrate.
+func castServeIsSlow(serveDuration time.Duration, segmentBytes int64) bool {
+	if segmentBytes <= 0 || serveDuration <= 0 {
+		return false
+	}
+	return serveDuration.Seconds() > hlsSegmentDuration*castSlowServeFraction
+}
+
+type castAudioEnvelope struct {
+	castSafe          bool
+	allowMultichannel bool
+}
+
+// appendAACTranscodeArgs writes the AAC encode options. env.castSafe enforces
+// AAC-LC. Multichannel AAC is normally rejected outright by TV-integrated
+// receivers (load accepted, then idle/ERROR), so it drops to stereo unless
+// env.allowMultichannel confirms the receiver supports 5.1. Non-Cast targets
+// get 5.1 AAC.
+func appendAACTranscodeArgs(args []string, streamSpecifier string, env castAudioEnvelope) []string {
+	option := func(name string) string { return name + streamSpecifier }
+	channels := castAACChannels(env)
+	layout := "5.1"
+	if channels == 2 {
+		layout = "stereo"
+	}
+	args = append(args,
+		option("-c:a"), "aac",
+		option("-ac:a"), strconv.Itoa(channels),
+		option("-ar:a"), "48000",
+		option("-channel_layout:a"), layout,
+		option("-b:a"), "192k",
+	)
+	if env.castSafe {
+		args = append(args, option("-profile:a"), "aac_low")
+	}
+	return args
+}
+
+// castAACChannels mirrors the channel count appendAACTranscodeArgs writes, so
+// the capability fingerprint describes the same audio the receiver is handed.
+func castAACChannels(env castAudioEnvelope) int {
+	if env.castSafe && !env.allowMultichannel {
+		return 2
+	}
+	return 6
 }
 
 func hlsWebVideoWillTranscode(playbackTarget string, probe *UnifiedProbeResult) bool {
@@ -631,6 +991,19 @@ func shouldPreferRequestedTranscodingOffset(playbackTarget string, probe *Unifie
 		return true
 	}
 	return probe == nil && strings.EqualFold(strings.TrimSpace(playbackTarget), "web") && trackIndex >= 0
+}
+
+func initialTranscodingOffset(startOffset, probedOffset float64, castMode bool) float64 {
+	if castMode {
+		// Stable Cast segment numbers are calculated from StartOffset. The Cast
+		// path accurately transcodes rather than copying keyframe pre-roll, so
+		// segment zero must begin at that exact same anchor.
+		return startOffset
+	}
+	if probedOffset > 0 {
+		return probedOffset
+	}
+	return startOffset
 }
 
 func sanitizeHLSLanguage(language string) string {
@@ -831,20 +1204,19 @@ type HLSManager struct {
 	hwAccelPref       string
 	hwAccelReady      bool
 	hwAccelRetryAfter time.Time
+
+	castCapsMu sync.RWMutex
+	castCaps   *castcaps.Store
 }
 
-// PlaybackActivityObserver receives player updates only after they have been
-// matched to a currently active stream.
-type PlaybackActivityObserver interface {
-	HandlePlaybackUpdate(userID string, update models.PlaybackProgressUpdate, percentWatched float64)
-}
-
-func (m *HLSManager) SetPlaybackActivityObserver(observer PlaybackActivityObserver) {
+// AddPlaybackActivityObserver registers one more consumer of this manager's
+// playback activity. See playbackObserverFanout for why there is more than one.
+func (m *HLSManager) AddPlaybackActivityObserver(observer PlaybackActivityObserver) {
 	if m == nil {
 		return
 	}
 	m.mu.Lock()
-	m.playbackObserver = observer
+	m.playbackObserver = addPlaybackObserver(m.playbackObserver, observer)
 	m.mu.Unlock()
 }
 
@@ -1285,7 +1657,7 @@ func (m *HLSManager) buildLocalWebDAVURLFromPath(path string) (string, bool) {
 }
 
 // CreateSession starts a new HLS transcoding session
-func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPath string, hasDV bool, dvProfile string, hasHDR bool, forceAAC bool, startOffset float64, transcodingOffset float64, audioTrackIndex int, subtitleTrackIndex int, profileID string, profileName string, clientIP string, castMode bool, prequeueType string, playbackTarget string, durationHint float64) (*HLSSession, error) {
+func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPath string, hasDV bool, dvProfile string, hasHDR bool, forceAAC bool, startOffset float64, transcodingOffset float64, audioTrackIndex int, subtitleTrackIndex int, profileID string, profileName string, clientIP string, castMode bool, prequeueType string, playbackTarget string, durationHint float64, castReceiverHost string) (*HLSSession, error) {
 	sessionID := generateSessionID()
 	outputDir := filepath.Join(m.baseDir, sessionID)
 
@@ -1366,6 +1738,22 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 	}
 
 	normalizedPlaybackTarget := strings.ToLower(strings.TrimSpace(playbackTarget))
+	requestedDirectCastMode := castMode && isDirectCastTarget(normalizedPlaybackTarget, "")
+	directCastMode := requestedDirectCastMode && canAttemptDirectCastCopyVideo(probeData, m.lookupCastCapabilities(castReceiverHost))
+	if requestedDirectCastMode && !directCastMode {
+		// Say so at creation. The startTranscoding-side guard cannot log this
+		// case: the session is already built as compatibility by then, so
+		// without this line a downgraded direct request is indistinguishable
+		// from one the client sent as compatibility.
+		codec, width, height := "", 0, 0
+		if probeData != nil {
+			codec, width, height = probeData.VideoCodec, probeData.VideoWidth, probeData.VideoHeight
+		}
+		log.Printf("[hls] session %s: direct Cast requested but %s %dx%d is outside the receiver copy envelope (receiver=%q); using compatibility transcode",
+			sessionID, codec, width, height, castReceiverHost)
+		normalizedPlaybackTarget = "web"
+	}
+	stableCastMode := castMode && !directCastMode
 	subtitleStreamsForSeek := []subtitleStreamInfo(nil)
 	if probeData != nil {
 		subtitleStreamsForSeek = probeData.SubtitleStreams
@@ -1374,10 +1762,7 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 	now := time.Now()
 	// Use provided transcodingOffset if valid, otherwise default to startOffset
 	// transcodingOffset may differ from startOffset when probed keyframe position is used
-	actualTranscodingOffset := startOffset
-	if transcodingOffset > 0 {
-		actualTranscodingOffset = transcodingOffset
-	}
+	actualTranscodingOffset := initialTranscodingOffset(startOffset, transcodingOffset, stableCastMode)
 	if startOffset > 0 && shouldPreferRequestedTranscodingOffset(normalizedPlaybackTarget, probeData, subtitleStreamsForSeek, subtitleTrackIndex) {
 		actualTranscodingOffset = startOffset
 		log.Printf("[hls] session %s: using requested start %.3fs instead of probed keyframe %.3fs for accurate web subtitle seek",
@@ -1415,8 +1800,10 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 		ProbeData:               probeData, // Cache unified probe results for startTranscoding
 		subtitleExtractOffsets:  make(map[int]float64),
 		CastMode:                castMode,
+		DirectCastMode:          directCastMode,
 		PrequeueType:            prequeueType, // "", "details", or "next_episode"
 		PlaybackTarget:          normalizedPlaybackTarget,
+		CastReceiverHost:        castReceiverHost,
 	}
 
 	m.mu.Lock()
@@ -2304,6 +2691,12 @@ func (m *HLSManager) fixDVCodecTag(session *HLSSession) error {
 // startTranscoding begins FFmpeg HLS transcoding
 func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, forceAAC bool) error {
 	startTime := time.Now()
+	session.disableUnsafeDirectCast(m.castCapabilities(session))
+	stableCastMode := session.usesStableCastTimeline()
+	if stableCastMode {
+		// Legacy Cast output must not depend on receiver/TV Dolby passthrough support.
+		forceAAC = true
+	}
 
 	// Cache forceAAC for recovery restarts
 	session.mu.Lock()
@@ -2369,12 +2762,22 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		forceAAC = true
 	}
 
-	// If audio probe failed (no streams returned) and we're using fMP4 output (DV/HDR),
-	// force AAC transcoding to avoid potential TrueHD-in-MP4 experimental codec errors.
-	// TrueHD in MP4/fMP4 requires -strict -2 and likely won't play on Apple devices anyway.
 	if len(audioStreams) == 0 && (session.HasDV || session.HasHDR) {
 		log.Printf("[hls] session %s: audio probe returned no streams and fMP4 output required; forcing AAC transcoding for safety", session.ID)
 		forceAAC = true
+	}
+
+	if session.DirectCastMode && !forceAAC && directCastAudioNeedsAAC(audioStreams, session.AudioTrackIndex) {
+		caps := m.castCapabilities(session)
+		if caps.Supports(castcaps.VariantTSAC3) && isSelectedAudioDolby(audioStreams, session.AudioTrackIndex) {
+			log.Printf("[hls] session %s: receiver supports AC-3; copying Dolby audio in direct Cast mode", session.ID)
+		} else {
+			log.Printf("[hls] session %s: direct Cast audio is not AAC; re-encoding audio only so the receiver can decode it (video stays copied)", session.ID)
+			forceAAC = true
+			session.mu.Lock()
+			session.forceAAC = true
+			session.mu.Unlock()
+		}
 	}
 
 	// For seeking to work with -c:v copy, we need a seekable input
@@ -2536,6 +2939,11 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	// will be transcoded and whether a same-pass subtitle is being muxed, because both change the
 	// seek strategy needed to keep the subtitle aligned with the video.
 	videoWillTranscode := hlsWebVideoWillTranscode(session.PlaybackTarget, session.ProbeData)
+	if stableCastMode {
+		// Stable Cast timelines require deterministic two-second keyframe
+		// boundaries so logical segment N always maps to the same media time.
+		videoWillTranscode = true
+	}
 	_, subtitleRenditionWanted := selectedTextSubtitleStream(subtitleStreams, session.SubtitleTrackIndex)
 	subtitleRenditionWanted = session.PlaybackTarget == "web" && subtitleRenditionWanted
 	forceVideoTranscodeForWebSubtitleSeek := shouldForceWebSubtitleVideoTranscode(session.PlaybackTarget, subtitleStreams, session.SubtitleTrackIndex, session.TranscodingOffset)
@@ -2543,13 +2951,12 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		videoWillTranscode = true
 	}
 
-	// Build the web video encode plan up-front so any hardware-device
+	// Build the video encode plan up-front so any hardware-device
 	// initialization (-vaapi_device / -init_hw_device) can be injected as a
 	// global option BEFORE -i. The plan picks a GPU H.264 encoder when one is
-	// detected and working, and tone maps HDR/DV down to SDR for the browser.
-	// Only the web player path is affected; native/live transcodes are untouched.
+	// detected and working, and tone maps HDR/DV down to SDR for web and Cast.
 	var webEncodePlan videoEncodePlan
-	useWebEncodePlan := videoWillTranscode && session.PlaybackTarget == "web"
+	useWebEncodePlan := videoWillTranscode && (session.PlaybackTarget == "web" || stableCastMode)
 	if useWebEncodePlan {
 		session.mu.RLock()
 		forceSoftwareEncode := session.forceSoftwareEncode
@@ -2559,11 +2966,27 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 			caps = detectHWAccel(m.ffmpegPath, string(HWNone))
 		}
 		tonemapNeeded := session.HasDV || session.HasHDR
+		castMaxWidth, castMaxHeight, castMaxFPS := 0, 0, 0
+		if stableCastMode {
+			session.mu.RLock()
+			capHeight := session.CastMaxHeight
+			session.mu.RUnlock()
+			castMaxWidth, castMaxHeight, castMaxFPS = legacyCastEncodeLimits(session.ProbeData, capHeight)
+			log.Printf("[hls] session %s: compatibility Cast encode box %dx%d@%d (capHeight=%d)",
+				session.ID, castMaxWidth, castMaxHeight, castMaxFPS, capHeight)
+		}
 		sourceTransfer := ""
 		if session.ProbeData != nil {
 			sourceTransfer = session.ProbeData.ColorTransfer
 		}
-		webEncodePlan = buildVideoEncodePlan(caps, tonemapNeeded, sourceTransfer)
+		webEncodePlan = buildVideoEncodePlanWithLimits(
+			caps,
+			tonemapNeeded,
+			castMaxWidth,
+			castMaxHeight,
+			castMaxFPS,
+			sourceTransfer,
+		)
 		if len(webEncodePlan.GlobalArgs) > 0 {
 			args = append(args, webEncodePlan.GlobalArgs...)
 		}
@@ -2582,7 +3005,10 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	// Force INPUT seeking when muxing a same-pass subtitle so the single -ss before -i applies to
 	// BOTH the video and the subtitle output. OUTPUT seeking only seeks the first output, which
 	// would leave the subtitle starting at the beginning of the file and wildly out of sync.
-	useOutputSeeking := session.TranscodingOffset > 0 && session.TranscodingOffset < outputSeekThreshold && !subtitleRenditionWanted
+	useOutputSeeking := session.TranscodingOffset > 0 &&
+		session.TranscodingOffset < outputSeekThreshold &&
+		!subtitleRenditionWanted &&
+		!stableCastMode
 
 	// For INPUT seeking, add -ss before -i.
 	// -noaccurate_seek keeps a copied video keyframe-friendly for normal playback. When web
@@ -2590,9 +3016,9 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	// video, audio, and the same-pass WebVTT all share the requested timestamp anchor instead of the
 	// earlier keyframe.
 	if session.TranscodingOffset > 0 && !useOutputSeeking {
-		if videoWillTranscode && subtitleRenditionWanted {
+		if videoWillTranscode && (subtitleRenditionWanted || stableCastMode) {
 			args = append(args, "-ss", fmt.Sprintf("%.3f", session.TranscodingOffset))
-			log.Printf("[hls] session %s: using INPUT seeking to %.3fs (accurate; web video+subtitle)", session.ID, session.TranscodingOffset)
+			log.Printf("[hls] session %s: using accurate INPUT seeking to %.3fs", session.ID, session.TranscodingOffset)
 		} else {
 			args = append(args, "-noaccurate_seek", "-ss", fmt.Sprintf("%.3f", session.TranscodingOffset))
 			log.Printf("[hls] session %s: using INPUT seeking to %.3fs with -noaccurate_seek", session.ID, session.TranscodingOffset)
@@ -2632,6 +3058,14 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	// This ensures A/V sync when transcoding TrueHD/DTS audio (which have variable timing)
 	// and helps maintain subtitle sync across seek operations
 	args = append(args, "-start_at_zero")
+	session.mu.RLock()
+	castSegmentStartNumber := session.SegmentStartNumber
+	session.mu.RUnlock()
+	if stableCastMode && castSegmentStartNumber > 0 {
+		// FFmpeg rebases a seeked run to zero. Offset its output timestamps back
+		// into the receiver's stable HLS timeline.
+		args = append(args, "-output_ts_offset", fmt.Sprintf("%.3f", float64(castSegmentStartNumber)*hlsSegmentDuration))
+	}
 
 	args = append(args,
 		"-map", "0:v:0", // Map primary video stream
@@ -2752,6 +3186,15 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		videoCodec = session.ProbeData.VideoCodec
 		needsVideoTranscode = IsIncompatibleVideoCodec(videoCodec)
 	}
+	if stableCastMode {
+		needsVideoTranscode = true
+		pixFmt, profile := "", ""
+		if session.ProbeData != nil {
+			pixFmt, profile = session.ProbeData.VideoPixFmt, session.ProbeData.VideoProfile
+		}
+		log.Printf("[hls] session %s: cast stable timeline requires deterministic H.264 segments; transcoding codec=%q pix_fmt=%q profile=%q",
+			session.ID, videoCodec, pixFmt, profile)
+	}
 	if session.PlaybackTarget == "web" && !isBrowserCopyCompatibleVideo(session.ProbeData) {
 		needsVideoTranscode = true
 		if session.ProbeData != nil {
@@ -2824,7 +3267,11 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	// - HDR10: iOS AVPlayer can't properly decode HEVC in MPEG-TS segments
 	var segmentExt string
 	needsFmp4 := session.HasDV || session.HasHDR
-	if session.HasDV && !session.DVDisabled {
+	if stableCastMode {
+		needsFmp4 = false
+		segmentExt = ".ts"
+		log.Printf("[hls] session %s: using MPEG-TS segments for cast compatibility", session.ID)
+	} else if session.HasDV && !session.DVDisabled {
 		segmentExt = ".m4s"
 		if needsVideoTranscode {
 			log.Printf("[hls] session %s: using fMP4 H.264 output for web-compatible Dolby Vision/HDR source; skipping HEVC DV tag and hevc_metadata filter", session.ID)
@@ -2864,9 +3311,19 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 				log.Printf("[hls] session %s: using hvc1 tag with fMP4 segments with HDR10 color metadata", session.ID)
 			}
 		}
-	} else if forceAAC {
-		// Cast sessions (forceAAC=true): use MPEG-TS for maximum Chromecast compatibility
-		// fMP4 with output seeking + copy mode can produce non-monotonic DTS that Chromecast rejects
+	} else if session.CastMode && !needsVideoTranscode && castPrefersMpegTS(session, m.castCapabilities(session)) {
+		// Cast receivers built into TVs (and older Chromecast firmware) reject
+		// HLS in fMP4 outright: the load is accepted, segments are fetched, and
+		// playback never starts. MPEG-TS is the universally understood Cast
+		// container, and H.264 + AAC/AC-3 remux into it without re-encoding, so
+		// direct Cast keeps its zero-transcode video path.
+		needsFmp4 = false
+		segmentExt = ".ts"
+		log.Printf("[hls] session %s: using MPEG-TS segments for direct Cast remux (Chromecast fMP4 HLS is not universally supported)", session.ID)
+	} else if forceAAC && !session.DirectCastMode {
+		// Non-direct Cast sessions (forceAAC=true): use MPEG-TS for maximum
+		// Chromecast compatibility. Direct Cast may still normalize audio to AAC
+		// while preserving the original video/container path.
 		needsFmp4 = false
 		segmentExt = ".ts"
 		log.Printf("[hls] session %s: using MPEG-TS segments for cast/forceAAC session (Chromecast compatibility)", session.ID)
@@ -2881,6 +3338,9 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 
 	// Audio handling
 	audioCodecHandled := false
+	// The audio the receiver actually decodes. Channels are only known when we
+	// encode it ourselves; a copied track's channel count is not probed.
+	castPlanAudioCodec, castPlanAudioChannels := "", 0
 
 	// Check if a specific incompatible audio track was selected (TrueHD, DTS, etc.)
 	if mappedSpecificAudio && session.AudioTrackIndex >= 0 {
@@ -2894,9 +3354,10 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 					// async=1000 allows up to 1000 samples of drift correction per second
 					// Note: -start_at_zero (set earlier) normalizes all stream timestamps for proper A/V sync
 					log.Printf("[hls] session %s: transcoding selected %s track to AAC", session.ID, audioStreams[i].Codec)
-					args = append(args,
-						"-af", "aresample=async=1000",
-						"-c:a", "aac", "-ac", "6", "-ar", "48000", "-channel_layout", "5.1", "-b:a", "192k")
+					caps := m.castCapabilities(session)
+					env := castAudioEnvelope{castSafe: session.CastMode, allowMultichannel: caps.Supports(castcaps.VariantTSAACMultichannel)}
+					args = appendAACTranscodeArgs(args, "", env)
+					castPlanAudioCodec, castPlanAudioChannels = "aac", castAACChannels(env)
 					audioCodecHandled = true
 				}
 				break
@@ -2909,21 +3370,28 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 			// Transcode first audio to AAC, copy others
 			// Must specify channel_layout for iOS AVPlayer compatibility
 			// Use aresample filter with async for proper A/V sync during transcoding
-			args = append(args,
-				"-af", "aresample=async=1000",
-				"-c:a:0", "aac", "-ac:a:0", "6", "-ar:a:0", "48000", "-channel_layout:a:0", "5.1", "-b:a:0", "192k",
-				"-c:a:1", "copy")
+			caps := m.castCapabilities(session)
+			env := castAudioEnvelope{castSafe: session.CastMode, allowMultichannel: caps.Supports(castcaps.VariantTSAACMultichannel)}
+			args = appendAACTranscodeArgs(args, ":0", env)
+			castPlanAudioCodec, castPlanAudioChannels = "aac", castAACChannels(env)
+			if !session.CastMode {
+				args = append(args, "-c:a:1", "copy")
+			}
 		} else if hasTrueHD && !hasCompatibleAudio {
 			// If only TrueHD exists, we must transcode it
 			// Must specify channel_layout for iOS AVPlayer compatibility (otherwise shows "media may be damaged")
 			// TrueHD has variable timing - use aresample filter with async to maintain A/V sync
 			log.Printf("[hls] session %s: transcoding TrueHD to AAC (no compatible alternative)", session.ID)
-			args = append(args,
-				"-af", "aresample=async=1000",
-				"-c:a", "aac", "-ac", "6", "-ar", "48000", "-channel_layout", "5.1", "-b:a", "192k")
+			caps := m.castCapabilities(session)
+			env := castAudioEnvelope{castSafe: session.CastMode, allowMultichannel: caps.Supports(castcaps.VariantTSAACMultichannel)}
+			args = appendAACTranscodeArgs(args, "", env)
+			castPlanAudioCodec, castPlanAudioChannels = "aac", castAACChannels(env)
 		} else {
 			// Copy compatible audio
 			args = append(args, "-c:a", "copy")
+			if selected, ok := selectedAudioStream(audioStreams, session.AudioTrackIndex); ok {
+				castPlanAudioCodec = selected.Codec
+			}
 		}
 	}
 
@@ -2974,9 +3442,13 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	segmentStartNum := "0"
 	session.mu.RLock()
 	isRecovery := session.RecoveryAttempts > 0
+	configuredSegmentStart := session.SegmentStartNumber
 	session.mu.RUnlock()
 
-	if isRecovery {
+	if stableCastMode && configuredSegmentStart > 0 {
+		segmentStartNum = strconv.Itoa(configuredSegmentStart)
+		log.Printf("[hls] session %s: stable cast timeline - starting from logical segment %s", session.ID, segmentStartNum)
+	} else if isRecovery {
 		// Find highest existing segment and start from the next one
 		highestSegment := m.findHighestSegmentNumber(session)
 		if highestSegment >= 0 {
@@ -2990,6 +3462,10 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	args = append(args, "-max_muxing_queue_size", "1024")
 
 	// HLS output settings
+	hlsInitTime := "1"
+	if stableCastMode {
+		hlsInitTime = fmt.Sprintf("%.0f", hlsSegmentDuration)
+	}
 	if needsFmp4 {
 		// Use fMP4 segments for Dolby Vision and HDR10
 		// iOS AVPlayer requires fMP4 for proper HEVC/HDR playback
@@ -2998,7 +3474,7 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		// Use hls_init_time for shorter first segment (faster initial playback)
 		args = append(args,
 			"-f", "hls",
-			"-hls_init_time", "1", // First segment is 1s for faster startup
+			"-hls_init_time", hlsInitTime,
 			"-hls_time", "2", // Subsequent segments are 2s
 			"-hls_list_size", "0",
 			"-hls_playlist_type", "event",
@@ -3019,7 +3495,7 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		// Use hls_init_time for shorter first segment (faster initial playback)
 		args = append(args,
 			"-f", "hls",
-			"-hls_init_time", "1", // First segment is 1s for faster startup
+			"-hls_init_time", hlsInitTime,
 			"-hls_time", "2", // Subsequent segments are 2s
 			"-hls_list_size", "0",
 			"-hls_playlist_type", "event",
@@ -3032,6 +3508,32 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 
 		if len(sidecarSubtitles) > 0 {
 			log.Printf("[hls] session %s: %d subtitle tracks will be extracted on demand", session.ID, len(sidecarSubtitles))
+		}
+	}
+
+	// The output plan is final here, so this is the one place that knows exactly
+	// what the receiver will be handed. Record it on the session; the fetch
+	// timeline grades it later without ever asking the device anything.
+	if session.CastMode {
+		castPlanVideoCodec := videoCodec
+		if needsVideoTranscode {
+			castPlanVideoCodec = "h264"
+		}
+		fingerprint := castVariantsForPlan(castVariantPlan{
+			Fmp4:          needsFmp4,
+			VideoCodec:    castPlanVideoCodec,
+			AudioCodec:    castPlanAudioCodec,
+			AudioChannels: castPlanAudioChannels,
+		})
+		session.mu.Lock()
+		session.castVariants = fingerprint
+		session.mu.Unlock()
+		if fingerprint.empty() {
+			log.Printf("[hls] session %s: cast output (fmp4=%v video=%q audio=%q channels=%d) matches no capability variant; playback will not be graded",
+				session.ID, needsFmp4, castPlanVideoCodec, castPlanAudioCodec, castPlanAudioChannels)
+		} else {
+			log.Printf("[hls] session %s: cast output exercises variant %s (fmp4=%v video=%q audio=%q channels=%d)",
+				session.ID, fingerprint.Primary, needsFmp4, castPlanVideoCodec, castPlanAudioCodec, castPlanAudioChannels)
 		}
 	}
 
@@ -4030,7 +4532,16 @@ func (m *HLSManager) KeepAlive(w http.ResponseWriter, r *http.Request, sessionID
 	paused := session.PlaybackPaused
 	buffering := session.PlaybackBuffering
 	ended := session.PlaybackEnded
+	// The internal stream path this session transcodes from. Consumers that have
+	// to reach the source again — the p2p auto-seeder re-resolves it to a current
+	// URL — cannot recover it from anywhere else on this request.
+	sourcePath := session.Path
 	session.mu.Unlock()
+
+	// A receiver that accepted the load and then stalled produces no further
+	// segment fetches, so the sender's keepalive is the only clock that can
+	// notice the silence.
+	m.noteCastKeepalive(session, now)
 
 	if hasPlaybackPosition {
 		m.mu.RLock()
@@ -4047,6 +4558,7 @@ func (m *HLSManager) KeepAlive(w http.ResponseWriter, r *http.Request, sessionID
 				IsBuffering:       buffering,
 				PlaybackEnded:     ended,
 				PlaybackSessionID: "hls:" + sessionID,
+				SourcePath:        sourcePath,
 			}, metadata)
 			percent := 0.0
 			if duration > 0 {
@@ -4446,6 +4958,7 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 	session.mu.Lock()
 	session.LastSegmentRequest = time.Now()
 	session.mu.Unlock()
+	m.noteCastReceiverPlaylist(session, r)
 
 	playlistPath := filepath.Join(session.OutputDir, "stream.m3u8")
 
@@ -4514,7 +5027,13 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 	session.mu.RLock()
 	seekGeneration := session.SeekGeneration
 	tonemappedToSDR := session.TonemappedToSDR
+	stableCastMode := session.usesStableCastTimeline()
+	sessionDuration := session.Duration
 	session.mu.RUnlock()
+
+	if stableCastMode && sessionDuration > 0 {
+		playlistContent = buildStableCastPlaylist(session)
+	}
 
 	// Build header tags to inject after #EXTM3U
 	var headerTags []string
@@ -4570,10 +5089,10 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 		// Find the highest segment number in the current playlist
 		highestExisting := -1
 		lines := strings.Split(playlistContent, "\n")
-		// Determine segment extension based on actual session format
+		// Determine segment extension based on actual session format.
 		segmentExt := ".m4s"
-		if session.forceAAC && !session.HasDV && !session.HasHDR {
-			segmentExt = ".ts" // Cast sessions use MPEG-TS for Chromecast compatibility
+		if session.usesStableCastTimeline() || (session.forceAAC && !session.DirectCastMode && !session.HasDV && !session.HasHDR) {
+			segmentExt = ".ts" // Stable Cast and non-direct forceAAC sessions use MPEG-TS for compatibility.
 		}
 		for _, line := range lines {
 			if strings.HasPrefix(line, "segment") && strings.HasSuffix(line, segmentExt) {
@@ -4637,6 +5156,41 @@ func playlistHasMediaSegment(content []byte) bool {
 	return false
 }
 
+func buildStableCastPlaylist(session *HLSSession) string {
+	session.mu.RLock()
+	duration := session.Duration
+	startOffset := session.StartOffset
+	session.mu.RUnlock()
+
+	effectiveDuration := duration - startOffset
+	if effectiveDuration < 0 {
+		effectiveDuration = 0
+	}
+	totalSegments := int(math.Ceil(effectiveDuration / hlsSegmentDuration))
+
+	var playlist strings.Builder
+	playlist.WriteString("#EXTM3U\n")
+	playlist.WriteString("#EXT-X-VERSION:3\n")
+	playlist.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", int(math.Ceil(hlsSegmentDuration))))
+	playlist.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
+	playlist.WriteString("#EXT-X-PLAYLIST-TYPE:VOD\n")
+	playlist.WriteString("#EXT-X-INDEPENDENT-SEGMENTS\n")
+
+	for segmentNum := 0; segmentNum < totalSegments; segmentNum++ {
+		segmentDuration := hlsSegmentDuration
+		segmentEnd := float64(segmentNum+1) * hlsSegmentDuration
+		if segmentEnd > effectiveDuration {
+			segmentDuration = effectiveDuration - float64(segmentNum)*hlsSegmentDuration
+		}
+		if segmentDuration < 0.1 {
+			continue
+		}
+		playlist.WriteString(fmt.Sprintf("#EXTINF:%.6f,\nsegment%d.ts\n", segmentDuration, segmentNum))
+	}
+	playlist.WriteString("#EXT-X-ENDLIST\n")
+	return playlist.String()
+}
+
 func (m *HLSManager) ServeMasterPlaylist(w http.ResponseWriter, r *http.Request, sessionID string) {
 	session, exists := m.GetSession(sessionID)
 	if !exists {
@@ -4647,6 +5201,7 @@ func (m *HLSManager) ServeMasterPlaylist(w http.ResponseWriter, r *http.Request,
 	session.mu.Lock()
 	session.LastSegmentRequest = time.Now()
 	session.mu.Unlock()
+	m.noteCastReceiverPlaylist(session, r)
 
 	if !m.shouldServeMasterPlaylist(session) {
 		http.Redirect(w, r, fmt.Sprintf("/video/hls/%s/stream.m3u8", sessionID), http.StatusTemporaryRedirect)
@@ -4779,6 +5334,158 @@ func (m *HLSManager) ServeSubtitlePlaylist(w http.ResponseWriter, r *http.Reques
 	_, _ = w.Write([]byte(playlistContent))
 }
 
+func (m *HLSManager) restartCastTranscodingForSegment(session *HLSSession, requestedSegment int) {
+	highestAvailable := m.findHighestSegmentNumber(session)
+	plan, shouldRestart := castSegmentRestartPlan(session, requestedSegment, highestAvailable)
+	if !shouldRestart {
+		return
+	}
+
+	segmentPath := filepath.Join(session.OutputDir, fmt.Sprintf("segment%d.ts", requestedSegment))
+	if _, err := os.Stat(segmentPath); err == nil {
+		return
+	}
+
+	session.mu.Lock()
+	// Another segment request may already have moved the active run close
+	// enough to satisfy this request sequentially.
+	if !session.Completed &&
+		((requestedSegment >= session.SegmentStartNumber &&
+			requestedSegment <= session.SegmentStartNumber+castOnDemandLeadSegments) ||
+			(session.LastSegmentServed >= 0 &&
+				requestedSegment > session.LastSegmentServed &&
+				requestedSegment <= session.LastSegmentServed+castOnDemandLeadSegments)) {
+		session.mu.Unlock()
+		return
+	}
+
+	log.Printf("[hls] session %s: stable Cast timeline jump to segment %d (media %.3fs, source %.3fs, highest available=%d)",
+		session.ID, plan.SegmentStartNumber, plan.OutputTimestampOffset, plan.TranscodingOffset, highestAvailable)
+	session.mu.Unlock()
+
+	m.restartCastTranscodingAt(session, plan)
+}
+
+// restartCastTranscodingAt replaces the running FFmpeg with one that resumes
+// the stable Cast timeline at plan.SegmentStartNumber. Callers own the decision
+// (timeline jump, quality change); this only performs the swap.
+func (m *HLSManager) restartCastTranscodingAt(session *HLSSession, plan castSegmentRestart) {
+	session.mu.Lock()
+	session.SeekInProgress = true
+	if session.Cancel != nil {
+		session.Cancel()
+	}
+	session.FFmpegCmd = nil
+	session.FFmpegPID = 0
+	session.Completed = false
+	session.LastSegmentServed = -1
+	session.FinalSegmentCount = -1
+	session.TranscodingOffset = plan.TranscodingOffset
+	session.SegmentStartNumber = plan.SegmentStartNumber
+	session.CreatedAt = time.Now()
+	session.LastSegmentRequest = time.Now()
+	session.RecoveryAttempts = 0
+	cachedForceAAC := session.forceAAC
+	youtubeVideoURL := session.YouTubeVideoURL
+	youtubeAudioURL := session.YouTubeAudioURL
+	youtubeProxyURL := session.YouTubeProxyURL
+	session.mu.Unlock()
+
+	// Let the cancelled process release its output files before the replacement
+	// process writes the same stable playlist.
+	time.Sleep(25 * time.Millisecond)
+
+	newCtx, newCancel := context.WithCancel(context.Background())
+	session.mu.Lock()
+	session.Cancel = newCancel
+	session.SeekInProgress = false
+	session.mu.Unlock()
+
+	go func(segmentStart int) {
+		var err error
+		if youtubeVideoURL != "" && youtubeAudioURL != "" {
+			err = m.startYouTubeTranscoding(newCtx, session, youtubeVideoURL, youtubeAudioURL, youtubeProxyURL)
+		} else {
+			err = m.startTranscoding(newCtx, session, cachedForceAAC)
+		}
+		if err == nil || errors.Is(err, context.Canceled) {
+			return
+		}
+
+		log.Printf("[hls] session %s: stable Cast segment restart failed: %v", session.ID, err)
+		session.mu.Lock()
+		if session.SegmentStartNumber == segmentStart {
+			session.Completed = true
+			session.FatalError = err.Error()
+			session.FatalErrorTime = time.Now()
+		}
+		session.mu.Unlock()
+	}(plan.SegmentStartNumber)
+}
+
+// isChromecastReceiverRequest reports whether a segment request came from the
+// Cast receiver itself rather than the sender app warming the backlog. Only the
+// receiver's pull rate says anything about the link that has to sustain
+// playback.
+func isChromecastReceiverRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.Contains(r.Header.Get("User-Agent"), "CrKey")
+}
+
+// noteCastSegmentDelivery watches how fast the Cast receiver is actually
+// pulling segments and drops a 1080p compatibility transcode to 720p once the
+// link has proven it cannot keep up. The switch happens at the next segment the
+// receiver will ask for, so the stable Cast timeline stays intact.
+func (m *HLSManager) noteCastSegmentDelivery(session *HLSSession, r *http.Request, servedSegment int, segmentBytes int64, serveDuration time.Duration) {
+	if session == nil || !session.usesStableCastTimeline() || !isChromecastReceiverRequest(r) {
+		return
+	}
+
+	session.mu.Lock()
+	if servedSegment < session.SegmentStartNumber+castSlowServeWarmupSegments {
+		session.castSlowServes = 0
+		session.mu.Unlock()
+		return
+	}
+	if !castServeIsSlow(serveDuration, segmentBytes) {
+		session.castSlowServes = 0
+		session.mu.Unlock()
+		return
+	}
+	session.castSlowServes++
+	slowStreak := session.castSlowServes
+	capHeight := session.CastMaxHeight
+	if !castShouldDropToFallbackHeight(slowStreak, capHeight) {
+		session.mu.Unlock()
+		log.Printf("[hls] session %s: slow Cast segment delivery %d/%d (segment=%d size=%d serve_time=%v)",
+			session.ID, slowStreak, castSlowServeStreak, servedSegment, segmentBytes, serveDuration)
+		return
+	}
+	session.CastMaxHeight = legacyCastHDMaxHeight
+	session.castSlowServes = 0
+	duration := session.Duration
+	startOffset := session.StartOffset
+	session.mu.Unlock()
+
+	restartSegment := servedSegment + 1
+	timelineOffset := float64(restartSegment) * hlsSegmentDuration
+	transcodingOffset := startOffset + timelineOffset
+	if duration > 0 && transcodingOffset >= duration {
+		log.Printf("[hls] session %s: slow Cast link near end of stream; keeping current quality", session.ID)
+		return
+	}
+
+	log.Printf("[hls] session %s: Cast receiver cannot sustain 1080p (serve_time=%v for %d bytes); dropping to 720p from segment %d",
+		session.ID, serveDuration, segmentBytes, restartSegment)
+	m.restartCastTranscodingAt(session, castSegmentRestart{
+		SegmentStartNumber:    restartSegment,
+		TranscodingOffset:     transcodingOffset,
+		OutputTimestampOffset: timelineOffset,
+	})
+}
+
 // ServeSegment serves an HLS segment file
 func (m *HLSManager) ServeSegment(w http.ResponseWriter, r *http.Request, sessionID, segmentName string) {
 	requestStart := time.Now()
@@ -4814,6 +5521,11 @@ func (m *HLSManager) ServeSegment(w http.ResponseWriter, r *http.Request, sessio
 	requestCount := session.SegmentRequestCount
 	session.mu.Unlock()
 
+	// Grade the receiver's own pull rate against what this session is asking it
+	// to decode. Nothing here contacts the device; it only reads the timeline
+	// the receiver produces by fetching what the user asked to play.
+	m.noteCastReceiverFetch(session, r, segmentName)
+
 	log.Printf("[hls] segment request #%d: session=%s segment=%s", requestCount, sessionID, segmentName)
 
 	// Validate segment name to prevent path traversal
@@ -4824,12 +5536,22 @@ func (m *HLSManager) ServeSegment(w http.ResponseWriter, r *http.Request, sessio
 	}
 
 	segmentPath := filepath.Join(session.OutputDir, segmentName)
+	if session.usesStableCastTimeline() {
+		if _, err := os.Stat(segmentPath); os.IsNotExist(err) {
+			m.restartCastTranscodingForSegment(session, segmentNum)
+		}
+	}
 
-	// Wait for segment to be created (up to 30 seconds for slow transcoding)
+	// Wait for segment to be created. Stable Cast jumps may need to establish a
+	// fresh upstream request and FFmpeg process before producing the target.
 	waitStart := time.Now()
 	segmentReady := false
 	var segmentSize int64
-	for i := 0; i < 300; i++ {
+	waitAttempts := 300
+	if session.usesStableCastTimeline() {
+		waitAttempts = 1200 // 30 seconds at 25ms per attempt
+	}
+	for i := 0; i < waitAttempts; i++ {
 		if stat, err := os.Stat(segmentPath); err == nil {
 			segmentSize = stat.Size()
 			segmentReady = true
@@ -4919,6 +5641,8 @@ func (m *HLSManager) ServeSegment(w http.ResponseWriter, r *http.Request, sessio
 	totalDuration := time.Since(requestStart)
 	log.Printf("[hls] segment served: session=%s segment=%s size=%d bytes serve_time=%v total_time=%v",
 		sessionID, segmentName, segmentSize, serveDuration, totalDuration)
+
+	m.noteCastSegmentDelivery(session, r, servedSegmentNum, segmentSize, serveDuration)
 
 	// Clean up old segments to save disk space.
 	// Live sessions use FFmpeg's delete_segments flag which handles cleanup automatically.
@@ -5537,6 +6261,7 @@ func (m *HLSManager) Shutdown() {
 // deleteOldSegments removes old segment files to save disk space, only deleting segments the player no longer needs
 func (m *HLSManager) deleteOldSegments(session *HLSSession, justServedSegment string) {
 	session.mu.RLock()
+	stableCastMode := session.usesStableCastTimeline()
 	outputDir := session.OutputDir
 	// TESTING: hasDV/hasHDR unused since we always use .m4s
 	_ = session.HasDV
@@ -5545,6 +6270,11 @@ func (m *HLSManager) deleteOldSegments(session *HLSSession, justServedSegment st
 	earliestBuffered := session.EarliestBufferedSegment
 	lastServedSegment := session.LastSegmentServed
 	session.mu.RUnlock()
+	if stableCastMode {
+		// consulting the sender first, so every generated logical segment must
+		// remain available for backward seeking.
+		return
+	}
 
 	// Use the minimum of EarliestBufferedSegment (from frontend) and LastSegmentServed (from backend)
 	// This ensures we don't delete segments that:
@@ -5567,8 +6297,8 @@ func (m *HLSManager) deleteOldSegments(session *HLSSession, justServedSegment st
 		return
 	}
 
-	// Keep 5 segments behind the safe point for seeking back (~20 seconds at 4s/segment)
-	cutoff := safeSegment - 5
+	// Keep recent segments behind the safe point for startup re-reads and short seeks.
+	cutoff := safeSegment - hlsSegmentCleanupRetainBehind
 	if cutoff < 0 {
 		return
 	}
@@ -5594,8 +6324,8 @@ func (m *HLSManager) deleteOldSegments(session *HLSSession, justServedSegment st
 			session.MinSegmentAvailable = newMinAvailable
 		}
 		session.mu.Unlock()
-		log.Printf("[hls] session %s: deleted %d old segments (earliestBuffered=%d, lastServed=%d, safeSegment=%d, keeping 5 behind, minAvailable=%d)",
-			sessionID, deletedCount, earliestBuffered, lastServedSegment, safeSegment, newMinAvailable)
+		log.Printf("[hls] session %s: deleted %d old segments (earliestBuffered=%d, lastServed=%d, safeSegment=%d, keeping %d behind, minAvailable=%d)",
+			sessionID, deletedCount, earliestBuffered, lastServedSegment, safeSegment, hlsSegmentCleanupRetainBehind, newMinAvailable)
 	}
 }
 
@@ -5806,4 +6536,291 @@ func (m *HLSManager) WaitForActualStartOffset(session *HLSSession, timeout time.
 	log.Printf("[hls] session %s: timeout waiting for first segment to parse actual start offset (using requested: %.3fs)",
 		session.ID, startOffset)
 	return startOffset
+}
+
+func (m *HLSManager) SetCastCapabilities(store *castcaps.Store) {
+	if m == nil {
+		return
+	}
+	m.castCapsMu.Lock()
+	defer m.castCapsMu.Unlock()
+	m.castCaps = store
+}
+
+// lookupCastCapabilities answers from cache for a receiver address. Session
+// creation needs this before an HLSSession exists.
+func (m *HLSManager) lookupCastCapabilities(host string) *castcaps.Capabilities {
+	if m == nil || strings.TrimSpace(host) == "" {
+		return nil
+	}
+	m.castCapsMu.RLock()
+	store := m.castCaps
+	m.castCapsMu.RUnlock()
+	if store == nil {
+		return nil
+	}
+	return store.Lookup(host)
+}
+
+func (m *HLSManager) castCapabilities(session *HLSSession) *castcaps.Capabilities {
+	if session == nil {
+		return nil
+	}
+	return m.lookupCastCapabilities(session.CastReceiverHost)
+}
+
+// castVariantFingerprint is what a Cast session actually asks its receiver to
+// play. It is derived from the ffmpeg arg plan rather than from the source
+// file, so it describes the bytes the receiver really has to decode.
+type castVariantFingerprint struct {
+	// Primary is the variant this session is direct evidence for. A stall is
+	// blamed on it and on nothing else.
+	Primary castcaps.Variant
+	// Implied are variants that sustained playback also proves, because Primary
+	// strictly contains them. They are never blamed for a stall.
+	Implied []castcaps.Variant
+}
+
+func (f castVariantFingerprint) empty() bool { return f.Primary == "" }
+
+// castVariantPlan is the receiver-facing shape of one ffmpeg output.
+type castVariantPlan struct {
+	Fmp4          bool   // container: fMP4 when true, MPEG-TS when false
+	VideoCodec    string // codec the receiver decodes, after any transcode
+	AudioCodec    string // codec the receiver decodes, after any transcode
+	AudioChannels int    // 0 when audio is copied and the count is unknown
+}
+
+// castVariantsForPlan maps an output plan onto the capability matrix. Each
+// container has exactly one interesting axis: an fMP4 output is decided by its
+// video codec (a receiver that plays fMP4 at all plays H.264 in it), and an
+// MPEG-TS output is decided by its audio codec (H.264 in TS is the universal
+// Cast baseline). A plan whose deciding axis is unknown - copied audio, whose
+// channel count nothing in the probe reports - maps to no variant at all: a
+// guess here becomes a cached verdict that silently steers every later session
+// against this receiver.
+func castVariantsForPlan(plan castVariantPlan) castVariantFingerprint {
+	if plan.Fmp4 {
+		switch strings.ToLower(strings.TrimSpace(plan.VideoCodec)) {
+		case "hevc", "h265", "hev1", "hvc1":
+			return castVariantFingerprint{
+				Primary: castcaps.VariantHEVCFMP4,
+				Implied: []castcaps.Variant{castcaps.VariantFMP4},
+			}
+		case "h264", "avc", "avc1":
+			return castVariantFingerprint{Primary: castcaps.VariantFMP4}
+		}
+		return castVariantFingerprint{}
+	}
+	switch strings.ToLower(strings.TrimSpace(plan.AudioCodec)) {
+	case "ac3", "ac-3", "eac3", "eac-3":
+		return castVariantFingerprint{Primary: castcaps.VariantTSAC3}
+	case "aac":
+		if plan.AudioChannels > 2 {
+			return castVariantFingerprint{
+				Primary: castcaps.VariantTSAACMultichannel,
+				Implied: []castcaps.Variant{castcaps.VariantTSAACStereo},
+			}
+		}
+		if plan.AudioChannels > 0 {
+			return castVariantFingerprint{Primary: castcaps.VariantTSAACStereo}
+		}
+	}
+	return castVariantFingerprint{}
+}
+
+const (
+	// A receiver that has pulled this much media over this long a wall-clock
+	// window is playing it. Anything shorter is indistinguishable from the
+	// buffer burst a receiver performs before deciding it cannot decode.
+	castProvenMediaSeconds = 20.0
+	castProvenElapsed      = 15 * time.Second
+
+	// Accept-then-stall, as measured on real hardware: the receiver takes the
+	// playlist and a handful of segments, then goes silent forever with no
+	// error while the sender keeps the session alive.
+	castStallMaxSegments = 6
+	castStallSilence     = 20 * time.Second
+
+	// Without a recent keepalive the sender is gone too, so receiver silence
+	// says nothing about what the receiver can decode.
+	castStallKeepaliveWindow = 30 * time.Second
+)
+
+// castPlaybackObservation is the receiver-side fetch timeline of one cast
+// session: what the device pulled, and when.
+type castPlaybackObservation struct {
+	Now       time.Time
+	Alive     bool      // session still running: not stopped, completed, or failed
+	Keepalive time.Time // last sender keepalive; zero when none has arrived
+	Playlist  bool      // the receiver fetched a media playlist
+	First     time.Time // receiver's first segment fetch
+	Last      time.Time // receiver's most recent segment fetch
+	Segments  int       // distinct segments the receiver fetched
+}
+
+// gradeCastPlayback turns a fetch timeline into a capability verdict. It
+// answers VerdictUnknown whenever the evidence is ambiguous: a verdict is
+// cached and then silently steers every later session on that receiver, so
+// saying nothing is always the cheaper mistake.
+func gradeCastPlayback(obs castPlaybackObservation) (castcaps.Verdict, string) {
+	if obs.Segments <= 0 || obs.First.IsZero() || obs.Last.IsZero() {
+		return castcaps.VerdictUnknown, ""
+	}
+
+	mediaSeconds := float64(obs.Segments) * hlsSegmentDuration
+	elapsed := obs.Last.Sub(obs.First)
+	if mediaSeconds >= castProvenMediaSeconds && elapsed > castProvenElapsed {
+		return castcaps.VerdictSupported, fmt.Sprintf(
+			"receiver fetched %d segments (%.0fs of media) spread over %s",
+			obs.Segments, mediaSeconds, elapsed.Round(time.Second))
+	}
+
+	if !obs.Alive || !obs.Playlist || obs.Segments >= castStallMaxSegments {
+		return castcaps.VerdictUnknown, ""
+	}
+	if obs.Keepalive.IsZero() || obs.Now.Sub(obs.Keepalive) > castStallKeepaliveWindow {
+		return castcaps.VerdictUnknown, ""
+	}
+	silence := obs.Now.Sub(obs.Last)
+	if silence < castStallSilence {
+		return castcaps.VerdictUnknown, ""
+	}
+	return castcaps.VerdictRejected, fmt.Sprintf(
+		"receiver took the playlist and %d segment(s) then fetched nothing for %s while the session stayed alive",
+		obs.Segments, silence.Round(time.Second))
+}
+
+// castRequestIsFromReceiver reports whether an HTTP request came from the Cast
+// receiver itself rather than the sender app warming the backlog. Only the
+// receiver's own fetches say anything about what it can decode.
+func castRequestIsFromReceiver(session *HLSSession, r *http.Request) bool {
+	if session == nil || r == nil {
+		return false
+	}
+	session.mu.RLock()
+	host := strings.TrimSpace(session.CastReceiverHost)
+	castMode := session.CastMode
+	session.mu.RUnlock()
+	if host == "" || !castMode {
+		return false
+	}
+	remote := strings.TrimSpace(r.RemoteAddr)
+	if hostOnly, _, err := net.SplitHostPort(remote); err == nil {
+		remote = hostOnly
+	}
+	return remote == host
+}
+
+// noteCastReceiverPlaylist records that the receiver pulled a media playlist.
+// A stall verdict requires this: a receiver that never even read the playlist
+// was never given the chance to reject the stream.
+func (m *HLSManager) noteCastReceiverPlaylist(session *HLSSession, r *http.Request) {
+	if !castRequestIsFromReceiver(session, r) {
+		return
+	}
+	session.mu.Lock()
+	session.castPlaylistFetched = true
+	session.mu.Unlock()
+}
+
+// noteCastReceiverFetch records one segment fetch by the receiver and regrades
+// the session. Fetches are counted at request time, not after a successful
+// serve: a request the server could not satisfy is still the receiver asking.
+func (m *HLSManager) noteCastReceiverFetch(session *HLSSession, r *http.Request, segmentName string) {
+	if !castRequestIsFromReceiver(session, r) {
+		return
+	}
+	var segmentNum int
+	if _, err := fmt.Sscanf(segmentName, "segment%d.", &segmentNum); err != nil {
+		return
+	}
+
+	now := time.Now()
+	session.mu.Lock()
+	if session.castVariantsGraded {
+		session.mu.Unlock()
+		return
+	}
+	if session.castFetchedSegments == nil {
+		session.castFetchedSegments = make(map[int]struct{})
+	}
+	session.castFetchedSegments[segmentNum] = struct{}{}
+	if session.castFirstFetch.IsZero() {
+		session.castFirstFetch = now
+	}
+	session.castLastFetch = now
+	session.mu.Unlock()
+
+	m.gradeCastSession(session, now)
+}
+
+// noteCastKeepalive records that the sender still wants this session, then
+// regrades. A stall produces no further segment fetches, so the keepalive is
+// the only clock that can ever notice it.
+func (m *HLSManager) noteCastKeepalive(session *HLSSession, now time.Time) {
+	if session == nil {
+		return
+	}
+	session.mu.Lock()
+	skip := session.castVariantsGraded || !session.CastMode || strings.TrimSpace(session.CastReceiverHost) == ""
+	if !skip {
+		session.castLastKeepalive = now
+	}
+	session.mu.Unlock()
+	if skip {
+		return
+	}
+	m.gradeCastSession(session, now)
+}
+
+// gradeCastSession records a verdict for the variants this session exercises,
+// at most once per session. Sessions with no receiver address, no cast mode, or
+// no recognizable variant are never graded.
+func (m *HLSManager) gradeCastSession(session *HLSSession, now time.Time) {
+	if m == nil || session == nil {
+		return
+	}
+	m.castCapsMu.RLock()
+	store := m.castCaps
+	m.castCapsMu.RUnlock()
+	if store == nil {
+		return
+	}
+
+	session.mu.Lock()
+	host := strings.TrimSpace(session.CastReceiverHost)
+	fingerprint := session.castVariants
+	if session.castVariantsGraded || host == "" || !session.CastMode || fingerprint.empty() {
+		session.mu.Unlock()
+		return
+	}
+	verdict, evidence := gradeCastPlayback(castPlaybackObservation{
+		Now:       now,
+		Alive:     !session.Stopped && !session.Completed && session.FatalError == "",
+		Keepalive: session.castLastKeepalive,
+		Playlist:  session.castPlaylistFetched,
+		First:     session.castFirstFetch,
+		Last:      session.castLastFetch,
+		Segments:  len(session.castFetchedSegments),
+	})
+	if verdict == castcaps.VerdictUnknown {
+		session.mu.Unlock()
+		return
+	}
+	session.castVariantsGraded = true
+	// The timeline has done its job and the fetch set only grows from here.
+	session.castFetchedSegments = nil
+	sessionID := session.ID
+	session.mu.Unlock()
+
+	variants := []castcaps.Variant{fingerprint.Primary}
+	if verdict == castcaps.VerdictSupported {
+		variants = append(variants, fingerprint.Implied...)
+	}
+	for _, variant := range variants {
+		store.Record(host, variant, verdict)
+		log.Printf("[hls] session %s: receiver %s recorded %s=%s (%s)",
+			sessionID, host, variant, verdict, evidence)
+	}
 }

--- a/backend/handlers/hls_cast_observation_test.go
+++ b/backend/handlers/hls_cast_observation_test.go
@@ -1,0 +1,318 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"novastream/services/castcaps"
+)
+
+// The legacy dongle measured today. Its address only has to be stable across
+// the fake requests; nothing in these tests contacts it.
+const observedReceiverHost = "192.168.8.108"
+
+func newObservationManager(t *testing.T) (*HLSManager, *castcaps.Store) {
+	t.Helper()
+	store := castcaps.NewStore(t.TempDir())
+	manager := &HLSManager{}
+	manager.SetCastCapabilities(store)
+	return manager, store
+}
+
+func newObservedCastSession(host string, fingerprint castVariantFingerprint) *HLSSession {
+	return &HLSSession{
+		ID:               "cast-observation",
+		CastMode:         true,
+		CastReceiverHost: host,
+		castVariants:     fingerprint,
+	}
+}
+
+// receiverFetch is a segment request as the receiver itself makes it: from the
+// receiver's own address, which is how the server tells it apart from the
+// sender app warming the backlog.
+func receiverFetch(host, segmentName string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/video/hls/cast-observation/"+segmentName, nil)
+	r.RemoteAddr = host + ":41234"
+	return r
+}
+
+func verdictFor(t *testing.T, store *castcaps.Store, host string, variant castcaps.Variant) castcaps.Verdict {
+	t.Helper()
+	caps := store.Lookup(host)
+	if caps == nil {
+		return castcaps.VerdictUnknown
+	}
+	return caps.Variants[variant]
+}
+
+// rewindFirstFetch moves the start of the fetch timeline into the past so a
+// sustained-playback window can be exercised without a sleeping test.
+func rewindFirstFetch(session *HLSSession, by time.Duration) {
+	session.mu.Lock()
+	session.castFirstFetch = session.castFirstFetch.Add(-by)
+	session.mu.Unlock()
+}
+
+// rewindLastFetch ages the most recent fetch so the receiver looks silent.
+func rewindLastFetch(session *HLSSession, by time.Duration) {
+	session.mu.Lock()
+	session.castLastFetch = session.castLastFetch.Add(-by)
+	session.mu.Unlock()
+}
+
+func TestCastObservationRecordsSupportedOnSustainedPlayback(t *testing.T) {
+	manager, store := newObservationManager(t)
+	session := newObservedCastSession(observedReceiverHost, castVariantFingerprint{
+		Primary: castcaps.VariantTSAACMultichannel,
+		Implied: []castcaps.Variant{castcaps.VariantTSAACStereo},
+	})
+
+	manager.noteCastReceiverPlaylist(session, receiverFetch(observedReceiverHost, "stream.m3u8"))
+	for i := range 10 {
+		manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, fmt.Sprintf("segment%d.ts", i)), fmt.Sprintf("segment%d.ts", i))
+	}
+
+	// Twenty seconds of media in an instant is a warm-up burst, which is also
+	// exactly what a receiver about to stall does. Nothing may be decided yet.
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantTSAACMultichannel); got != castcaps.VerdictUnknown {
+		t.Fatalf("burst of 10 segments already recorded %q; want no verdict", got)
+	}
+
+	// The eleventh fetch arrives sixteen seconds after the first: the receiver
+	// is consuming the stream in real time, not buffering and giving up.
+	rewindFirstFetch(session, 16*time.Second)
+	manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, "segment10.ts"), "segment10.ts")
+
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantTSAACMultichannel); got != castcaps.VerdictSupported {
+		t.Fatalf("primary variant verdict = %q, want %q", got, castcaps.VerdictSupported)
+	}
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantTSAACStereo); got != castcaps.VerdictSupported {
+		t.Fatalf("implied variant verdict = %q, want %q", got, castcaps.VerdictSupported)
+	}
+}
+
+func TestCastObservationRecordsRejectedOnAcceptThenStall(t *testing.T) {
+	manager, store := newObservationManager(t)
+	// The measured 4K HEVC direct-copy signature: the load is accepted, a few
+	// segments are pulled, and playback never starts.
+	session := newObservedCastSession(observedReceiverHost, castVariantFingerprint{
+		Primary: castcaps.VariantHEVCFMP4,
+		Implied: []castcaps.Variant{castcaps.VariantFMP4},
+	})
+
+	manager.noteCastReceiverPlaylist(session, receiverFetch(observedReceiverHost, "stream.m3u8"))
+	manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, "init.mp4"), "init.mp4")
+	for i := range 3 {
+		manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, fmt.Sprintf("segment%d.m4s", i)), fmt.Sprintf("segment%d.m4s", i))
+	}
+
+	// Ten seconds of keepalives with no fetch is not yet a stall: a receiver
+	// buffering a slow source looks identical.
+	rewindLastFetch(session, 10*time.Second)
+	manager.noteCastKeepalive(session, time.Now())
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantHEVCFMP4); got != castcaps.VerdictUnknown {
+		t.Fatalf("10s of silence already recorded %q; want no verdict", got)
+	}
+
+	// Twenty-one seconds of silence while the sender keeps the session alive is
+	// the accept-then-stall signature.
+	rewindLastFetch(session, 11*time.Second)
+	manager.noteCastKeepalive(session, time.Now())
+
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantHEVCFMP4); got != castcaps.VerdictRejected {
+		t.Fatalf("primary variant verdict = %q, want %q", got, castcaps.VerdictRejected)
+	}
+	// A stall is blamed on the primary variant only. Blaming the container for
+	// an HEVC decode failure would bar H.264 fMP4 on a receiver that plays it.
+	if got := verdictFor(t, store, observedReceiverHost, castcaps.VariantFMP4); got != castcaps.VerdictUnknown {
+		t.Fatalf("implied variant was blamed for the stall: %q", got)
+	}
+}
+
+func TestCastObservationRecordsNothingForAmbiguousSession(t *testing.T) {
+	manager, store := newObservationManager(t)
+	session := newObservedCastSession(observedReceiverHost, castVariantFingerprint{
+		Primary: castcaps.VariantTSAACStereo,
+	})
+
+	manager.noteCastReceiverPlaylist(session, receiverFetch(observedReceiverHost, "stream.m3u8"))
+	for i := range 4 {
+		manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, fmt.Sprintf("segment%d.ts", i)), fmt.Sprintf("segment%d.ts", i))
+	}
+	manager.noteCastKeepalive(session, time.Now())
+
+	if records := store.All(); len(records) != 0 {
+		t.Fatalf("short session wrote %d capability record(s): %+v", len(records), records)
+	}
+}
+
+func TestCastObservationRecordsNothingWithoutReceiverHost(t *testing.T) {
+	manager, store := newObservationManager(t)
+	session := newObservedCastSession("", castVariantFingerprint{Primary: castcaps.VariantTSAACStereo})
+
+	// A cast session with no receiver address cannot attribute anything, so
+	// even fetches that look like the receiver's are ignored.
+	manager.noteCastReceiverPlaylist(session, receiverFetch(observedReceiverHost, "stream.m3u8"))
+	for i := range 12 {
+		manager.noteCastReceiverFetch(session, receiverFetch(observedReceiverHost, fmt.Sprintf("segment%d.ts", i)), fmt.Sprintf("segment%d.ts", i))
+	}
+
+	// Even a timeline that would otherwise be decisive stays unrecorded.
+	now := time.Now()
+	session.mu.Lock()
+	session.castPlaylistFetched = true
+	session.castFetchedSegments = map[int]struct{}{}
+	for i := range 12 {
+		session.castFetchedSegments[i] = struct{}{}
+	}
+	session.castFirstFetch = now.Add(-30 * time.Second)
+	session.castLastFetch = now
+	session.mu.Unlock()
+	manager.gradeCastSession(session, now)
+
+	if records := store.All(); len(records) != 0 {
+		t.Fatalf("hostless session wrote %d capability record(s): %+v", len(records), records)
+	}
+}
+
+func TestGradeCastPlayback(t *testing.T) {
+	now := time.Date(2026, 8, 2, 20, 0, 0, 0, time.UTC)
+	sustained := castPlaybackObservation{
+		Now:       now,
+		Alive:     true,
+		Keepalive: now.Add(-2 * time.Second),
+		Playlist:  true,
+		First:     now.Add(-18 * time.Second),
+		Last:      now,
+		Segments:  10,
+	}
+	stalled := castPlaybackObservation{
+		Now:       now,
+		Alive:     true,
+		Keepalive: now.Add(-2 * time.Second),
+		Playlist:  true,
+		First:     now.Add(-25 * time.Second),
+		Last:      now.Add(-21 * time.Second),
+		Segments:  3,
+	}
+
+	mutate := func(base castPlaybackObservation, f func(*castPlaybackObservation)) castPlaybackObservation {
+		f(&base)
+		return base
+	}
+
+	for _, tc := range []struct {
+		name string
+		obs  castPlaybackObservation
+		want castcaps.Verdict
+	}{
+		{"sustained playback is proof", sustained, castcaps.VerdictSupported},
+		{"20s of media in a burst proves nothing", mutate(sustained, func(o *castPlaybackObservation) {
+			o.First = o.Last.Add(-3 * time.Second)
+		}), castcaps.VerdictUnknown},
+		{"a long thin trickle is not 20s of media", mutate(sustained, func(o *castPlaybackObservation) {
+			o.Segments = 9
+		}), castcaps.VerdictUnknown},
+		{"accept then stall is a rejection", stalled, castcaps.VerdictRejected},
+		{"19s of silence is still buffering", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Last = o.Now.Add(-19 * time.Second)
+		}), castcaps.VerdictUnknown},
+		{"six segments is past the stall envelope", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Segments = 6
+		}), castcaps.VerdictUnknown},
+		{"a dead session says nothing", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Alive = false
+		}), castcaps.VerdictUnknown},
+		{"a gone sender says nothing", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Keepalive = o.Now.Add(-90 * time.Second)
+		}), castcaps.VerdictUnknown},
+		{"no keepalive at all says nothing", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Keepalive = time.Time{}
+		}), castcaps.VerdictUnknown},
+		{"a receiver that never read the playlist says nothing", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Playlist = false
+		}), castcaps.VerdictUnknown},
+		{"no fetches at all says nothing", mutate(stalled, func(o *castPlaybackObservation) {
+			o.Segments = 0
+			o.First = time.Time{}
+			o.Last = time.Time{}
+		}), castcaps.VerdictUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, evidence := gradeCastPlayback(tc.obs)
+			if got != tc.want {
+				t.Fatalf("gradeCastPlayback = %q (%s), want %q", got, evidence, tc.want)
+			}
+			if got != castcaps.VerdictUnknown && evidence == "" {
+				t.Fatal("a recorded verdict must carry the evidence that decided it")
+			}
+		})
+	}
+}
+
+func TestCastVariantsForPlan(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		plan        castVariantPlan
+		wantPrimary castcaps.Variant
+		wantImplied []castcaps.Variant
+	}{
+		{
+			name:        "TS with stereo AAC is the baseline variant",
+			plan:        castVariantPlan{VideoCodec: "h264", AudioCodec: "aac", AudioChannels: 2},
+			wantPrimary: castcaps.VariantTSAACStereo,
+		},
+		{
+			name:        "TS with 5.1 AAC also proves stereo",
+			plan:        castVariantPlan{VideoCodec: "h264", AudioCodec: "aac", AudioChannels: 6},
+			wantPrimary: castcaps.VariantTSAACMultichannel,
+			wantImplied: []castcaps.Variant{castcaps.VariantTSAACStereo},
+		},
+		{
+			name:        "copied Dolby in TS is the AC-3 variant",
+			plan:        castVariantPlan{VideoCodec: "h264", AudioCodec: "eac3"},
+			wantPrimary: castcaps.VariantTSAC3,
+		},
+		{
+			name: "copied AAC of unknown channel count grades nothing",
+			plan: castVariantPlan{VideoCodec: "h264", AudioCodec: "aac"},
+		},
+		{
+			name:        "H.264 in fMP4 is the container variant",
+			plan:        castVariantPlan{Fmp4: true, VideoCodec: "h264", AudioCodec: "aac", AudioChannels: 2},
+			wantPrimary: castcaps.VariantFMP4,
+		},
+		{
+			name:        "HEVC in fMP4 also proves the container",
+			plan:        castVariantPlan{Fmp4: true, VideoCodec: "hevc", AudioCodec: "aac", AudioChannels: 2},
+			wantPrimary: castcaps.VariantHEVCFMP4,
+			wantImplied: []castcaps.Variant{castcaps.VariantFMP4},
+		},
+		{
+			name: "an unrecognized codec grades nothing",
+			plan: castVariantPlan{Fmp4: true, VideoCodec: "mpeg4", AudioCodec: "aac", AudioChannels: 2},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := castVariantsForPlan(tc.plan)
+			if got.Primary != tc.wantPrimary {
+				t.Fatalf("primary = %q, want %q", got.Primary, tc.wantPrimary)
+			}
+			if len(got.Implied) != len(tc.wantImplied) {
+				t.Fatalf("implied = %v, want %v", got.Implied, tc.wantImplied)
+			}
+			for i, want := range tc.wantImplied {
+				if got.Implied[i] != want {
+					t.Fatalf("implied[%d] = %q, want %q", i, got.Implied[i], want)
+				}
+			}
+			if got.empty() != (tc.wantPrimary == "") {
+				t.Fatalf("empty() = %v for primary %q", got.empty(), got.Primary)
+			}
+		})
+	}
+}

--- a/backend/handlers/hls_direct_cast_test.go
+++ b/backend/handlers/hls_direct_cast_test.go
@@ -1,0 +1,525 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"novastream/services/castcaps"
+	"novastream/services/streaming"
+)
+
+type directCastTestProvider struct {
+	directURL string
+}
+
+func (p directCastTestProvider) Stream(context.Context, streaming.Request) (*streaming.Response, error) {
+	return &streaming.Response{Body: io.NopCloser(strings.NewReader("video"))}, nil
+}
+
+func (p directCastTestProvider) GetDirectURL(context.Context, string) (string, error) {
+	return p.directURL, nil
+}
+
+func TestStartHLSSessionDirectCastWithoutProbeFallsBackToStableTimeline(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(inputPath, []byte("not a real media file"), 0644); err != nil {
+		t.Fatalf("write input fixture: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		query url.Values
+	}{
+		{
+			name: "target cast-direct",
+			query: url.Values{
+				"path":         {inputPath},
+				"cast":         {"true"},
+				"target":       {"cast-direct"},
+				"durationHint": {"120"},
+			},
+		},
+		{
+			name: "castProfile direct",
+			query: url.Values{
+				"path":         {inputPath},
+				"cast":         {"true"},
+				"target":       {"web"},
+				"castProfile":  {"direct"},
+				"durationHint": {"120"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := NewVideoHandlerWithProvider(true, "/usr/bin/true", "/definitely-missing-ffprobe", t.TempDir(), directCastTestProvider{directURL: inputPath})
+			defer handler.hlsManager.Shutdown()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/video/hls/start?"+tc.query.Encode(), nil)
+			handler.StartHLSSession(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			var body struct {
+				StableCastTimeline bool `json:"stableCastTimeline"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if !body.StableCastTimeline {
+				t.Fatalf("stableCastTimeline = false, want true when direct cast safety cannot be verified")
+			}
+		})
+	}
+}
+
+func TestStartHLSSessionCompatibilityCastRemainsStableTimeline(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(inputPath, []byte("not a real media file"), 0644); err != nil {
+		t.Fatalf("write input fixture: %v", err)
+	}
+
+	handler := NewVideoHandlerWithProvider(true, "/usr/bin/true", "/definitely-missing-ffprobe", t.TempDir(), directCastTestProvider{directURL: inputPath})
+	defer handler.hlsManager.Shutdown()
+
+	query := url.Values{
+		"path":         {inputPath},
+		"cast":         {"true"},
+		"forceAAC":     {"true"},
+		"target":       {"web"},
+		"castProfile":  {"compatibility"},
+		"durationHint": {"120"},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/video/hls/start?"+query.Encode(), nil)
+	handler.StartHLSSession(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		StableCastTimeline bool `json:"stableCastTimeline"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.StableCastTimeline {
+		t.Fatalf("stableCastTimeline = false, want true for compatibility cast profile")
+	}
+}
+
+func TestDirectCastH264RemuxesToMpegTSWithoutLegacyCastForcing(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "direct-cast",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			VideoLevel:         41,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, false)
+
+	if strings.Contains(logs, "session direct-cast: cast stable timeline requires deterministic H.264 segments") {
+		t.Fatalf("direct cast produced legacy stable timeline transcode log; logs=%s", logs)
+	}
+	if !argPair(args, "-c:v", "copy") {
+		t.Fatalf("direct cast args did not copy H.264 video; args=%v", args)
+	}
+	// Receivers built into TVs accept an fMP4 HLS load and then never start
+	// playing; H.264 remuxes into MPEG-TS with no re-encode, so direct Cast
+	// keeps the copy path in the container every receiver understands.
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("direct cast args did not use MPEG-TS segments; args=%v", args)
+	}
+	if argPair(args, "-hls_segment_type", "fmp4") {
+		t.Fatalf("direct cast args used fMP4 segments; args=%v", args)
+	}
+}
+
+// A gen2 Chromecast cannot decode HEVC at any resolution, and every receiver
+// tested so far stalls silently on an fMP4 HLS load. An unprobed receiver
+// therefore gets the compatibility transcode rather than an HEVC copy.
+func TestDirectCastHEVCFallsBackToCompatibilityWithoutCapabilityProof(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "direct-cast-hevc",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		HasHDR:         true,
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "hevc",
+			VideoPixFmt:        "yuv420p10le",
+			VideoProfile:       "Main 10",
+			VideoWidth:         3840,
+			VideoHeight:        2160,
+			VideoLevel:         153,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, false)
+
+	if !strings.Contains(logs, "outside the receiver copy envelope") {
+		t.Fatalf("HEVC direct cast did not fall back to compatibility; logs=%s", logs)
+	}
+	if argPair(args, "-c:v", "copy") {
+		t.Fatalf("HEVC direct cast copied 4K video a receiver cannot decode; args=%v", args)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("compatibility fallback must use MPEG-TS; args=%v", args)
+	}
+}
+
+func TestDirectCast1080pH264StillCopies(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "direct-cast-1080p",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			VideoLevel:         41,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, false)
+
+	if strings.Contains(logs, "outside the receiver copy envelope") {
+		t.Fatalf("in-envelope H.264 must keep the copy path; logs=%s", logs)
+	}
+	if !argPair(args, "-c:v", "copy") {
+		t.Fatalf("1080p H.264 direct cast did not copy video; args=%v", args)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("direct cast copy must remux into MPEG-TS; args=%v", args)
+	}
+}
+
+func TestDirectCastNonAACAudioReEncodesAudioOnlyInMpegTS(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "direct-cast-aac",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			VideoLevel:         41,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "eac3"}},
+			HasCompatibleAudio: true,
+		},
+	}, false)
+
+	if strings.Contains(logs, "cast stable timeline requires deterministic H.264 segments") {
+		t.Fatalf("direct forceAAC cast unexpectedly used stable timeline; logs=%s", logs)
+	}
+	if !argPair(args, "-c:v", "copy") {
+		t.Fatalf("direct forceAAC cast did not copy video; args=%v", args)
+	}
+	if !argPair(args, "-c:a:0", "aac") {
+		t.Fatalf("direct cast did not re-encode E-AC-3 audio the receiver may not decode; args=%v", args)
+	}
+	if !argPair(args, "-ac:a:0", "2") || !argPair(args, "-profile:a:0", "aac_low") {
+		t.Fatalf("direct cast audio must be stereo AAC-LC; receivers reject multichannel AAC; args=%v", args)
+	}
+	if argPair(args, "-c:a:1", "copy") {
+		t.Fatalf("direct cast must not carry a second, undecodable audio track; args=%v", args)
+	}
+	if !strings.Contains(logs, "direct Cast audio is not AAC") {
+		t.Fatalf("direct cast did not log the audio-only re-encode; logs=%s", logs)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("direct cast should remux into MPEG-TS; args=%v", args)
+	}
+}
+
+func TestDirectCastIncompatibleVideoFallsBackToCompatibilityTranscode(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "direct-cast-incompatible",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "mpeg4",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "Simple Profile",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, false)
+
+	if !strings.Contains(logs, "session direct-cast-incompatible: cast direct video is outside the receiver copy envelope") {
+		t.Fatalf("incompatible direct cast did not log compatibility fallback; logs=%s", logs)
+	}
+	if argPair(args, "-c:v", "copy") {
+		t.Fatalf("incompatible direct cast copied video instead of transcoding; args=%v", args)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("incompatible direct cast did not use MPEG-TS compatibility segments; args=%v", args)
+	}
+}
+
+func TestCompatibilityCastHDRTranscodingArgsKeepLegacyStableMPEGTSPath(t *testing.T) {
+	args, logs := runCastArgPlanTest(t, &HLSSession{
+		ID:             "compat-cast",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		HasHDR:         true,
+		CastMode:       true,
+		PlaybackTarget: "web",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "hevc",
+			VideoPixFmt:        "yuv420p10le",
+			VideoProfile:       "Main 10",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, true)
+
+	if !strings.Contains(logs, "session compat-cast: cast stable timeline requires deterministic H.264 segments") {
+		t.Fatalf("compatibility cast did not produce legacy stable timeline transcode log; logs=%s", logs)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("compatibility cast args did not use MPEG-TS segments; args=%v", args)
+	}
+	if argPair(args, "-c:v", "copy") {
+		t.Fatalf("compatibility cast unexpectedly copied video instead of legacy transcode; args=%v", args)
+	}
+}
+
+func runCastArgPlanTest(t *testing.T, session *HLSSession, forceAAC bool) ([]string, string) {
+	t.Helper()
+
+	capturePath := filepath.Join(t.TempDir(), "ffmpeg-args.txt")
+	ffmpegPath := filepath.Join(t.TempDir(), "fake-ffmpeg.sh")
+	script := "#!/bin/sh\nprintf '%s\n' \"$@\" > \"$CAPTURE_FFMPEG_ARGS\"\nexit 0\n"
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	t.Setenv("CAPTURE_FFMPEG_ARGS", capturePath)
+
+	inputPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(inputPath, []byte("not a real media file"), 0644); err != nil {
+		t.Fatalf("write input fixture: %v", err)
+	}
+	manager := NewHLSManager(t.TempDir(), ffmpegPath, "", directCastTestProvider{directURL: inputPath})
+	defer manager.Shutdown()
+
+	if err := os.MkdirAll(session.OutputDir, 0755); err != nil {
+		t.Fatalf("create session output dir: %v", err)
+	}
+	session.CreatedAt = time.Now()
+	session.LastAccess = time.Now()
+	session.LastSegmentRequest = time.Now()
+	session.MinSegmentRequested = -1
+	session.MaxSegmentRequested = -1
+	session.LastPlaybackSegment = -1
+	session.LastSegmentServed = -1
+	session.EarliestBufferedSegment = -1
+	session.FinalSegmentCount = -1
+
+	var logBuf strings.Builder
+	originalLogOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	if err := manager.startTranscoding(context.Background(), session, forceAAC); err != nil {
+		t.Fatalf("startTranscoding returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured ffmpeg args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(args) == 1 && args[0] == "" {
+		args = nil
+	}
+	return args, logBuf.String()
+}
+
+func argPair(args []string, key, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompatibilityCastTranscodesAt1080pByDefault(t *testing.T) {
+	args, _ := runCastArgPlanTest(t, &HLSSession{
+		ID:             "compat-cast-1080",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		PlaybackTarget: "web",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, true)
+
+	filter := castFilterArg(args)
+	if !strings.Contains(filter, "min(1920,iw)") || !strings.Contains(filter, "min(1080,ih)") {
+		t.Fatalf("compatibility cast did not encode at 1080p; filter=%q args=%v", filter, args)
+	}
+}
+
+func TestCompatibilityCastHonoursSlowLinkHeightCap(t *testing.T) {
+	args, _ := runCastArgPlanTest(t, &HLSSession{
+		ID:             "compat-cast-720",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		PlaybackTarget: "web",
+		CastMaxHeight:  legacyCastHDMaxHeight,
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "aac"}},
+			HasCompatibleAudio: true,
+		},
+	}, true)
+
+	filter := castFilterArg(args)
+	if !strings.Contains(filter, "min(1280,iw)") || !strings.Contains(filter, "min(720,ih)") {
+		t.Fatalf("slow-link cap did not drop the encode to 720p; filter=%q args=%v", filter, args)
+	}
+}
+
+func castFilterArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-vf" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// Capability widening must prove the exact thing it permits. VariantFMP4 is an
+// H.264 asset: it says the container is accepted, nothing about HEVC decode.
+func TestDirectCastCopyWideningRequiresMatchingProof(t *testing.T) {
+	hevc4K := &UnifiedProbeResult{
+		VideoCodec:   "hevc",
+		VideoWidth:   3840,
+		VideoHeight:  2160,
+		VideoLevel:   153,
+		AvgFrameRate: "24000/1001",
+	}
+	h264Above := &UnifiedProbeResult{
+		VideoCodec:   "h264",
+		VideoWidth:   3840,
+		VideoHeight:  2160,
+		VideoLevel:   51,
+		AvgFrameRate: "24000/1001",
+	}
+	caps := func(verdict castcaps.Verdict, variants ...castcaps.Variant) *castcaps.Capabilities {
+		c := &castcaps.Capabilities{Variants: map[castcaps.Variant]castcaps.Verdict{}}
+		for _, v := range variants {
+			c.Variants[v] = verdict
+		}
+		return c
+	}
+	proven := func(variants ...castcaps.Variant) *castcaps.Capabilities {
+		return caps(castcaps.VerdictSupported, variants...)
+	}
+	assumed := func(variants ...castcaps.Variant) *castcaps.Capabilities {
+		return caps(castcaps.VerdictAssumed, variants...)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		probe *UnifiedProbeResult
+		caps  *castcaps.Capabilities
+		want  bool
+	}{
+		{"unidentified receiver refuses 4K HEVC", hevc4K, nil, false},
+		{"identified receiver with no verdicts refuses 4K HEVC", hevc4K, caps(castcaps.VerdictUnknown), false},
+		{"container proof alone refuses HEVC", hevc4K, proven(castcaps.VariantFMP4), false},
+		{"HEVC proof without container refuses", hevc4K, proven(castcaps.VariantHEVCFMP4), false},
+		{"both proofs allow HEVC copy", hevc4K, proven(castcaps.VariantFMP4, castcaps.VariantHEVCFMP4), true},
+		// A model prior is worth one attempt: the cost of being wrong is a
+		// session that falls back, not a session that silently never starts.
+		{"model prior allows an HEVC copy attempt", hevc4K, assumed(castcaps.VariantFMP4, castcaps.VariantHEVCFMP4), true},
+		{"container prior alone refuses HEVC", hevc4K, assumed(castcaps.VariantFMP4), false},
+		{"an observed rejection outranks the container prior", hevc4K, func() *castcaps.Capabilities {
+			c := assumed(castcaps.VariantFMP4)
+			c.Variants[castcaps.VariantHEVCFMP4] = castcaps.VerdictRejected
+			return c
+		}(), false},
+		{"no variant measures 4K H.264", h264Above, proven(castcaps.VariantFMP4, castcaps.VariantHEVCFMP4), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canAttemptDirectCastCopyVideo(tc.probe, tc.caps); got != tc.want {
+				t.Fatalf("canAttemptDirectCastCopyVideo = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/handlers/hls_probe.go
+++ b/backend/handlers/hls_probe.go
@@ -67,6 +67,9 @@ type UnifiedProbeResult struct {
 	VideoCodec         string // e.g., "h264", "hevc", "mpeg4" - used to detect incompatible codecs
 	VideoPixFmt        string // e.g., "yuv420p", "yuv420p10le" - used for browser copy compatibility
 	VideoProfile       string // e.g., "High", "High 10" - used for browser copy compatibility
+	VideoWidth         int    // Primary video stream width in pixels
+	VideoHeight        int    // Primary video stream height in pixels
+	VideoLevel         int    // H.264 level as reported by ffprobe (for example, 41)
 	AvgFrameRate       string // e.g., "24000/1001" from primary video stream
 	AudioStreams       []audioStreamInfo
 	SubtitleStreams    []subtitleStreamInfo
@@ -287,6 +290,9 @@ func (m *HLSManager) parseUnifiedProbeOutput(output []byte) (*UnifiedProbeResult
 			CodecName     string            `json:"codec_name"`
 			PixFmt        string            `json:"pix_fmt"`
 			Profile       string            `json:"profile"`
+			Width         int               `json:"width"`
+			Height        int               `json:"height"`
+			Level         int               `json:"level"`
 			AvgFrameRate  string            `json:"avg_frame_rate"`
 			ColorTransfer string            `json:"color_transfer"`
 			Tags          map[string]string `json:"tags"`
@@ -346,6 +352,9 @@ func (m *HLSManager) parseUnifiedProbeOutput(output []byte) (*UnifiedProbeResult
 				result.VideoCodec = codec
 				result.VideoPixFmt = strings.ToLower(strings.TrimSpace(stream.PixFmt))
 				result.VideoProfile = strings.ToLower(strings.TrimSpace(stream.Profile))
+				result.VideoWidth = stream.Width
+				result.VideoHeight = stream.Height
+				result.VideoLevel = stream.Level
 				result.AvgFrameRate = strings.TrimSpace(stream.AvgFrameRate)
 			}
 			if result.ColorTransfer == "" {

--- a/backend/handlers/hls_test.go
+++ b/backend/handlers/hls_test.go
@@ -45,7 +45,7 @@ func TestCreateSessionRejectsElfHostedPlaceholderRedirect(t *testing.T) {
 		context.Background(),
 		"https://comet.elfhosted.com/playback/expired",
 		"https://comet.elfhosted.com/playback/expired",
-		false, "", false, false, 0, 0, -1, -1, "", "", "", false, "", "", 0,
+		false, "", false, false, 0, 0, -1, -1, "", "", "", false, "", "", 0, "",
 	)
 	if !errors.Is(err, errExternalStreamPlaceholder) {
 		t.Fatalf("CreateSession error = %v, want external placeholder error", err)

--- a/backend/handlers/hwaccel.go
+++ b/backend/handlers/hwaccel.go
@@ -249,12 +249,7 @@ func detectHWAccel(ffmpegPath, pref string) HWAccelCaps {
 	var candidates []HWAccelKind
 	switch pref {
 	case "auto":
-		// NVENC and QSV/VAAPI are the common Docker passthrough cases;
-		// VideoToolbox covers macOS hosts.
-		candidates = []HWAccelKind{HWNVENC, HWQSV, HWVAAPI}
-		if runtime.GOOS == "darwin" {
-			candidates = append([]HWAccelKind{HWVideoToolbox}, candidates...)
-		}
+		candidates = autoEncodeCandidates(encoders)
 	case string(HWNVENC):
 		candidates = []HWAccelKind{HWNVENC}
 	case string(HWQSV):
@@ -282,6 +277,19 @@ func detectHWAccel(ffmpegPath, pref string) HWAccelCaps {
 
 	log.Printf("[hwaccel] no usable hardware encoder found for preference=%s candidates=%v; using libx264", pref, candidates)
 	return caps
+}
+
+// autoEncodeCandidates orders the "auto" preference probes. NVENC and QSV/VAAPI
+// are the common Docker passthrough cases; VideoToolbox covers macOS hosts.
+// Candidacy follows the encoder the configured ffmpeg actually reports rather
+// than this process's GOOS, so a build that exposes VideoToolbox is always
+// tried first. Every candidate still has to pass a real test encode.
+func autoEncodeCandidates(encoders map[string]bool) []HWAccelKind {
+	candidates := []HWAccelKind{HWNVENC, HWQSV, HWVAAPI}
+	if encoders[hwEncoderName(HWVideoToolbox)] || runtime.GOOS == "darwin" {
+		candidates = append([]HWAccelKind{HWVideoToolbox}, candidates...)
+	}
+	return candidates
 }
 
 // detectTonemap returns the best verified tone-mapping implementation.
@@ -543,6 +551,15 @@ func looksLikeCapabilityFlags(s string) bool {
 // sourceTransfer is optional for compatibility with callers that have no probe
 // metadata; those sources conservatively default to PQ.
 func buildVideoEncodePlan(caps HWAccelCaps, tonemapNeeded bool, sourceTransfer ...string) videoEncodePlan {
+	return buildVideoEncodePlanWithLimits(caps, tonemapNeeded, 0, 0, 0, sourceTransfer...)
+}
+
+func buildVideoEncodePlanWithLimits(
+	caps HWAccelCaps,
+	tonemapNeeded bool,
+	maxWidth, maxHeight, maxFPS int,
+	sourceTransfer ...string,
+) videoEncodePlan {
 	plan := videoEncodePlan{Kind: caps.Encode}
 
 	// VAAPI/QSV encoders need their own filter hardware device for the hwupload
@@ -559,6 +576,20 @@ func buildVideoEncodePlan(caps HWAccelCaps, tonemapNeeded bool, sourceTransfer .
 		}
 	}
 	var filters []string
+	if maxWidth > 0 && maxHeight > 0 {
+		// Fit inside the receiver's decode box before tone mapping and hardware
+		// upload. The min() bounds prevent upscaling; the aspect-ratio and
+		// divisibility options keep the output valid for 4:2:0 H.264 encoders.
+		filters = append(filters, fmt.Sprintf(
+			"scale=w='min(%d,iw)':h='min(%d,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
+			maxWidth,
+			maxHeight,
+		))
+	}
+	if maxFPS > 0 {
+		// Cap high-frame-rate input without duplicating lower-rate frames.
+		filters = append(filters, fmt.Sprintf("fps='min(source_fps,%d)'", maxFPS))
+	}
 	if tonemapNeeded && tonemapImpl != "" {
 		plan.Tonemap = tonemapImpl
 		inputTransfer := "smpte2084"
@@ -661,6 +692,9 @@ func buildVideoEncodePlan(caps HWAccelCaps, tonemapNeeded bool, sourceTransfer .
 			"-level", "4.1",
 			"-pix_fmt", "yuv420p",
 		}
+	}
+	if maxFPS > 0 {
+		plan.EncoderArgs = append(plan.EncoderArgs, "-level:v", "4.1")
 	}
 
 	if len(filters) > 0 {

--- a/backend/handlers/playback_observer.go
+++ b/backend/handlers/playback_observer.go
@@ -1,0 +1,46 @@
+package handlers
+
+import "novastream/models"
+
+// PlaybackActivityObserver receives player updates only after they have been
+// matched to a currently active stream.
+type PlaybackActivityObserver interface {
+	HandlePlaybackUpdate(userID string, update models.PlaybackProgressUpdate, percentWatched float64)
+}
+
+// playbackObserverFanout delivers one matched playback update to every
+// registered consumer.
+//
+// Live playback has more than one consumer: watch notifications, and the p2p
+// integration that seeds what is being watched into the swarm. Neither may
+// displace or delay the other, so each consumer is dispatched on its own
+// goroutine — the notification service performs its webhook round trips inline,
+// and a slow webhook must not hold up a seed (or the reverse).
+type playbackObserverFanout []PlaybackActivityObserver
+
+func (f playbackObserverFanout) HandlePlaybackUpdate(userID string, update models.PlaybackProgressUpdate, percentWatched float64) {
+	for _, observer := range f {
+		go observer.HandlePlaybackUpdate(userID, update, percentWatched)
+	}
+}
+
+// addPlaybackObserver registers one more consumer alongside whatever is already
+// registered, so registration order does not matter. That is what lets main wire
+// the p2p integration onto playback activity even though it is built after the
+// video handler that owns the HLS manager.
+//
+// The append copies rather than extends in place: a fanout that is already
+// registered may be mid-dispatch on another goroutine.
+func addPlaybackObserver(registered, observer PlaybackActivityObserver) PlaybackActivityObserver {
+	if observer == nil {
+		return registered
+	}
+	switch current := registered.(type) {
+	case nil:
+		return observer
+	case playbackObserverFanout:
+		return append(current[:len(current):len(current)], observer)
+	default:
+		return playbackObserverFanout{current, observer}
+	}
+}

--- a/backend/handlers/prequeue.go
+++ b/backend/handlers/prequeue.go
@@ -602,6 +602,9 @@ type VideoFullResult struct {
 	VideoCodec   string // e.g., "h264", "hevc", "mpeg4" - used to detect incompatible codecs
 	VideoPixFmt  string // e.g., "yuv420p", "yuv420p10le" - used for browser compatibility
 	VideoProfile string // e.g., "High", "High 10" - used for browser compatibility
+	VideoWidth   int    // Primary video stream width in pixels
+	VideoHeight  int    // Primary video stream height in pixels
+	VideoLevel   int    // H.264 level as reported by ffprobe (for example, 41)
 	AvgFrameRate string // e.g., "24000/1001" from primary video stream
 	// Audio codec detection
 	HasTrueHD          bool // Audio requires transcoding (TrueHD, DTS-HD, etc.)
@@ -624,6 +627,22 @@ func validatePrequeueVideoProbe(result *VideoFullResult) error {
 	}
 	if strings.TrimSpace(result.VideoCodec) == "" {
 		return fmt.Errorf("metadata probe found no playable video track")
+	}
+	return nil
+}
+
+func validatePrequeueEpisodeDuration(mediaType string, episode *models.EpisodeReference, durationSeconds float64) error {
+	if mediaType != "series" || episode == nil || episode.RuntimeMinutes <= 0 || durationSeconds <= 0 {
+		return nil
+	}
+	expectedSeconds := float64(episode.RuntimeMinutes * 60)
+	maximumSeconds := expectedSeconds * 3
+	if durationSeconds > maximumSeconds {
+		return fmt.Errorf(
+			"probed duration %.2fs exceeds 3x the expected %dm episode runtime",
+			durationSeconds,
+			episode.RuntimeMinutes,
+		)
 	}
 	return nil
 }
@@ -1789,6 +1808,27 @@ func (h *PrequeueHandler) runPrequeueWorker(prequeueID, titleID, titleName, imdb
 						Reason:      "prequeue:metadata-probe-unplayable",
 					}); markErr != nil {
 						log.Printf("[prequeue] Failed to mark unplayable probe result bad for %s: %v", result.Title, markErr)
+					}
+				}
+				resolution = nil
+				lastErr = probeErr
+				continue
+			}
+			if probeErr = validatePrequeueEpisodeDuration(mediaType, targetEpisode, probeResult.Duration); probeErr != nil {
+				log.Printf("[prequeue] Episode duration mismatch for %s: %v, trying next result", result.Title, probeErr)
+				if h.badStreamsSvc != nil {
+					provider := result.Attributes["provider"]
+					if provider == "" {
+						provider = result.Attributes["debridProvider"]
+					}
+					if _, markErr := h.badStreamsSvc.Mark(badstreams.MarkRequest{
+						ReleaseName: result.Title,
+						ServiceType: string(result.ServiceType),
+						Provider:    provider,
+						SourcePath:  resolution.WebDAVPath,
+						Reason:      "prequeue:episode-duration-mismatch",
+					}); markErr != nil {
+						log.Printf("[prequeue] Failed to mark duration-mismatched result bad for %s: %v", result.Title, markErr)
 					}
 				}
 				resolution = nil

--- a/backend/handlers/stream_tracker.go
+++ b/backend/handlers/stream_tracker.go
@@ -241,12 +241,14 @@ func GetStreamTracker() *StreamTracker {
 	return globalStreamTracker
 }
 
-func (t *StreamTracker) SetPlaybackActivityObserver(observer PlaybackActivityObserver) {
+// AddPlaybackActivityObserver registers one more consumer of matched playback
+// activity. See playbackObserverFanout for why there is more than one.
+func (t *StreamTracker) AddPlaybackActivityObserver(observer PlaybackActivityObserver) {
 	if t == nil {
 		return
 	}
 	t.mu.Lock()
-	t.playbackObserver = observer
+	t.playbackObserver = addPlaybackObserver(t.playbackObserver, observer)
 	t.mu.Unlock()
 }
 
@@ -346,6 +348,12 @@ func (t *StreamTracker) ObservePlaybackActivity(userID string, update models.Pla
 		// single playback. Key notifications like the consolidated Active
 		// Streams row, not by an individual transport connection.
 		update.PlaybackSessionID = "direct:" + trackedStreamSlotKey(best)
+		// A player that reported no source path still has one: the request this
+		// heartbeat was matched to names it. Consumers that must reach the source
+		// again, rather than merely name it, depend on that.
+		if strings.TrimSpace(update.SourcePath) == "" {
+			update.SourcePath = best.Path
+		}
 		update = enrichPlaybackUpdateFromStream(update, best.MediaMetadata)
 	}
 	t.mu.RUnlock()

--- a/backend/handlers/video.go
+++ b/backend/handlers/video.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
+	"novastream/services/castcaps"
 	"os"
 	"os/exec"
 	"path"
@@ -120,6 +121,10 @@ type VideoHandler struct {
 	prewarmSvc    PrewarmService
 	libraryAccess *libraryaccess.Service
 
+	// castCaps answers "what can this receiver actually decode" from cache.
+	// Never probes on this path: a cast start must not wait on a device.
+	castCaps *castcaps.Store
+
 	// External playback URLs commonly redirect through an addon before reaching
 	// the debrid CDN. Keep one hardened client alive for connection reuse and
 	// remember short-lived final redirects so FFmpeg range requests do not pay
@@ -173,6 +178,12 @@ type VideoHandler struct {
 	// User/account services for stream limit enforcement
 	usersSvc    UsersProvider
 	accountsSvc AccountsProvider
+
+	// Hardware encode capabilities for the legacy DLNA MPEG-TS output. The HLS
+	// manager owns the cached detection, so these are only used when transmux is
+	// disabled globally (no manager exists) and a DLNA renderer forces the path.
+	dlnaCapsOnce sync.Once
+	dlnaCaps     HWAccelCaps
 }
 
 const (
@@ -351,10 +362,87 @@ type rangeBlockCache struct {
 	mu     sync.Mutex
 	blocks map[string][]rangeCacheBlock // keyed by file path
 
+	// Total instance length per path, learned from upstream Content-Range or a
+	// HEAD Content-Length. DLNA renderers refuse to seek (and LG webOS aborts
+	// playback outright) when a 206 reports "/*" instead of the real size, so
+	// every partial response must be able to name the full file length.
+	totalMu sync.RWMutex
+	totals  map[string]int64
+
 	// In-flight fetch coalescing: when multiple requests land in the same
 	// fetch window, only one CDN request is made; others wait on the channel.
 	flightMu sync.Mutex
 	inFlight map[string]chan struct{} // key: "path:fetchStart"
+}
+
+// setTotal records the full file length for a path. First writer wins; the
+// value is immutable for a given file so later callers cannot regress it.
+func (c *rangeBlockCache) setTotal(path string, total int64) {
+	if total <= 0 {
+		return
+	}
+	c.totalMu.Lock()
+	defer c.totalMu.Unlock()
+	if c.totals == nil {
+		c.totals = make(map[string]int64)
+	}
+	if _, ok := c.totals[path]; !ok {
+		c.totals[path] = total
+	}
+}
+
+// total returns the known full file length, or 0 when it has not been learned.
+func (c *rangeBlockCache) total(path string) int64 {
+	c.totalMu.RLock()
+	defer c.totalMu.RUnlock()
+	return c.totals[path]
+}
+
+// contentRangeValue formats a Content-Range for a partial response, naming the
+// real instance length when known and falling back to "*" only when it is not.
+func (c *rangeBlockCache) contentRangeValue(path string, start, end int64) string {
+	if total := c.total(path); total > 0 {
+		return fmt.Sprintf("bytes %d-%d/%d", start, end, total)
+	}
+	return fmt.Sprintf("bytes %d-%d/*", start, end)
+}
+
+// parseContentRangeTotal extracts the instance length from an upstream
+// "bytes START-END/TOTAL" header. Returns 0 when the total is absent or "*".
+func parseContentRangeTotal(value string) int64 {
+	slash := strings.LastIndexByte(value, '/')
+	if slash < 0 {
+		return 0
+	}
+	total, err := strconv.ParseInt(strings.TrimSpace(value[slash+1:]), 10, 64)
+	if err != nil || total <= 0 {
+		return 0
+	}
+	return total
+}
+
+// parseContentRangeStart reports the first byte offset an upstream actually
+// served, from a "bytes START-END/TOTAL" header. The spool must confirm this
+// matches the window it asked for: caching a body that starts somewhere else
+// files those bytes under the wrong offset and corrupts every later read.
+func parseContentRangeStart(value string) (int64, bool) {
+	spec := strings.TrimSpace(value)
+	if !strings.HasPrefix(strings.ToLower(spec), "bytes ") {
+		return 0, false
+	}
+	spec = strings.TrimSpace(spec[len("bytes "):])
+	if slash := strings.IndexByte(spec, '/'); slash >= 0 {
+		spec = spec[:slash]
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 {
+		return 0, false
+	}
+	start, err := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
+	if err != nil || start < 0 {
+		return 0, false
+	}
+	return start, true
 }
 
 func (c *rangeBlockCache) get(path string, start, end int64) ([]byte, bool) {
@@ -947,6 +1035,7 @@ func (h *VideoHandler) StreamVideo(w http.ResponseWriter, r *http.Request) {
 	// Determine whether transmuxing is desired and possible
 	ext := detectContainerExt(cleanPath)
 	target := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("target")))
+	outputContainer := dlnaStreamProfileFromRequest(r).container()
 	shouldTransmux, overrideTransmux, transmuxReason := h.shouldTransmux(r, cleanPath, ext)
 	if transmuxReason != "" {
 	}
@@ -985,7 +1074,7 @@ func (h *VideoHandler) StreamVideo(w http.ResponseWriter, r *http.Request) {
 			r.Header.Del("Range")
 		}
 
-		handled, err := h.streamWithTransmuxProvider(w, r, cleanPath, forceAAC, overrideTransmux)
+		handled, err := h.streamWithTransmuxProvider(w, r, cleanPath, forceAAC, overrideTransmux, outputContainer)
 		if handled {
 			if err != nil {
 				log.Printf("[video] provider transmux error for %q: %v", cleanPath, err)
@@ -1043,11 +1132,10 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 				if cached, hit := h.rangeCache.get(cleanPath, rangeStart, rangeEnd+1); hit {
 					videoTracef("[video] range cache HIT: path=%q range=%q (%d bytes)", cleanPath, rangeHeader, rangeLen)
 					h.writeCommonHeaders(w)
-					w.Header().Set("Content-Type", "video/mp4")
-					w.Header().Set("Accept-Ranges", "bytes")
+					normalizeMediaContentType(w, "", cleanPath)
+					writeDlnaHeaders(w, r)
 					w.Header().Set("Content-Length", strconv.FormatInt(int64(len(cached)), 10))
-					// We don't know total file size from cache alone, but the client already knows it
-					// from previous requests. Omit Content-Range for cache hits of tiny requests.
+					w.Header().Set("Content-Range", h.rangeCache.contentRangeValue(cleanPath, rangeStart, rangeStart+int64(len(cached))-1))
 					w.WriteHeader(http.StatusPartialContent)
 					w.Write(cached)
 					return true, nil
@@ -1076,9 +1164,10 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 					if cached, hit := h.rangeCache.get(cleanPath, rangeStart, rangeEnd+1); hit {
 						videoTracef("[video] range cache HIT (after coalesce): path=%q range=%q (%d bytes)", cleanPath, rangeHeader, rangeLen)
 						h.writeCommonHeaders(w)
-						w.Header().Set("Content-Type", "video/mp4")
-						w.Header().Set("Accept-Ranges", "bytes")
+						normalizeMediaContentType(w, "", cleanPath)
+						writeDlnaHeaders(w, r)
 						w.Header().Set("Content-Length", strconv.FormatInt(int64(len(cached)), 10))
+						w.Header().Set("Content-Range", h.rangeCache.contentRangeValue(cleanPath, rangeStart, rangeStart+int64(len(cached))-1))
 						w.WriteHeader(http.StatusPartialContent)
 						w.Write(cached)
 						return true, nil
@@ -1094,11 +1183,29 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 						Method:      r.Method,
 					})
 					if fetchErr == nil {
+						// The upstream 206 names the real file length; record it so
+						// every spool response can report a true instance length.
+						h.rangeCache.setTotal(cleanPath, parseContentRangeTotal(fetchResp.Headers.Get("Content-Range")))
+
+						// Only cache a body the upstream actually served at the window
+						// we asked for. Debrid CDNs sometimes ignore Range and answer
+						// 200 from byte 0; filing those bytes under fetchStart poisons
+						// the block and every later read of it returns data from the
+						// wrong offset. The parallel fetcher already rejects non-206
+						// for the same reason — this path has to agree.
+						servedStart, haveStart := parseContentRangeStart(fetchResp.Headers.Get("Content-Range"))
+						honoured := fetchResp.Status == http.StatusPartialContent && haveStart && servedStart == fetchStart
+
 						fetchBuf := make([]byte, rangeCacheMinFetchSize+4096)
 						n, _ := io.ReadFull(fetchResp.Body, fetchBuf)
 						fetchResp.Close()
 						fetchCancel()
 						h.rangeCache.finishFetch(cleanPath, fetchStart)
+						if !honoured {
+							log.Printf("[video] range cache SKIP: upstream ignored window path=%q want=%d status=%d got=%q — falling back to direct stream",
+								cleanPath, fetchStart, fetchResp.Status, fetchResp.Headers.Get("Content-Range"))
+							n = 0
+						}
 						if n > 0 {
 							fetchBuf = fetchBuf[:n]
 							h.rangeCache.put(cleanPath, fetchStart, fetchBuf)
@@ -1109,9 +1216,10 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 							reqEnd := reqOffset + rangeLen
 							if reqEnd <= int64(n) {
 								h.writeCommonHeaders(w)
-								w.Header().Set("Content-Type", "video/mp4")
-								w.Header().Set("Accept-Ranges", "bytes")
+								normalizeMediaContentType(w, "", cleanPath)
+								writeDlnaHeaders(w, r)
 								w.Header().Set("Content-Length", strconv.FormatInt(rangeLen, 10))
+								w.Header().Set("Content-Range", h.rangeCache.contentRangeValue(cleanPath, reqOffset+fetchStart, reqOffset+fetchStart+rangeLen-1))
 								w.WriteHeader(http.StatusPartialContent)
 								w.Write(fetchBuf[reqOffset:reqEnd])
 								return true, nil
@@ -1194,6 +1302,12 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 	contentRange := resp.Headers.Get("Content-Range")
 	contentLength := resp.Headers.Get("Content-Length")
 	acceptRanges := resp.Headers.Get("Accept-Ranges")
+	if total := parseContentRangeTotal(contentRange); total > 0 {
+		h.rangeCache.setTotal(cleanPath, total)
+	} else if resp.Status == http.StatusOK && resp.ContentLength > 0 {
+		// A full-body 200 (including the HEAD probe) names the whole file.
+		h.rangeCache.setTotal(cleanPath, resp.ContentLength)
+	}
 	expectedLength := resp.ContentLength
 	if expectedLength <= 0 && contentLength != "" {
 		if parsed, parseErr := strconv.ParseInt(contentLength, 10, 64); parseErr == nil && parsed >= 0 {
@@ -1250,7 +1364,11 @@ func (h *VideoHandler) streamViaProvider(w http.ResponseWriter, r *http.Request,
 		}
 		videoTracef("[video] setting filename headers: %s", filename)
 	}
+	if expectedLength > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(expectedLength, 10))
+	}
 	normalizeMediaContentType(w, filename, cleanPath)
+	writeDlnaHeaders(w, r)
 
 	status := resp.Status
 	if status == 0 {
@@ -1489,12 +1607,78 @@ func isClientGone(err error) bool {
 	return false
 }
 
+// transmuxContainer selects the muxer used for a transmuxed response. The zero
+// value is the fragmented MP4 output every current caller expects.
+type transmuxContainer int
+
+const (
+	// outputFmp4 is the fragmented MP4 stream consumed by the apps and browsers.
+	outputFmp4 transmuxContainer = iota
+	// outputMpegTs is a 188-byte MPEG-TS stream for legacy DLNA renderers that
+	// accept neither Matroska, MP4 nor HLS. Declaring it as video/mpeg (rather
+	// than video/vnd.dlna.mpeg-tts, which implies 192-byte timestamped packets)
+	// is what pre-2012 renderers actually play.
+	outputMpegTs
+)
+
+func (c transmuxContainer) contentType() string {
+	if c == outputMpegTs {
+		return "video/mpeg"
+	}
+	return "video/mp4"
+}
+
+// dlnaStreamProfile is the ?dlnaProfile= request value. It names a renderer
+// family rather than a codec so the server owns the exact ffmpeg recipe.
+type dlnaStreamProfile string
+
+const (
+	// dlnaProfileNone leaves streaming behaviour untouched.
+	dlnaProfileNone dlnaStreamProfile = ""
+	// dlnaProfileAVCTS is H.264 + AC3 in MPEG-TS (DLNA AVC_TS_HD_24_AC3_ISO).
+	dlnaProfileAVCTS dlnaStreamProfile = "avc-ts"
+)
+
+// parseDLNAStreamProfile accepts the known profile names case-insensitively and
+// maps anything else to dlnaProfileNone, so an unknown value never changes the
+// behaviour a normal client sees.
+func parseDLNAStreamProfile(raw string) dlnaStreamProfile {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(dlnaProfileAVCTS):
+		return dlnaProfileAVCTS
+	default:
+		return dlnaProfileNone
+	}
+}
+
+func dlnaStreamProfileFromRequest(r *http.Request) dlnaStreamProfile {
+	if r == nil || r.URL == nil {
+		return dlnaProfileNone
+	}
+	return parseDLNAStreamProfile(r.URL.Query().Get("dlnaProfile"))
+}
+
+func (p dlnaStreamProfile) container() transmuxContainer {
+	if p == dlnaProfileAVCTS {
+		return outputMpegTs
+	}
+	return outputFmp4
+}
+
 func (h *VideoHandler) shouldTransmux(r *http.Request, cleanPath, ext string) (bool, bool, string) {
 	query := r.URL.Query()
 	format := strings.ToLower(strings.TrimSpace(query.Get("format")))
 	target := strings.ToLower(strings.TrimSpace(query.Get("target")))
 	manualFlag := strings.ToLower(strings.TrimSpace(query.Get("transmux")))
 	dvFlag := strings.ToLower(strings.TrimSpace(query.Get("dv"))) == "true"
+
+	// A legacy DLNA renderer needs a full H.264/AC3 MPEG-TS transcode whatever
+	// the source container is, so the profile overrides every other heuristic —
+	// including Dolby Vision, which these SDR panels cannot display.
+	if parseDLNAStreamProfile(query.Get("dlnaProfile")) == dlnaProfileAVCTS {
+		log.Printf("[video] DLNA avc-ts transcode requested for path=%q", cleanPath)
+		return true, true, "dlna avc-ts profile"
+	}
 
 	// Check for Dolby Vision flag - MUST transmux to preserve DV metadata
 	if dvFlag {
@@ -1642,7 +1826,7 @@ func detectContainerExt(name string) string {
 	return strings.ToLower(strings.TrimSpace(path.Ext(lower)))
 }
 
-func (h *VideoHandler) streamWithTransmuxProvider(w http.ResponseWriter, r *http.Request, cleanPath string, forceAAC bool, override bool) (bool, error) {
+func (h *VideoHandler) streamWithTransmuxProvider(w http.ResponseWriter, r *http.Request, cleanPath string, forceAAC bool, override bool, container transmuxContainer) (bool, error) {
 	if !h.transmux && !override {
 		return false, errors.New("transmux disabled")
 	}
@@ -1661,8 +1845,14 @@ func (h *VideoHandler) streamWithTransmuxProvider(w http.ResponseWriter, r *http
 
 	if r.Method == http.MethodHead {
 		h.writeCommonHeaders(w)
-		w.Header().Set("Content-Type", "video/mp4")
+		w.Header().Set("Content-Type", container.contentType())
 		w.Header().Set("Accept-Ranges", "none")
+		if container == outputMpegTs {
+			// DLNA renderers abort when the server never confirms the transfer
+			// mode they asked for. Accept-Ranges stays "none": the transcode is
+			// progressive and cannot answer a byte-seek.
+			writeDlnaMpegTsHeaders(w, r)
+		}
 
 		if h.ffprobePath != "" {
 			if meta, err := h.runFFProbeFromProvider(ctx, cleanPath); err == nil && meta != nil {
@@ -1702,7 +1892,13 @@ func (h *VideoHandler) streamWithTransmuxProvider(w http.ResponseWriter, r *http
 		}
 	}
 
-	plan := h.buildTransmuxPlan(meta, "pipe:0", forceAAC, fallbackReason)
+	var plan transmuxPlan
+	if container == outputMpegTs {
+		plan = h.buildMpegTsPlan(meta, "pipe:0", fallbackReason)
+		log.Printf("[video] DLNA avc-ts output path=%q duration=%.3f ffmpeg=%s", cleanPath, plan.duration, strings.Join(plan.args, " "))
+	} else {
+		plan = h.buildTransmuxPlan(meta, "pipe:0", forceAAC, fallbackReason)
+	}
 
 	resp, err := h.streamer.Stream(ctx, streaming.Request{Path: cleanPath, Method: http.MethodGet})
 	if err != nil {
@@ -1747,12 +1943,32 @@ func (h *VideoHandler) streamWithTransmuxProvider(w http.ResponseWriter, r *http
 	}
 
 	go func() {
-		_, _ = io.Copy(io.Discard, stderr)
+		if plan.container != outputMpegTs {
+			_, _ = io.Copy(io.Discard, stderr)
+			return
+		}
+		// The DLNA arm is the only one that re-encodes video, so surface encoder
+		// failures instead of silently serving a stream the renderer drops.
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := stderr.Read(buf)
+			if n > 0 {
+				if msg := strings.TrimSpace(string(buf[:n])); msg != "" {
+					log.Printf("[video] DLNA avc-ts ffmpeg: %s", msg)
+				}
+			}
+			if readErr != nil {
+				return
+			}
+		}
 	}()
 
 	h.writeCommonHeaders(w)
-	w.Header().Set("Content-Type", "video/mp4")
+	w.Header().Set("Content-Type", plan.container.contentType())
 	w.Header().Set("Accept-Ranges", "none")
+	if plan.container == outputMpegTs {
+		writeDlnaMpegTsHeaders(w, r)
+	}
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Transfer-Encoding", "chunked")
 	if plan.duration > 0 {
@@ -2377,9 +2593,12 @@ func (h *VideoHandler) ProbeVideo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// buildTransmuxPlan produces the default fragmented MP4 plan: video is stream
+// copied and only incompatible audio is re-encoded.
 func (h *VideoHandler) buildTransmuxPlan(meta *ffprobeOutput, inputSpecifier string, forceAAC bool, fallbackReason string) transmuxPlan {
 	plan := transmuxPlan{
-		videoMap: "0:v:0",
+		container: outputFmp4,
+		videoMap:  "0:v:0",
 		audio: audioPlan{
 			mode:   audioPlanFallback,
 			reason: fallbackReason,
@@ -2692,6 +2911,202 @@ func appendStreamingOutputArgs(args []string, movflags string) []string {
 		"pipe:1",
 	)
 	return args
+}
+
+const (
+	// dlnaMaxWidth and dlnaMaxHeight bound the H.264 output for legacy DLNA
+	// renderers. Their AVC level 4.0 decoders top out at the 1080p box, and a
+	// height-only cap would hand an ultra-wide source a 2578-pixel-wide frame.
+	dlnaMaxWidth  = 1920
+	dlnaMaxHeight = 1080
+	// dlnaMaxAudioChannels is the AC3 encoder's ceiling (5.1).
+	dlnaMaxAudioChannels = 6
+	// dlnaAC3Bitrate is comfortably inside AC3's 640 kbps limit at 5.1.
+	dlnaAC3Bitrate = "448k"
+)
+
+// mpegTsEncodeInput is the probe-derived shape of one legacy DLNA transcode.
+// Zero values are the "probe unavailable" case and stay safe: the scaler is
+// applied (it never upscales) and the audio is downmixed.
+type mpegTsEncodeInput struct {
+	inputURL string
+	videoMap string
+	// audioMap is empty when the source has no audio stream to carry.
+	audioMap       string
+	sourceWidth    int
+	sourceHeight   int
+	audioChannels  int
+	hdr            bool
+	sourceTransfer string
+}
+
+// buildMpegTsArgs assembles the complete ffmpeg invocation for the legacy DLNA
+// output: H.264 + AC3 in a 188-byte transport stream. Nothing is stream copied —
+// these renderers accept exactly one video and one audio codec — so the encoder
+// selection, HDR tone mapping and downscale all come from the same hardware
+// plan the HLS web path uses.
+func buildMpegTsArgs(in mpegTsEncodeInput, caps HWAccelCaps) []string {
+	maxWidth, maxHeight := dlnaMaxWidth, dlnaMaxHeight
+	if in.sourceWidth > 0 && in.sourceHeight > 0 &&
+		in.sourceWidth <= dlnaMaxWidth && in.sourceHeight <= dlnaMaxHeight {
+		// Already inside the renderer's decode box, so drop the scaler entirely
+		// rather than round-tripping a 720p source through it.
+		maxWidth, maxHeight = 0, 0
+	}
+
+	encode := buildVideoEncodePlanWithLimits(caps, in.hdr, maxWidth, maxHeight, 0, in.sourceTransfer)
+	if in.hdr && !encode.Tonemapped {
+		warnMissingTonemapOnce()
+	}
+
+	args := make([]string, 0, 40)
+	args = append(args, "-nostdin", "-loglevel", "error")
+	// Hardware device initialization has to precede -i.
+	args = append(args, encode.GlobalArgs...)
+	args = append(args, "-i", in.inputURL)
+
+	videoMap := strings.TrimSpace(in.videoMap)
+	if videoMap == "" {
+		videoMap = "0:v:0"
+	}
+	args = append(args, "-map", videoMap)
+	if in.audioMap != "" {
+		args = append(args, "-map", in.audioMap)
+	}
+	// MPEG-TS cannot carry the text subtitle codecs these sources ship, and a
+	// legacy demuxer gives up on elementary streams it does not recognize, so
+	// only video and audio are mapped.
+	args = append(args, "-sn", "-dn")
+
+	if encode.Filter != "" {
+		args = append(args, "-vf", encode.Filter)
+	}
+	args = append(args, encode.EncoderArgs...)
+
+	if in.audioMap == "" {
+		args = append(args, "-an")
+	} else {
+		args = append(args, "-c:a", "ac3", "-b:a", dlnaAC3Bitrate)
+		if in.audioChannels > dlnaMaxAudioChannels || in.audioChannels <= 0 {
+			// The AC3 encoder stops at 5.1: a 7.1 source (or an unknown layout,
+			// which may well be 7.1) aborts the whole stream without a downmix.
+			args = append(args, "-ac", strconv.Itoa(dlnaMaxAudioChannels))
+		}
+	}
+
+	return appendMpegTsOutputArgs(args)
+}
+
+// appendMpegTsOutputArgs closes out a 188-byte MPEG-TS pipe. This is the
+// MPEG-TS sibling of appendStreamingOutputArgs; -movflags is MP4-only and
+// FFmpeg warns or errors when it is passed to another muxer.
+func appendMpegTsOutputArgs(args []string) []string {
+	return append(args,
+		// Renderers that parse the stream late still need to find a PAT/PMT.
+		"-mpegts_flags", "+resend_headers",
+		"-muxdelay", "0",
+		"-muxpreload", "0",
+		"-f", "mpegts",
+		"pipe:1",
+	)
+}
+
+var missingTonemapWarning sync.Once
+
+// warnMissingTonemapOnce reports the absence of a tone-map filter once per
+// process. A washed-out picture beats a refused stream, so the transcode goes
+// ahead without tone mapping.
+func warnMissingTonemapOnce() {
+	missingTonemapWarning.Do(func() {
+		log.Printf("[video] no tone-map filter available in this FFmpeg build; HDR sources stream to SDR renderers untone-mapped")
+	})
+}
+
+// sourceNeedsToneMapping reports whether a video stream carries HDR signalling
+// an SDR renderer cannot interpret, along with the source transfer function so
+// HLG is tone mapped from the right curve. detectDolbyVision already covers DV
+// RPUs plus PQ/HLG on HEVC; the raw transfer check catches HDR10 carried by
+// other codecs.
+func sourceNeedsToneMapping(stream *ffprobeStream) (bool, string) {
+	if stream == nil {
+		return false, ""
+	}
+	transfer := strings.ToLower(strings.TrimSpace(stream.ColorTransfer))
+	if hasDV, _, hdrFormat := detectDolbyVision(stream); hasDV || hdrFormat != "" {
+		return true, transfer
+	}
+	return transfer == "smpte2084" || transfer == "arib-std-b67", transfer
+}
+
+// dlnaEncodeCaps returns the hardware encode capabilities for the DLNA MPEG-TS
+// transcode. The HLS manager already caches detection and honours the configured
+// preference, so reuse it; when transmux is disabled globally no manager exists,
+// so detect once and remember it.
+func (h *VideoHandler) dlnaEncodeCaps() HWAccelCaps {
+	if h.hlsManager != nil {
+		return h.hlsManager.hwAccelCaps()
+	}
+	h.dlnaCapsOnce.Do(func() {
+		h.dlnaCaps = detectHWAccel(h.ffmpegPath, currentHWAccelPreference(h.configManager))
+	})
+	return h.dlnaCaps
+}
+
+// buildMpegTsPlan produces the H.264/AC3 MPEG-TS transcode plan for legacy DLNA
+// renderers.
+func (h *VideoHandler) buildMpegTsPlan(meta *ffprobeOutput, inputSpecifier, fallbackReason string) transmuxPlan {
+	plan := transmuxPlan{
+		container: outputMpegTs,
+		videoMap:  "0:v:0",
+		audio: audioPlan{
+			mode:   audioPlanTranscode,
+			reason: "dlna avc-ts renderers require ac3 audio",
+		},
+	}
+	in := mpegTsEncodeInput{
+		inputURL: inputSpecifier,
+		videoMap: plan.videoMap,
+		// The "?" keeps ffmpeg from failing outright on a video-only source.
+		audioMap: "0:a:0?",
+	}
+
+	if meta == nil {
+		if reason := strings.TrimSpace(fallbackReason); reason != "" {
+			plan.audio.reason = reason
+		}
+		plan.args = buildMpegTsArgs(in, h.dlnaEncodeCaps())
+		return plan
+	}
+
+	plan.usedProbe = true
+	plan.duration = parseFloat(meta.Format.Duration)
+
+	if stream := selectPrimaryVideoStream(meta); stream != nil {
+		plan.videoMap = fmt.Sprintf("0:%d", stream.Index)
+		plan.videoCodec = strings.ToLower(strings.TrimSpace(stream.CodecName))
+		hasDV, dvProfile, _ := detectDolbyVision(stream)
+		plan.hasDolbyVision = hasDV
+		plan.dolbyVisionProfile = dvProfile
+		in.videoMap = plan.videoMap
+		in.sourceWidth = stream.Width
+		in.sourceHeight = stream.Height
+		in.hdr, in.sourceTransfer = sourceNeedsToneMapping(stream)
+	}
+
+	// Reuse the shared track selection so the renderer hears the same audio the
+	// app would have picked, then re-encode whatever it lands on to AC3.
+	if audio := determineAudioPlan(meta, false); audio.stream != nil {
+		plan.audio.stream = audio.stream
+		plan.audio.reason = fmt.Sprintf("transcoding audio codec %s to ac3 for dlna renderer", audio.codec())
+		in.audioMap = fmt.Sprintf("0:%d", audio.stream.Index)
+		in.audioChannels = audio.stream.Channels
+	} else {
+		plan.audio = audioPlan{mode: audioPlanNone, reason: "no audio streams detected"}
+		in.audioMap = ""
+	}
+
+	plan.args = buildMpegTsArgs(in, h.dlnaEncodeCaps())
+	return plan
 }
 
 func shouldTagHevcAsHvc1(codec string) bool {
@@ -3098,7 +3513,10 @@ func (p audioPlan) codec() string {
 }
 
 type transmuxPlan struct {
-	args               []string
+	args []string
+	// container is the muxer the args write to and the Content-Type the response
+	// must advertise. Zero value is the fragmented MP4 output.
+	container          transmuxContainer
 	audio              audioPlan
 	videoMap           string
 	videoCodec         string
@@ -3130,6 +3548,7 @@ type ffprobeStream struct {
 	Height         int               `json:"height"`
 	PixFmt         string            `json:"pix_fmt"`
 	Profile        string            `json:"profile"`
+	Level          int               `json:"level"`
 	AvgFrameRate   string            `json:"avg_frame_rate"`
 	ColorSpace     string            `json:"color_space"`
 	ColorTransfer  string            `json:"color_transfer"`
@@ -3309,6 +3728,54 @@ func (h *VideoHandler) writeCommonHeaders(w http.ResponseWriter) {
 	w.Header().Set("Expires", "0")
 }
 
+// dlnaContentFeatures advertises byte-seek support (OP=01), no transcode
+// (CI=0), and the standard streaming flag set: streaming transfer mode,
+// background transfer, connection stalling, DLNA v1.5.
+const dlnaContentFeatures = "DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000"
+
+// writeDlnaHeaders satisfies the DLNA HTTP serving requirements that strict
+// renderers enforce. LG webOS negotiates a stream, then aborts with "file
+// cannot be recognized" when the server never echoes transferMode.dlna.org or
+// confirms contentFeatures.dlna.org, regardless of codec or container. The
+// DIDL-Lite we send already advertises DLNA.ORG_OP=01, so the HTTP responses
+// have to agree or the renderer treats the resource as inconsistent.
+func writeDlnaHeaders(w http.ResponseWriter, r *http.Request) {
+	mode := strings.TrimSpace(r.Header.Get("transferMode.dlna.org"))
+	if mode == "" {
+		mode = "Streaming"
+	}
+	// Assign the header map directly: Set would canonicalize these to
+	// "Transfermode.dlna.org", and DLNA renderers match the spec casing.
+	w.Header()["transferMode.dlna.org"] = []string{mode}
+	w.Header()["contentFeatures.dlna.org"] = []string{dlnaContentFeatures}
+	w.Header().Set("Accept-Ranges", "bytes")
+}
+
+// dlnaMpegTsContentFeatures describes the progressive transport stream. OP=00
+// because a live transcode cannot byte-seek, which is consistent with the
+// Accept-Ranges: none this arm sends; CI=1 because the stream is transcoded.
+const dlnaMpegTsContentFeatures = "DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO;DLNA.ORG_OP=00;DLNA.ORG_CI=1;DLNA.ORG_FLAGS=01700000000000000000000000000000"
+
+// writeDlnaMpegTsHeaders describes the progressive MPEG-TS transcode to a
+// renderer. It cannot reuse writeDlnaHeaders, which advertises byte seeking this
+// arm does not support. Omitting contentFeatures entirely is not an option: a
+// DLNA 1.0 renderer that asked for it and receives nothing cannot confirm the
+// profile and rejects SetAVTransportURI with UPnP 714 "Illegal MIME-type"
+// (observed on a Sony BRAVIA KDL-46NX700).
+func writeDlnaMpegTsHeaders(w http.ResponseWriter, r *http.Request) {
+	if r == nil {
+		return
+	}
+	mode := strings.TrimSpace(r.Header.Get("transferMode.dlna.org"))
+	if mode == "" {
+		mode = "Streaming"
+	}
+	// Assign the header map directly: Set would canonicalize the keys to
+	// "Transfermode.dlna.org", and DLNA renderers match the spec casing.
+	w.Header()["transferMode.dlna.org"] = []string{mode}
+	w.Header()["contentFeatures.dlna.org"] = []string{dlnaMpegTsContentFeatures}
+}
+
 func sanitizeExternalDisplayName(input string) string {
 	name := strings.TrimSpace(input)
 	if name == "" {
@@ -3467,6 +3934,18 @@ func (h *VideoHandler) StartHLSSession(w http.ResponseWriter, r *http.Request) {
 	forceAAC := r.URL.Query().Get("forceAAC") == "true"
 	castMode := r.URL.Query().Get("cast") == "true"
 	playbackTarget := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("target")))
+	castProfile := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("castProfile")))
+	if castMode && isDirectCastTarget(playbackTarget, castProfile) {
+		playbackTarget = "cast-direct"
+	}
+
+	var castReceiverHost string
+	if castMode {
+		if ip := net.ParseIP(strings.TrimSpace(r.URL.Query().Get("castDeviceIp"))); ip != nil {
+			castReceiverHost = ip.String()
+		}
+	}
+
 	durationHint := 0.0
 	if durationParam := strings.TrimSpace(r.URL.Query().Get("durationHint")); durationParam != "" {
 		if parsed, err := strconv.ParseFloat(durationParam, 64); err == nil {
@@ -3583,7 +4062,7 @@ func (h *VideoHandler) StartHLSSession(w http.ResponseWriter, r *http.Request) {
 	videoTracef("[video] creating HLS session for path=%q dv=%v dvProfile=%q hdr=%v start=%.3fs transcodingOffset=%.3fs audioTrack=%d subtitleTrack=%d",
 		cleanPath, hasDV, dvProfile, hasHDR, startSeconds, transcodingOffset, audioTrackIndex, subtitleTrackIndex)
 
-	session, err := h.hlsManager.CreateSession(r.Context(), cleanPath, path, hasDV, dvProfile, hasHDR, forceAAC, startSeconds, transcodingOffset, audioTrackIndex, subtitleTrackIndex, profileID, profileName, getClientIP(r), castMode, "", playbackTarget, durationHint)
+	session, err := h.hlsManager.CreateSession(r.Context(), cleanPath, path, hasDV, dvProfile, hasHDR, forceAAC, startSeconds, transcodingOffset, audioTrackIndex, subtitleTrackIndex, profileID, profileName, getClientIP(r), castMode, "", playbackTarget, durationHint, castReceiverHost)
 	if err != nil {
 		log.Printf("[video] failed to create HLS session: %v", err)
 		if errors.Is(err, streaming.ErrStaleTorrent) {
@@ -3613,11 +4092,12 @@ func (h *VideoHandler) StartHLSSession(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	response := map[string]interface{}{
-		"sessionId":         session.ID,
-		"playlistUrl":       h.hlsManager.buildSessionPlaylistURL(session),
-		"startOffset":       session.StartOffset,
-		"actualStartOffset": actualStartOffset,
-		"keyframeDelta":     keyframeDelta,
+		"sessionId":          session.ID,
+		"playlistUrl":        h.hlsManager.buildSessionPlaylistURL(session),
+		"startOffset":        session.StartOffset,
+		"actualStartOffset":  actualStartOffset,
+		"keyframeDelta":      keyframeDelta,
+		"stableCastTimeline": session.usesStableCastTimeline() && session.Duration > 0,
 	}
 
 	// Include duration if it was successfully probed
@@ -5123,7 +5603,7 @@ func (h *VideoHandler) CreateHLSSession(ctx context.Context, path string, hasDV 
 		}
 	}
 
-	session, err := h.hlsManager.CreateSession(ctx, path, path, hasDV, dvProfile, hasHDR, false, startOffset, 0, audioTrackIndex, subtitleTrackIndex, profileID, "", "", false, prequeueType, "", 0)
+	session, err := h.hlsManager.CreateSession(ctx, path, path, hasDV, dvProfile, hasHDR, false, startOffset, 0, audioTrackIndex, subtitleTrackIndex, profileID, "", "", false, prequeueType, "", 0, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HLS session: %w", err)
 	}
@@ -5407,6 +5887,9 @@ func (h *VideoHandler) ProbeVideoFull(ctx context.Context, path string) (*VideoF
 		result.VideoCodec = strings.ToLower(strings.TrimSpace(stream.CodecName))
 		result.VideoPixFmt = strings.ToLower(strings.TrimSpace(stream.PixFmt))
 		result.VideoProfile = strings.ToLower(strings.TrimSpace(stream.Profile))
+		result.VideoWidth = stream.Width
+		result.VideoHeight = stream.Height
+		result.VideoLevel = stream.Level
 		result.AvgFrameRate = strings.TrimSpace(stream.AvgFrameRate)
 
 		// Detect Dolby Vision
@@ -5510,6 +5993,9 @@ func (h *VideoHandler) unifiedProbeToVideoFull(cached *UnifiedProbeResult) *Vide
 		VideoCodec:               cached.VideoCodec,
 		VideoPixFmt:              cached.VideoPixFmt,
 		VideoProfile:             cached.VideoProfile,
+		VideoWidth:               cached.VideoWidth,
+		VideoHeight:              cached.VideoHeight,
+		VideoLevel:               cached.VideoLevel,
 		AvgFrameRate:             cached.AvgFrameRate,
 		HasDolbyVision:           cached.HasDolbyVision,
 		HasHDR10:                 cached.HasHDR10,
@@ -5553,6 +6039,9 @@ func (h *VideoHandler) videoFullToUnifiedProbe(result *VideoFullResult) *Unified
 		VideoCodec:               result.VideoCodec,
 		VideoPixFmt:              result.VideoPixFmt,
 		VideoProfile:             result.VideoProfile,
+		VideoWidth:               result.VideoWidth,
+		VideoHeight:              result.VideoHeight,
+		VideoLevel:               result.VideoLevel,
 		AvgFrameRate:             result.AvgFrameRate,
 		HasDolbyVision:           result.HasDolbyVision,
 		HasHDR10:                 result.HasHDR10,
@@ -6156,29 +6645,29 @@ func (h *VideoHandler) requireAllowedExternalPath(w http.ResponseWriter, r *http
 
 func configuredProviderHostPolicy(configManager ConfigProvider) requestsecurity.RestrictedHostPolicy {
 	allowed := make(map[string]struct{})
-	if configManager != nil {
-		if settings, err := configManager.Load(); err == nil {
-			addURLOrigin := func(raw string) {
-				parsed, err := url.Parse(strings.TrimSpace(raw))
-				if err != nil || parsed == nil {
-					return
-				}
-				scheme := strings.ToLower(parsed.Scheme)
-				if parsed.Hostname() != "" && (scheme == "http" || scheme == "https") {
-					port := parsed.Port()
-					if port == "" {
-						switch scheme {
-						case "http":
-							port = "80"
-						case "https":
-							port = "443"
-						}
-					}
-					if port != "" {
-						allowed[privateMediaEndpointKey(parsed.Hostname(), port)] = struct{}{}
-					}
+	addURLOrigin := func(raw string) {
+		parsed, err := url.Parse(strings.TrimSpace(raw))
+		if err != nil || parsed == nil {
+			return
+		}
+		scheme := strings.ToLower(parsed.Scheme)
+		if parsed.Hostname() != "" && (scheme == "http" || scheme == "https") {
+			port := parsed.Port()
+			if port == "" {
+				switch scheme {
+				case "http":
+					port = "80"
+				case "https":
+					port = "443"
 				}
 			}
+			if port != "" {
+				allowed[privateMediaEndpointKey(parsed.Hostname(), port)] = struct{}{}
+			}
+		}
+	}
+	if configManager != nil {
+		if settings, err := configManager.Load(); err == nil {
 			for _, origin := range settings.Server.AllowedPrivateMediaOrigins {
 				addURLOrigin(origin)
 			}
@@ -6608,6 +7097,7 @@ func (h *VideoHandler) CropDetect(w http.ResponseWriter, r *http.Request) {
 		sort.Float64s(topFractions)
 		sort.Float64s(bottomFractions)
 		medianTop := topFractions[len(topFractions)/2]
+
 		medianBottom := bottomFractions[len(bottomFractions)/2]
 
 		// Asymmetry check: if top and bottom differ by more than 3%, discard both
@@ -6652,9 +7142,20 @@ func (h *VideoHandler) resolveSeekableURL(ctx context.Context, cleanPath string)
 	}
 
 	// Try WebDAV URL (usenet)
+
 	if webdavURL := h.buildWebDAVURL(cleanPath); webdavURL != "" {
 		return webdavURL, nil
 	}
 
 	return "", fmt.Errorf("no seekable URL available")
+}
+
+func (h *VideoHandler) SetCastCapabilities(store *castcaps.Store) {
+	if h == nil {
+		return
+	}
+	h.castCaps = store
+	if h.hlsManager != nil {
+		h.hlsManager.SetCastCapabilities(store)
+	}
 }

--- a/backend/handlers/video_dlna_mpegts_test.go
+++ b/backend/handlers/video_dlna_mpegts_test.go
@@ -1,0 +1,699 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseDLNAStreamProfile(t *testing.T) {
+	testCases := []struct {
+		name  string
+		raw   string
+		want  dlnaStreamProfile
+		mount transmuxContainer
+	}{
+		{name: "canonical value", raw: "avc-ts", want: dlnaProfileAVCTS, mount: outputMpegTs},
+		{name: "mixed case", raw: "AVC-TS", want: dlnaProfileAVCTS, mount: outputMpegTs},
+		{name: "surrounding space", raw: "  avc-ts\t", want: dlnaProfileAVCTS, mount: outputMpegTs},
+		{name: "absent", raw: "", want: dlnaProfileNone, mount: outputFmp4},
+		{name: "whitespace only", raw: "   ", want: dlnaProfileNone, mount: outputFmp4},
+		{name: "unknown value", raw: "avc_ts", want: dlnaProfileNone, mount: outputFmp4},
+		{name: "other profile", raw: "mpeg2-ts", want: dlnaProfileNone, mount: outputFmp4},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDLNAStreamProfile(tc.raw)
+			if got != tc.want {
+				t.Fatalf("parseDLNAStreamProfile(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+			if container := got.container(); container != tc.mount {
+				t.Fatalf("container for %q = %v, want %v", tc.raw, container, tc.mount)
+			}
+		})
+	}
+}
+
+func TestDLNAStreamProfileFromRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=a.mkv&dlnaProfile=avc-ts&token=x", nil)
+	if got := dlnaStreamProfileFromRequest(req); got != dlnaProfileAVCTS {
+		t.Fatalf("profile = %q, want %q", got, dlnaProfileAVCTS)
+	}
+
+	plain := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=a.mkv", nil)
+	if got := dlnaStreamProfileFromRequest(plain); got != dlnaProfileNone {
+		t.Fatalf("profile = %q, want none", got)
+	}
+}
+
+func TestTransmuxContainerContentType(t *testing.T) {
+	if got, want := outputMpegTs.contentType(), "video/mpeg"; got != want {
+		t.Fatalf("mpegts content type = %q, want %q", got, want)
+	}
+	// The zero value must stay fMP4 so existing callers are unaffected.
+	var zero transmuxContainer
+	if got, want := zero.contentType(), "video/mp4"; got != want {
+		t.Fatalf("default content type = %q, want %q", got, want)
+	}
+}
+
+// The DLNA profile has to force the transcode on for any source container, even
+// one that would normally be served directly or with transmux disabled.
+func TestShouldTransmuxHonoursDLNAProfile(t *testing.T) {
+	testCases := []struct {
+		name          string
+		transmux      bool
+		query         string
+		ext           string
+		want          bool
+		wantOverride  bool
+		wantReasonHas string
+	}{
+		{
+			name: "mkv with profile", transmux: true,
+			query: "dlnaProfile=avc-ts", ext: ".mkv",
+			want: true, wantOverride: true, wantReasonHas: "dlna",
+		},
+		{
+			name: "mp4 with profile", transmux: true,
+			query: "dlnaProfile=avc-ts", ext: ".mp4",
+			want: true, wantOverride: true, wantReasonHas: "dlna",
+		},
+		{
+			name: "unknown container with profile", transmux: true,
+			query: "dlnaProfile=avc-ts", ext: "",
+			want: true, wantOverride: true, wantReasonHas: "dlna",
+		},
+		{
+			name: "profile beats manual disable", transmux: true,
+			query: "dlnaProfile=avc-ts&transmux=0", ext: ".mkv",
+			want: true, wantOverride: true, wantReasonHas: "dlna",
+		},
+		{
+			name: "profile works with transmux disabled globally", transmux: false,
+			query: "dlnaProfile=avc-ts", ext: ".mkv",
+			want: true, wantOverride: true, wantReasonHas: "dlna",
+		},
+		{
+			name: "unknown profile leaves mp4 direct", transmux: true,
+			query: "dlnaProfile=bogus", ext: ".mp4",
+			want: false, wantOverride: false, wantReasonHas: "already mp4",
+		},
+		{
+			name: "no profile leaves mp4 direct", transmux: true,
+			query: "", ext: ".mp4",
+			want: false, wantOverride: false, wantReasonHas: "already mp4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &VideoHandler{transmux: tc.transmux}
+			req := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=movie"+tc.ext+"&"+tc.query, nil)
+
+			should, override, reason := h.shouldTransmux(req, "movie"+tc.ext, tc.ext)
+			if should != tc.want {
+				t.Fatalf("shouldTransmux = %t, want %t (reason %q)", should, tc.want, reason)
+			}
+			if override != tc.wantOverride {
+				t.Fatalf("override = %t, want %t (reason %q)", override, tc.wantOverride, reason)
+			}
+			if !strings.Contains(reason, tc.wantReasonHas) {
+				t.Fatalf("reason = %q, want it to contain %q", reason, tc.wantReasonHas)
+			}
+		})
+	}
+}
+
+func TestBuildMpegTsArgsEmitsTransportStreamOutput(t *testing.T) {
+	args := buildMpegTsArgs(mpegTsEncodeInput{
+		inputURL:      "pipe:0",
+		videoMap:      "0:0",
+		audioMap:      "0:1",
+		sourceWidth:   1920,
+		sourceHeight:  1080,
+		audioChannels: 6,
+	}, HWAccelCaps{Encode: HWNone})
+
+	joined := strings.Join(args, " ")
+
+	// The 188-byte MPEG-TS pipe is the whole point of this arm.
+	if !strings.HasSuffix(joined, "-f mpegts pipe:1") {
+		t.Fatalf("args must end with the mpegts pipe output, got %q", joined)
+	}
+	if !strings.Contains(joined, "-mpegts_flags +resend_headers") {
+		t.Fatalf("missing PAT/PMT resend flag: %q", joined)
+	}
+	// -movflags belongs to the MP4 muxer; FFmpeg complains when another muxer sees it.
+	if strings.Contains(joined, "-movflags") {
+		t.Fatalf("mpegts args must not carry -movflags: %q", joined)
+	}
+	if strings.Contains(joined, "-f mp4") {
+		t.Fatalf("mpegts args must not select the mp4 muxer: %q", joined)
+	}
+	// Video must be re-encoded to H.264 High, never copied.
+	if strings.Contains(joined, "-c:v copy") {
+		t.Fatalf("mpegts args must transcode video, got %q", joined)
+	}
+	for _, want := range []string{
+		"-i pipe:0", "-map 0:0", "-map 0:1", "-sn", "-dn",
+		"-c:v libx264", "-profile:v high",
+		"-c:a ac3", "-b:a 448k",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %q", want, joined)
+		}
+	}
+	// 5.1 already fits the AC3 encoder, so no downmix should be forced.
+	if strings.Contains(joined, "-ac 6") {
+		t.Fatalf("5.1 source must not be re-downmixed: %q", joined)
+	}
+	// Subtitles cannot ride along in a DLNA transport stream.
+	if strings.Contains(joined, "mov_text") {
+		t.Fatalf("mpegts args must not map subtitles: %q", joined)
+	}
+}
+
+func TestBuildMpegTsArgsPrefersHardwareEncoder(t *testing.T) {
+	testCases := []struct {
+		name string
+		caps HWAccelCaps
+		want string
+	}{
+		{name: "videotoolbox host", caps: HWAccelCaps{Encode: HWVideoToolbox}, want: "-c:v h264_videotoolbox"},
+		{name: "no hardware encoder", caps: HWAccelCaps{Encode: HWNone}, want: "-c:v libx264"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			joined := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{inputURL: "pipe:0"}, tc.caps), " ")
+			if !strings.Contains(joined, tc.want) {
+				t.Fatalf("args missing %q: %q", tc.want, joined)
+			}
+			if !strings.Contains(joined, "-profile:v high") {
+				t.Fatalf("args missing -profile:v high: %q", joined)
+			}
+		})
+	}
+}
+
+func TestBuildMpegTsArgsScaleNeverUpscales(t *testing.T) {
+	testCases := []struct {
+		name      string
+		width     int
+		height    int
+		wantScale bool
+	}{
+		{name: "4k source is capped", width: 3840, height: 2160, wantScale: true},
+		{name: "ultra wide source is capped", width: 4096, height: 1716, wantScale: true},
+		{name: "1080p source is left alone", width: 1920, height: 1080, wantScale: false},
+		{name: "720p source is not upscaled", width: 1280, height: 720, wantScale: false},
+		{name: "sd source is not upscaled", width: 720, height: 480, wantScale: false},
+		// Without a probe the box is applied anyway: it can only shrink.
+		{name: "unknown geometry keeps the cap", width: 0, height: 0, wantScale: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			joined := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+				inputURL:     "pipe:0",
+				sourceWidth:  tc.width,
+				sourceHeight: tc.height,
+			}, HWAccelCaps{Encode: HWNone}), " ")
+
+			hasScale := strings.Contains(joined, "scale=")
+			if hasScale != tc.wantScale {
+				t.Fatalf("scale filter present = %t, want %t: %q", hasScale, tc.wantScale, joined)
+			}
+			if !hasScale {
+				return
+			}
+			// min(1080,ih) is what keeps a shorter source from being stretched.
+			if !strings.Contains(joined, "h='min(1080,ih)'") || !strings.Contains(joined, "w='min(1920,iw)'") {
+				t.Fatalf("scale filter must clamp to the 1080p box without upscaling: %q", joined)
+			}
+			if !strings.Contains(joined, "force_original_aspect_ratio=decrease") {
+				t.Fatalf("scale filter must preserve aspect ratio: %q", joined)
+			}
+		})
+	}
+}
+
+func TestBuildMpegTsArgsToneMapsHDROnly(t *testing.T) {
+	caps := HWAccelCaps{Encode: HWNone, Tonemap: "zscale", Zscale: true}
+
+	hdr := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+		inputURL:       "pipe:0",
+		sourceWidth:    3840,
+		sourceHeight:   2160,
+		hdr:            true,
+		sourceTransfer: "smpte2084",
+	}, caps), " ")
+	// The curve itself is the shared encode plan's call, not this path's: assert
+	// that an HDR source is tone mapped, not which operator does it.
+	if !strings.Contains(hdr, "tonemap=tonemap=") {
+		t.Fatalf("HDR source must be tone mapped to SDR: %q", hdr)
+	}
+	if !strings.Contains(hdr, "color_trc=smpte2084") {
+		t.Fatalf("HDR tone map must declare the PQ input transfer: %q", hdr)
+	}
+	// Scale and tone map have to compose into a single -vf value.
+	if got := strings.Count(hdr, "-vf"); got != 1 {
+		t.Fatalf("-vf occurrences = %d, want 1: %q", got, hdr)
+	}
+
+	sdr := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+		inputURL:       "pipe:0",
+		sourceWidth:    1920,
+		sourceHeight:   1080,
+		sourceTransfer: "bt709",
+	}, caps), " ")
+	if strings.Contains(sdr, "tonemap") {
+		t.Fatalf("SDR source must not be tone mapped: %q", sdr)
+	}
+
+	hlg := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+		inputURL:       "pipe:0",
+		hdr:            true,
+		sourceTransfer: "arib-std-b67",
+	}, caps), " ")
+	if !strings.Contains(hlg, "color_trc=arib-std-b67") {
+		t.Fatalf("HLG tone map must keep its own input transfer: %q", hlg)
+	}
+}
+
+// A build without zscale/libplacebo/tonemap_opencl must still stream: an
+// untone-mapped picture beats a refused connection.
+func TestBuildMpegTsArgsWithoutToneMapperStillStreams(t *testing.T) {
+	joined := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+		inputURL:       "pipe:0",
+		sourceWidth:    3840,
+		sourceHeight:   2160,
+		hdr:            true,
+		sourceTransfer: "smpte2084",
+	}, HWAccelCaps{Encode: HWNone, Tonemap: ""}), " ")
+
+	if strings.Contains(joined, "tonemap") {
+		t.Fatalf("no tone mapper is available, so none may be requested: %q", joined)
+	}
+	if !strings.HasSuffix(joined, "-f mpegts pipe:1") {
+		t.Fatalf("stream must still be produced: %q", joined)
+	}
+}
+
+func TestBuildMpegTsArgsAudioHandling(t *testing.T) {
+	testCases := []struct {
+		name        string
+		audioMap    string
+		channels    int
+		wantDownmix bool
+		wantSilent  bool
+	}{
+		{name: "stereo is kept as is", audioMap: "0:1", channels: 2},
+		{name: "5.1 is kept as is", audioMap: "0:1", channels: 6},
+		{name: "7.1 is downmixed", audioMap: "0:1", channels: 8, wantDownmix: true},
+		{name: "unknown layout is downmixed", audioMap: "0:1", channels: 0, wantDownmix: true},
+		{name: "no audio stream", audioMap: "", wantSilent: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			joined := strings.Join(buildMpegTsArgs(mpegTsEncodeInput{
+				inputURL:      "pipe:0",
+				audioMap:      tc.audioMap,
+				audioChannels: tc.channels,
+			}, HWAccelCaps{Encode: HWNone}), " ")
+
+			if tc.wantSilent {
+				if !strings.Contains(joined, "-an") {
+					t.Fatalf("a source without audio must disable audio: %q", joined)
+				}
+				if strings.Contains(joined, "-c:a ac3") {
+					t.Fatalf("no audio stream to encode: %q", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, "-c:a ac3 -b:a 448k") {
+				t.Fatalf("audio must be encoded to AC3: %q", joined)
+			}
+			if got := strings.Contains(joined, "-ac 6"); got != tc.wantDownmix {
+				t.Fatalf("downmix present = %t, want %t: %q", got, tc.wantDownmix, joined)
+			}
+		})
+	}
+}
+
+func TestBuildMpegTsPlanFromProbe(t *testing.T) {
+	h := &VideoHandler{}
+	meta := &ffprobeOutput{
+		Streams: []ffprobeStream{
+			{
+				Index:         0,
+				CodecType:     "video",
+				CodecName:     "hevc",
+				Width:         3840,
+				Height:        2160,
+				ColorTransfer: "smpte2084",
+			},
+			{Index: 1, CodecType: "audio", CodecName: "truehd", Channels: 8},
+			{Index: 2, CodecType: "subtitle", CodecName: "subrip"},
+		},
+		Format: ffprobeFormat{Duration: "7200.500"},
+	}
+
+	plan := h.buildMpegTsPlan(meta, "pipe:0", "")
+	joined := strings.Join(plan.args, " ")
+
+	if plan.container != outputMpegTs {
+		t.Fatalf("container = %v, want mpegts", plan.container)
+	}
+	if !plan.usedProbe {
+		t.Fatalf("plan must record that the probe was used")
+	}
+	if plan.duration != 7200.5 {
+		t.Fatalf("duration = %v, want 7200.5", plan.duration)
+	}
+	if plan.audio.mode != audioPlanTranscode {
+		t.Fatalf("audio mode = %q, want transcode", plan.audio.mode)
+	}
+	for _, want := range []string{"-map 0:0", "-map 0:1", "-ac 6", "-f mpegts pipe:1"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %q", want, joined)
+		}
+	}
+	if strings.Contains(joined, "-map 0:2") {
+		t.Fatalf("subtitle stream must not be mapped: %q", joined)
+	}
+}
+
+func TestBuildMpegTsPlanWithoutProbe(t *testing.T) {
+	h := &VideoHandler{}
+
+	plan := h.buildMpegTsPlan(nil, "pipe:0", "ffprobe failed: boom")
+	joined := strings.Join(plan.args, " ")
+
+	if plan.container != outputMpegTs {
+		t.Fatalf("container = %v, want mpegts", plan.container)
+	}
+	if plan.usedProbe {
+		t.Fatalf("plan must not claim probe metadata")
+	}
+	if plan.audio.reason != "ffprobe failed: boom" {
+		t.Fatalf("audio reason = %q, want the ffprobe failure", plan.audio.reason)
+	}
+	// Unknown geometry and layout: cap the frame and downmix, since neither can
+	// be verified from the source.
+	for _, want := range []string{"-map 0:v:0", "-map 0:a:0?", "h='min(1080,ih)'", "-ac 6", "-f mpegts pipe:1"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %q", want, joined)
+		}
+	}
+}
+
+func TestSourceNeedsToneMapping(t *testing.T) {
+	testCases := []struct {
+		name         string
+		stream       *ffprobeStream
+		want         bool
+		wantTransfer string
+	}{
+		{name: "nil stream", stream: nil},
+		{
+			name:   "sdr h264",
+			stream: &ffprobeStream{CodecName: "h264", ColorTransfer: "bt709"},
+			want:   false, wantTransfer: "bt709",
+		},
+		{
+			name:   "hdr10 hevc",
+			stream: &ffprobeStream{CodecName: "hevc", ColorTransfer: "smpte2084"},
+			want:   true, wantTransfer: "smpte2084",
+		},
+		{
+			name:   "hlg hevc",
+			stream: &ffprobeStream{CodecName: "hevc", ColorTransfer: "arib-std-b67"},
+			want:   true, wantTransfer: "arib-std-b67",
+		},
+		{
+			// detectDolbyVision only inspects HEVC, so the raw transfer has to
+			// catch HDR10 in other codecs.
+			name:   "hdr10 av1",
+			stream: &ffprobeStream{CodecName: "av1", ColorTransfer: "smpte2084"},
+			want:   true, wantTransfer: "smpte2084",
+		},
+		{
+			name: "dolby vision side data",
+			stream: &ffprobeStream{
+				CodecName:    "hevc",
+				SideDataList: []ffprobeSideData{{SideDataType: "DOVI configuration record", DVProfile: 5, DVLevel: 6}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, transfer := sourceNeedsToneMapping(tc.stream)
+			if got != tc.want {
+				t.Fatalf("sourceNeedsToneMapping = %t, want %t", got, tc.want)
+			}
+			if transfer != tc.wantTransfer {
+				t.Fatalf("transfer = %q, want %q", transfer, tc.wantTransfer)
+			}
+		})
+	}
+}
+
+// fakeFFmpegHandler builds a video handler whose "ffmpeg" copies stdin to
+// stdout, so the response body is the provider payload and the surrounding
+// header/plumbing behaviour is what gets asserted.
+func fakeFFmpegHandler(t *testing.T, payload []byte) *VideoHandler {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ffmpeg shell script is POSIX-only")
+	}
+
+	scriptPath := filepath.Join(t.TempDir(), "fake-ffmpeg.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexec cat\n"), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	// An unresolvable ffprobe keeps the plan on its no-metadata path.
+	return NewVideoHandlerWithProvider(true, scriptPath, filepath.Join(t.TempDir(), "absent-ffprobe"), t.TempDir(), &mockProvider{data: payload})
+}
+
+func TestStreamVideoDLNAProfileServesMpegTs(t *testing.T) {
+	payload := []byte("TRANSPORT-STREAM-PAYLOAD")
+	h := fakeFFmpegHandler(t, payload)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=movies/title.mkv&dlnaProfile=avc-ts", nil)
+	req.Header.Set("transferMode.dlna.org", "Streaming")
+	rec := httptest.NewRecorder()
+
+	h.StreamVideo(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", res.StatusCode, rec.Body.String())
+	}
+	if got, want := res.Header.Get("Content-Type"), "video/mpeg"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	if got, want := res.Header.Get("Accept-Ranges"), "none"; got != want {
+		t.Fatalf("Accept-Ranges = %q, want %q", got, want)
+	}
+	if got := res.Header["transferMode.dlna.org"]; len(got) != 1 || got[0] != "Streaming" {
+		t.Fatalf("transferMode.dlna.org = %v, want [Streaming]", got)
+	}
+	// A DLNA 1.0 renderer that receives no contentFeatures cannot confirm the
+	// profile and rejects SetAVTransportURI with UPnP 714 "Illegal MIME-type"
+	// (observed on a Sony BRAVIA KDL-46NX700 before this header was sent).
+	features := res.Header["contentFeatures.dlna.org"]
+	if len(features) != 1 {
+		t.Fatalf("contentFeatures.dlna.org = %v, want exactly one value", features)
+	}
+	for _, want := range []string{"DLNA.ORG_PN=AVC_TS_HD_24_AC3_ISO", "DLNA.ORG_CI=1"} {
+		if !strings.Contains(features[0], want) {
+			t.Fatalf("contentFeatures.dlna.org = %q, want it to contain %q", features[0], want)
+		}
+	}
+	// The advertised operation must agree with Accept-Ranges: none, or the
+	// renderer is promised byte seeking this arm cannot perform.
+	if !strings.Contains(features[0], "DLNA.ORG_OP=00") {
+		t.Fatalf("contentFeatures.dlna.org = %q, want DLNA.ORG_OP=00 to match Accept-Ranges: none", features[0])
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != string(payload) {
+		t.Fatalf("body = %q, want %q", body, payload)
+	}
+}
+
+// Legacy renderers open the stream with "Range: bytes=0-" and then play the
+// whole 200 response; a 206 or an empty body kills playback.
+func TestStreamVideoDLNAProfileIgnoresRange(t *testing.T) {
+	payload := []byte("TRANSPORT-STREAM-PAYLOAD")
+	h := fakeFFmpegHandler(t, payload)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=movies/title.mkv&dlnaProfile=avc-ts", nil)
+	req.Header.Set("Range", "bytes=0-")
+	rec := httptest.NewRecorder()
+
+	h.StreamVideo(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Range"); got != "" {
+		t.Fatalf("Content-Range = %q, want none", got)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != string(payload) {
+		t.Fatalf("body = %q, want the full stream %q", body, payload)
+	}
+}
+
+// The renderer sends two HEADs before it opens the stream.
+func TestStreamVideoDLNAProfileHeadAnnouncesMpegTs(t *testing.T) {
+	h := fakeFFmpegHandler(t, []byte("payload"))
+
+	req := httptest.NewRequest(http.MethodHead, "/api/video/stream?path=movies/title.mkv&dlnaProfile=avc-ts", nil)
+	rec := httptest.NewRecorder()
+
+	h.StreamVideo(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got, want := res.Header.Get("Content-Type"), "video/mpeg"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	if got, want := res.Header.Get("Accept-Ranges"), "none"; got != want {
+		t.Fatalf("Accept-Ranges = %q, want %q", got, want)
+	}
+}
+
+// Without the profile the transmux path must keep answering fMP4.
+func TestStreamVideoWithoutDLNAProfileKeepsMp4(t *testing.T) {
+	h := fakeFFmpegHandler(t, []byte("payload"))
+
+	for _, method := range []string{http.MethodHead, http.MethodGet} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/video/stream?path=movies/title.mkv", nil)
+			rec := httptest.NewRecorder()
+
+			h.StreamVideo(rec, req)
+
+			res := rec.Result()
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", res.StatusCode)
+			}
+			if got, want := res.Header.Get("Content-Type"), "video/mp4"; got != want {
+				t.Fatalf("Content-Type = %q, want %q", got, want)
+			}
+			if got := res.Header["transferMode.dlna.org"]; len(got) != 0 {
+				t.Fatalf("fMP4 responses must not echo DLNA transfer mode, got %v", got)
+			}
+		})
+	}
+}
+
+// End-to-end proof against the real encoder: the response body has to be a
+// transport stream carrying H.264 video and AC3 audio, which is the only
+// combination the target renderers decode.
+func TestStreamVideoDLNAProfileProducesPlayableMpegTs(t *testing.T) {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	ffprobePath, err := exec.LookPath("ffprobe")
+	if err != nil {
+		t.Skip("ffprobe not installed")
+	}
+
+	// A tiny HEVC/AC3 Matroska source: none of it is playable by the renderers
+	// this profile targets, so everything has to be re-encoded.
+	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
+	build := exec.Command(ffmpegPath, "-nostdin", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "testsrc=size=640x360:rate=24:duration=2",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+		"-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p",
+		"-c:a", "aac", "-shortest", sourcePath)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("could not build the test source: %v (%s)", err, out)
+	}
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read test source: %v", err)
+	}
+
+	h := NewVideoHandlerWithProvider(true, ffmpegPath, ffprobePath, t.TempDir(), &mockProvider{data: source})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/video/stream?path=movies/title.mkv&dlnaProfile=avc-ts", nil)
+	req.Header.Set("Range", "bytes=0-")
+	rec := httptest.NewRecorder()
+
+	h.StreamVideo(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got, want := res.Header.Get("Content-Type"), "video/mpeg"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+	// 0x47 is the MPEG-TS sync byte; 188 is the packet size the renderers expect.
+	if body[0] != 0x47 {
+		t.Fatalf("first byte = %#x, want the 0x47 transport stream sync byte", body[0])
+	}
+	if len(body)%188 != 0 {
+		t.Fatalf("body length %d is not a multiple of 188 bytes", len(body))
+	}
+
+	outPath := filepath.Join(t.TempDir(), "out.ts")
+	if err := os.WriteFile(outPath, body, 0o644); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+	probe := exec.Command(ffprobePath, "-v", "error",
+		"-show_entries", "format=format_name:stream=codec_name",
+		"-of", "default=noprint_wrappers=1:nokey=1", outPath)
+	out, err := probe.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ffprobe response: %v (%s)", err, out)
+	}
+	report := string(out)
+	for _, want := range []string{"mpegts", "h264", "ac3"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("ffprobe report %q missing %q", report, want)
+		}
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -747,8 +747,8 @@ func main() {
 	videoHandler.SetPrequeueStore(prequeueHandler.GetStore())
 	localBaseURL := fmt.Sprintf("http://127.0.0.1:%d", settings.Server.Port)
 	videoHandler.SetLocalBaseURL(localBaseURL)
-	videoHandler.GetHLSManager().SetPlaybackActivityObserver(notificationService)
-	handlers.GetStreamTracker().SetPlaybackActivityObserver(notificationService)
+	videoHandler.GetHLSManager().AddPlaybackActivityObserver(notificationService)
+	handlers.GetStreamTracker().AddPlaybackActivityObserver(notificationService)
 	historyHandler.SetActivePlaybackTrackers(handlers.GetStreamTracker())
 
 	if videoHandler != nil && settings.WebDAV.Enabled {

--- a/backend/services/castcaps/capabilities.go
+++ b/backend/services/castcaps/capabilities.go
@@ -1,0 +1,150 @@
+// Package castcaps records what a Cast receiver can actually play, without ever
+// taking the receiver away from its owner to find out.
+//
+// The Cast protocol has no capability query, and receivers lie by omission:
+// they accept a load request for a stream they cannot decode, fetch a few segments and
+// then sit in BUFFERING forever, or land in IDLE/ERROR seconds later. The
+// tempting answer is to load a test clip and watch the playhead, but that hijacks
+// whatever the household is watching, so this package does not do it and must
+// never do it.
+//
+// What is left are two honest, silent sources:
+//
+//   - Identity the device already publishes over plain HTTP on port 8008
+//     (eureka_info, and the DIAL device description when served). Mapped through
+//     PriorFor, that yields "assumed" verdicts: plausible, unproven.
+//   - Observation of playback the user actually requested, fed back through
+//     Store.Record as "supported" or "rejected". Those are facts.
+//
+// Nothing here connects to the CASTV2 port, launches an app, or loads media.
+package castcaps
+
+import "time"
+
+// Variant is one container/codec combination worth knowing about before a cast
+// starts.
+type Variant string
+
+const (
+	// VariantTSAACStereo is the universal baseline: MPEG-TS with stereo AAC-LC.
+	// Every receiver measured so far plays it, including first-generation
+	// hardware, so it is the only thing ever assumed for an unknown device.
+	VariantTSAACStereo Variant = "ts-aac-stereo"
+	// VariantFMP4 is the fMP4 container carrying H.264. Container support says
+	// nothing about codecs: legacy receivers accept the load request and stall silently.
+	VariantFMP4 Variant = "fmp4-aac-stereo"
+	// VariantHEVCFMP4 decides whether HEVC video can be copied to the receiver
+	// instead of re-encoded. Container support does not imply it: a
+	// second-generation Chromecast takes fMP4 and cannot decode HEVC.
+	VariantHEVCFMP4 Variant = "fmp4-hevc"
+	// VariantTSAC3 decides whether Dolby audio can be passed through untouched.
+	// Never assumed: AC-3 in TS was rejected by every device measured, including
+	// a modern webOS panel that certainly has a Dolby decoder.
+	VariantTSAC3 Variant = "ts-ac3"
+	// VariantTSAACMultichannel decides whether re-encoded audio can stay 5.1.
+	VariantTSAACMultichannel Variant = "ts-aac51"
+)
+
+// AllVariants lists every variant, baseline first.
+var AllVariants = []Variant{VariantTSAACStereo, VariantFMP4, VariantHEVCFMP4, VariantTSAC3, VariantTSAACMultichannel}
+
+// Verdict is how much we know about one variant on one receiver.
+type Verdict string
+
+const (
+	// VerdictUnknown means never observed and no prior worth stating.
+	VerdictUnknown Verdict = ""
+	// VerdictAssumed comes from the model/firmware prior: plausible, unproven.
+	VerdictAssumed Verdict = "assumed"
+	// VerdictSupported means a real playback session sustained this variant.
+	VerdictSupported Verdict = "supported"
+	// VerdictRejected means a real playback session failed on this variant:
+	// an error, or the accept-then-stall signature.
+	VerdictRejected Verdict = "rejected"
+)
+
+// verdictRank orders verdicts so a later report can only ever add certainty:
+// unknown < assumed < supported < rejected.
+//
+// Rejected outranking supported is deliberate. A variant that stalled once will
+// stall again, and the failure mode is a silent freeze on the user's TV, so one
+// measured failure outweighs an earlier success. Firmware updates are the
+// legitimate way out of a rejection, and Store.Ensure handles that by clearing
+// observations when the build revision changes.
+func verdictRank(v Verdict) int {
+	switch v {
+	case VerdictAssumed:
+		return 1
+	case VerdictSupported:
+		return 2
+	case VerdictRejected:
+		return 3
+	default:
+		return 0
+	}
+}
+
+// normalizeVerdict maps anything unrecognized - including verdict strings
+// written by older builds of this package, such as the literal "unknown" - onto
+// the current set.
+func normalizeVerdict(v Verdict) Verdict {
+	switch v {
+	case VerdictAssumed, VerdictSupported, VerdictRejected:
+		return v
+	default:
+		return VerdictUnknown
+	}
+}
+
+// observed reports whether a verdict came from watching real playback.
+func observed(v Verdict) bool {
+	return v == VerdictSupported || v == VerdictRejected
+}
+
+// Capabilities is everything known about one receiver.
+type Capabilities struct {
+	Identity
+	Variants  map[Variant]Verdict `json:"variants"`
+	UpdatedAt time.Time           `json:"updatedAt"`
+}
+
+// Supports reports proven support only. Use it for any decision whose failure
+// mode is a silent stall on the user's screen: a guess is not good enough there.
+func (c *Capabilities) Supports(variant Variant) bool {
+	if c == nil {
+		return false
+	}
+	return c.Variants[variant] == VerdictSupported
+}
+
+// Allows reports proven or assumed support. Use it to decide whether an upgrade
+// is worth attempting at all, so an unproven receiver can still earn a fact.
+func (c *Capabilities) Allows(variant Variant) bool {
+	if c == nil {
+		return false
+	}
+	switch c.Variants[variant] {
+	case VerdictSupported, VerdictAssumed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Verdict returns what is known about one variant.
+func (c *Capabilities) Verdict(variant Variant) Verdict {
+	if c == nil {
+		return VerdictUnknown
+	}
+	return normalizeVerdict(c.Variants[variant])
+}
+
+// clone deep-copies the variant map so callers cannot mutate cached state.
+func (c Capabilities) clone() Capabilities {
+	copied := c
+	copied.Variants = make(map[Variant]Verdict, len(c.Variants))
+	for variant, verdict := range c.Variants {
+		copied.Variants[variant] = verdict
+	}
+	return copied
+}

--- a/backend/services/castcaps/capabilities_test.go
+++ b/backend/services/castcaps/capabilities_test.go
@@ -1,0 +1,90 @@
+package castcaps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCapabilities_SupportsVsAllows(t *testing.T) {
+	tests := []struct {
+		name         string
+		verdict      Verdict
+		wantSupports bool
+		wantAllows   bool
+	}{
+		// The whole point of the split: an assumed variant is worth attempting
+		// but must never gate something that fails as a silent stall.
+		{"assumed", VerdictAssumed, false, true},
+		{"supported", VerdictSupported, true, true},
+		{"rejected", VerdictRejected, false, false},
+		{"unknown", VerdictUnknown, false, false},
+		{"absent", "no-such-verdict", false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			caps := &Capabilities{Variants: map[Variant]Verdict{VariantFMP4: tc.verdict}}
+			if got := caps.Supports(VariantFMP4); got != tc.wantSupports {
+				t.Fatalf("Supports(%q) = %v, want %v", tc.verdict, got, tc.wantSupports)
+			}
+			if got := caps.Allows(VariantFMP4); got != tc.wantAllows {
+				t.Fatalf("Allows(%q) = %v, want %v", tc.verdict, got, tc.wantAllows)
+			}
+			// An untouched variant answers no to both regardless.
+			if caps.Supports(VariantHEVCFMP4) || caps.Allows(VariantHEVCFMP4) {
+				t.Fatal("an unmentioned variant must answer no to both")
+			}
+		})
+	}
+}
+
+func TestCapabilities_NilReceiver(t *testing.T) {
+	var caps *Capabilities
+	for _, variant := range AllVariants {
+		if caps.Supports(variant) {
+			t.Fatalf("nil Capabilities.Supports(%s) = true", variant)
+		}
+		if caps.Allows(variant) {
+			t.Fatalf("nil Capabilities.Allows(%s) = true", variant)
+		}
+		if got := caps.Verdict(variant); got != VerdictUnknown {
+			t.Fatalf("nil Capabilities.Verdict(%s) = %q", variant, got)
+		}
+	}
+	// A non-nil record with a nil map must be equally safe.
+	empty := &Capabilities{}
+	if empty.Supports(VariantTSAACStereo) || empty.Allows(VariantTSAACStereo) {
+		t.Fatal("empty Capabilities must answer no")
+	}
+}
+
+func TestCapabilities_VerdictNormalizesLegacyStrings(t *testing.T) {
+	// Older builds wrote the literal "unknown"; it must not read back as a
+	// fourth state.
+	caps := &Capabilities{Variants: map[Variant]Verdict{VariantFMP4: "unknown"}}
+	if got := caps.Verdict(VariantFMP4); got != VerdictUnknown {
+		t.Fatalf("Verdict = %q, want %q", got, VerdictUnknown)
+	}
+}
+
+func TestVerdictRankOrdering(t *testing.T) {
+	ordered := []Verdict{VerdictUnknown, VerdictAssumed, VerdictSupported, VerdictRejected}
+	for i := 1; i < len(ordered); i++ {
+		if verdictRank(ordered[i-1]) >= verdictRank(ordered[i]) {
+			t.Fatalf("rank(%q) must be below rank(%q)", ordered[i-1], ordered[i])
+		}
+	}
+	if observed(VerdictAssumed) || observed(VerdictUnknown) {
+		t.Fatal("only supported/rejected come from observation")
+	}
+	if !observed(VerdictSupported) || !observed(VerdictRejected) {
+		t.Fatal("supported and rejected are observations")
+	}
+}
+
+func TestAllVariants_BaselineFirst(t *testing.T) {
+	want := []Variant{VariantTSAACStereo, VariantFMP4, VariantHEVCFMP4, VariantTSAC3, VariantTSAACMultichannel}
+	if !reflect.DeepEqual(AllVariants, want) {
+		t.Fatalf("AllVariants = %v, want %v", AllVariants, want)
+	}
+}

--- a/backend/services/castcaps/discovery.go
+++ b/backend/services/castcaps/discovery.go
@@ -1,0 +1,114 @@
+package castcaps
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// dialProbeTimeout bounds the TCP connect used to decide whether a LAN address
+// is worth an HTTP request at all.
+const dialProbeTimeout = 700 * time.Millisecond
+
+// discoveryConcurrency bounds the sweep so a /24 finishes quickly without
+// flooding a home router's connection table.
+const discoveryConcurrency = 64
+
+// Discover sweeps a /24 for hosts serving the Cast setup port and describes the
+// ones that answer. mDNS is filtered on plenty of home networks (and inside
+// containers), so a bounded port sweep is the dependable way to find receivers.
+//
+// Passive throughout: a TCP connect to 8008 and two HTTP GETs. Nothing is
+// launched and nothing is played.
+func Discover(ctx context.Context, cidr string) []Identity {
+	hosts, err := hostsInCIDR(cidr)
+	if err != nil {
+		return nil
+	}
+
+	var (
+		mu         sync.Mutex
+		identities []Identity
+		wg         sync.WaitGroup
+	)
+	limit := make(chan struct{}, discoveryConcurrency)
+	for _, host := range hosts {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			limit <- struct{}{}
+			defer func() { <-limit }()
+
+			dialer := net.Dialer{Timeout: dialProbeTimeout}
+			conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, fmt.Sprint(setupPort)))
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+
+			identity, err := Describe(ctx, host)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			identities = append(identities, identity)
+			mu.Unlock()
+		}(host)
+	}
+	wg.Wait()
+	return identities
+}
+
+func hostsInCIDR(cidr string) ([]string, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	ones, bits := network.Mask.Size()
+	if bits-ones > 8 {
+		return nil, fmt.Errorf("refusing to scan a network larger than /24: %s", cidr)
+	}
+	var hosts []string
+	for ip := network.IP.Mask(network.Mask); network.Contains(ip); ip = nextIP(ip) {
+		last := ip[len(ip)-1]
+		if last == 0 || last == 255 {
+			continue
+		}
+		hosts = append(hosts, ip.String())
+	}
+	return hosts, nil
+}
+
+func nextIP(ip net.IP) net.IP {
+	next := make(net.IP, len(ip))
+	copy(next, ip)
+	for i := len(next) - 1; i >= 0; i-- {
+		next[i]++
+		if next[i] != 0 {
+			break
+		}
+	}
+	return next
+}
+
+// LocalCIDR returns the /24 of the first non-loopback IPv4 interface address.
+func LocalCIDR() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP.IsLoopback() {
+			continue
+		}
+		ipv4 := ipNet.IP.To4()
+		if ipv4 == nil {
+			continue
+		}
+		return fmt.Sprintf("%d.%d.%d.0/24", ipv4[0], ipv4[1], ipv4[2])
+	}
+	return ""
+}

--- a/backend/services/castcaps/identity.go
+++ b/backend/services/castcaps/identity.go
@@ -1,0 +1,172 @@
+package castcaps
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// setupPort is the plain-HTTP port every Cast receiver serves its setup and DIAL
+// documents on. It is the only port this package ever talks to; 8009 (CASTV2) is
+// what would let us launch an app, and we never do.
+const setupPort = 8008
+
+// describeTimeout bounds each passive GET. Receivers on the LAN answer in
+// milliseconds; anything slower is asleep or not a Cast device.
+const describeTimeout = 3500 * time.Millisecond
+
+// maxDescribeBody caps what we read from an unauthenticated device on the LAN.
+const maxDescribeBody = 256 << 10
+
+// Identity is what a receiver tells us without being asked to play anything.
+type Identity struct {
+	Host          string `json:"host"`
+	Name          string `json:"name"`          // eureka_info.name
+	ModelName     string `json:"modelName"`     // DIAL <modelName>, "" when unavailable
+	Manufacturer  string `json:"manufacturer"`  // DIAL <manufacturer>
+	BuildRevision string `json:"buildRevision"` // eureka_info.cast_build_revision
+	UDN           string `json:"udn"`           // eureka_info.ssdp_udn
+}
+
+// eurekaInfo is the subset of /setup/eureka_info worth keeping.
+type eurekaInfo struct {
+	Name              string `json:"name"`
+	SSDPUDN           string `json:"ssdp_udn"`
+	CastBuildRevision string `json:"cast_build_revision"`
+	BuildVersion      string `json:"build_version"`
+	Detail            struct {
+		ModelName    string `json:"model_name"`
+		Manufacturer string `json:"manufacturer"`
+	} `json:"detail"`
+	Settings struct {
+		Name string `json:"name"`
+	} `json:"settings"`
+}
+
+// dialDeviceDesc is the subset of the DIAL/UPnP device description worth keeping.
+// LG's webOS Cast implementation does not serve this document at all, so every
+// field here is optional.
+type dialDeviceDesc struct {
+	XMLName xml.Name `xml:"root"`
+	Device  struct {
+		FriendlyName string `xml:"friendlyName"`
+		Manufacturer string `xml:"manufacturer"`
+		ModelName    string `xml:"modelName"`
+	} `xml:"device"`
+}
+
+// Describe reads a receiver's identity with two passive GETs on port 8008. It
+// never launches an app and never loads media.
+//
+// The two sources disagree about which devices serve them: a Chromecast dongle
+// answers both, an LG panel answers eureka_info and 404s the DIAL description.
+// Either one alone is enough, so only a receiver that answered nothing is an
+// error.
+func Describe(ctx context.Context, host string) (Identity, error) {
+	return describe(ctx, describeClient(), fmt.Sprintf("http://%s:%d", host, setupPort), host)
+}
+
+func describeClient() *http.Client {
+	return &http.Client{Timeout: describeTimeout}
+}
+
+// describe is Describe with the base URL injected so tests can serve recorded
+// payloads instead of touching a receiver somebody is watching.
+func describe(ctx context.Context, client *http.Client, base, host string) (Identity, error) {
+	identity := Identity{Host: host}
+
+	var eurekaErr, dialErr error
+	if info, err := fetchEurekaInfo(ctx, client, base); err != nil {
+		eurekaErr = err
+	} else {
+		identity.Name = firstNonEmpty(info.Name, info.Settings.Name)
+		identity.BuildRevision = firstNonEmpty(info.CastBuildRevision, info.BuildVersion)
+		identity.UDN = info.SSDPUDN
+		// eureka_info's detail block is a weaker source than DIAL for these two,
+		// so DIAL overwrites them below when it answers.
+		identity.ModelName = info.Detail.ModelName
+		identity.Manufacturer = info.Detail.Manufacturer
+	}
+
+	if desc, err := fetchDeviceDesc(ctx, client, base); err != nil {
+		dialErr = err
+	} else {
+		if name := strings.TrimSpace(desc.Device.ModelName); name != "" {
+			identity.ModelName = name
+		}
+		if maker := strings.TrimSpace(desc.Device.Manufacturer); maker != "" {
+			identity.Manufacturer = maker
+		}
+		identity.Name = firstNonEmpty(identity.Name, desc.Device.FriendlyName)
+	}
+
+	if eurekaErr != nil && dialErr != nil {
+		return Identity{Host: host}, fmt.Errorf("describe %s: eureka_info: %w; device-desc: %v", host, eurekaErr, dialErr)
+	}
+	if identity.Name == "" {
+		identity.Name = host
+	}
+	return identity, nil
+}
+
+func fetchEurekaInfo(ctx context.Context, client *http.Client, base string) (eurekaInfo, error) {
+	var info eurekaInfo
+	body, err := getBody(ctx, client, base+"/setup/eureka_info?options=detail")
+	if err != nil {
+		return info, err
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return info, fmt.Errorf("decode eureka_info: %w", err)
+	}
+	return info, nil
+}
+
+func fetchDeviceDesc(ctx context.Context, client *http.Client, base string) (dialDeviceDesc, error) {
+	var desc dialDeviceDesc
+	body, err := getBody(ctx, client, base+"/ssdp/device-desc.xml")
+	if err != nil {
+		return desc, err
+	}
+	if err := xml.Unmarshal(body, &desc); err != nil {
+		return desc, fmt.Errorf("decode device-desc.xml: %w", err)
+	}
+	return desc, nil
+}
+
+func getBody(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDescribeBody))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) == 0 {
+		return nil, errors.New("empty response body")
+	}
+	return body, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/backend/services/castcaps/identity_test.go
+++ b/backend/services/castcaps/identity_test.go
@@ -1,0 +1,173 @@
+package castcaps
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func fixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+// receiverStub serves recorded payloads on the two paths Describe is allowed to
+// read, and records every path asked for so a test can prove nothing else was.
+type receiverStub struct {
+	eureka   []byte
+	eurekaSt int
+	dial     []byte
+	dialSt   int
+
+	asked []string
+}
+
+func (s *receiverStub) serve(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.asked = append(s.asked, r.URL.RequestURI())
+		switch r.URL.Path {
+		case "/setup/eureka_info":
+			if s.eurekaSt != 0 {
+				w.WriteHeader(s.eurekaSt)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(s.eureka)
+		case "/ssdp/device-desc.xml":
+			if s.dialSt != 0 {
+				w.WriteHeader(s.dialSt)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write(s.dial)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestDescribe(t *testing.T) {
+	lg := fixture(t, "eureka_info_lg_c2.json")
+	dongle := fixture(t, "eureka_info_dongle.json")
+	dialDongle := fixture(t, "device_desc_dongle.xml")
+
+	tests := []struct {
+		name    string
+		host    string
+		stub    receiverStub
+		want    Identity
+		wantErr bool
+	}{
+		{
+			// 192.168.8.105: modern webOS panel. Serves eureka_info, 404s DIAL.
+			name: "lg panel without DIAL document",
+			host: "192.168.8.105",
+			stub: receiverStub{eureka: lg, dialSt: http.StatusNotFound},
+			want: Identity{
+				Host:          "192.168.8.105",
+				Name:          "[LG] webOS TV OLED65C2PUA",
+				BuildRevision: "1.68.cast_20250829_0200_RC13.800768591",
+				UDN:           "1b2c3d4e-5f60-4718-8293-a4b5c6d7e8f9",
+			},
+		},
+		{
+			// 192.168.8.108: legacy dongle. Serves both; only DIAL names the model.
+			name: "legacy dongle serving both documents",
+			host: "192.168.8.108",
+			stub: receiverStub{eureka: dongle, dial: dialDongle},
+			want: Identity{
+				Host:          "192.168.8.108",
+				Name:          "Avery's room TV",
+				ModelName:     "Eureka Dongle",
+				Manufacturer:  "Google Inc.",
+				BuildRevision: "1.56.291998",
+				UDN:           "9f8e7d6c-5b4a-4392-8170-6f5e4d3c2b1a",
+			},
+		},
+		{
+			name: "DIAL only still identifies the model",
+			host: "10.0.0.5",
+			stub: receiverStub{eurekaSt: http.StatusServiceUnavailable, dial: dialDongle},
+			want: Identity{
+				Host:         "10.0.0.5",
+				Name:         "Avery's room TV",
+				ModelName:    "Eureka Dongle",
+				Manufacturer: "Google Inc.",
+			},
+		},
+		{
+			name: "unparseable eureka payload falls back to DIAL",
+			host: "10.0.0.6",
+			stub: receiverStub{eureka: []byte("<html>not json</html>"), dial: dialDongle},
+			want: Identity{
+				Host:         "10.0.0.6",
+				Name:         "Avery's room TV",
+				ModelName:    "Eureka Dongle",
+				Manufacturer: "Google Inc.",
+			},
+		},
+		{
+			name: "nameless receiver falls back to its address",
+			host: "10.0.0.7",
+			stub: receiverStub{eureka: []byte(`{"cast_build_revision":"1.42.1"}`), dialSt: http.StatusNotFound},
+			want: Identity{Host: "10.0.0.7", Name: "10.0.0.7", BuildRevision: "1.42.1"},
+		},
+		{
+			name:    "no source answers",
+			host:    "10.0.0.8",
+			stub:    receiverStub{eurekaSt: http.StatusNotFound, dialSt: http.StatusNotFound},
+			want:    Identity{Host: "10.0.0.8"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := tc.stub
+			server := stub.serve(t)
+
+			got, err := describe(context.Background(), server.Client(), server.URL, tc.host)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("identity = %#v, want %#v", got, tc.want)
+			}
+
+			asked := append([]string(nil), stub.asked...)
+			sort.Strings(asked)
+			want := []string{"/setup/eureka_info?options=detail", "/ssdp/device-desc.xml"}
+			if !reflect.DeepEqual(asked, want) {
+				t.Fatalf("requested %v, want exactly %v: Describe must stay passive", asked, want)
+			}
+		})
+	}
+}
+
+func TestDescribe_UnreachableHost(t *testing.T) {
+	// Port 1 on the loopback refuses instantly, so this exercises the transport
+	// failure path without waiting out a timeout.
+	if _, err := describe(context.Background(), describeClient(), "http://127.0.0.1:1", "127.0.0.1"); err == nil {
+		t.Fatal("expected an error when nothing answers")
+	}
+}
+
+func TestSetupPortIsPassive(t *testing.T) {
+	// 8009 is the CASTV2 port: reaching it is how a caller would launch an app
+	// and load media, which this package must never do.
+	if setupPort != 8008 {
+		t.Fatalf("setupPort = %d, want 8008", setupPort)
+	}
+}

--- a/backend/services/castcaps/priors.go
+++ b/backend/services/castcaps/priors.go
@@ -1,0 +1,115 @@
+package castcaps
+
+import (
+	"strconv"
+	"strings"
+)
+
+// modernCastMajor/modernCastMinor separates the two Cast stacks we have
+// measured: 192.168.8.108 reports 1.56.291998, the webOS panel 1.68.cast_...
+// 1.60 is the round number between them. It distinguishes "known legacy, refuse
+// everything" from "unknown, attempt nothing beyond the baseline" — NOT
+// "modern, assume more". Both measured devices rejected fMP4 and AC-3, the
+// 1.68 panel included, so a newer stack buys no assumption.
+const (
+	modernCastMajor = 1
+	modernCastMinor = 60
+)
+
+// legacyModelNames are receivers known to be the gen1/gen2 Cast stack. Google
+// shipped every early dongle - and the TV-integrated Cast built from the same
+// firmware - as "Eureka Dongle".
+var legacyModelNames = []string{"eureka dongle"}
+
+// PriorFor maps a receiver identity onto assumed verdicts. Pure function, no I/O.
+//
+// Every verdict it returns is a guess from published identity, never a
+// measurement, so callers must treat VerdictAssumed as "worth attempting" and
+// not as "safe to rely on". Only three envelopes are worth stating, because only
+// three are defensible from measured hardware:
+//
+//   - Legacy Cast stack: MPEG-TS with stereo AAC-LC and nothing else. Measured on
+//     a 1.56 dongle, which stalls silently on fMP4 and refuses AC-3 in TS.
+//   - Modern receiver: TS baseline, fMP4, HEVC in fMP4 and multichannel AAC.
+//     Measured on a webOS panel at 1.68.
+//   - Anything unidentifiable: the baseline only.
+//
+// VariantTSAC3 is left unknown everywhere. AC-3 in MPEG-TS was rejected by both
+// measured devices, including the panel with a Dolby decoder, so Dolby
+// passthrough is never assumed for anyone.
+func PriorFor(id Identity) map[Variant]Verdict {
+	if isLegacyCast(id) {
+		return map[Variant]Verdict{
+			VariantTSAACStereo:       VerdictAssumed,
+			VariantFMP4:              VerdictRejected,
+			VariantHEVCFMP4:          VerdictRejected,
+			VariantTSAC3:             VerdictRejected,
+			VariantTSAACMultichannel: VerdictRejected,
+		}
+	}
+	// Everything else, modern stacks included: the baseline only. Every other
+	// variant stays VerdictUnknown, which reads as "do not attempt". The one
+	// modern receiver we have measured rejected fMP4 with an explicit ERROR in
+	// 1.0s, so "the firmware is new" is not evidence that anything beyond the
+	// baseline works. An upgrade needs an observed VerdictSupported, which the
+	// playback grader can only record for a variant we actually sent — so the
+	// upgrade path opens when real evidence arrives, not on a guess whose
+	// failure mode is a receiver that stalls with no error.
+	return map[Variant]Verdict{VariantTSAACStereo: VerdictAssumed}
+}
+
+// isLegacyCast reports the gen1/gen2/TV-integrated-old-Cast envelope, either by
+// model name or by a build revision older than the modern cutoff.
+func isLegacyCast(id Identity) bool {
+	model := strings.ToLower(strings.TrimSpace(id.ModelName))
+	for _, legacy := range legacyModelNames {
+		if model == legacy {
+			return true
+		}
+	}
+	if major, minor, ok := parseBuildRevision(id.BuildRevision); ok {
+		return !atLeast(major, minor, modernCastMajor, modernCastMinor)
+	}
+	return false
+}
+
+// buildRevisionAtLeast reports whether a receiver's cast_build_revision is at
+// least major.minor. An unparseable or missing revision reports false: absence
+// of evidence is not evidence of a modern receiver.
+func buildRevisionAtLeast(revision string, major, minor int) bool {
+	gotMajor, gotMinor, ok := parseBuildRevision(revision)
+	if !ok {
+		return false
+	}
+	return atLeast(gotMajor, gotMinor, major, minor)
+}
+
+func atLeast(gotMajor, gotMinor, wantMajor, wantMinor int) bool {
+	if gotMajor != wantMajor {
+		return gotMajor > wantMajor
+	}
+	return gotMinor >= wantMinor
+}
+
+// parseBuildRevision reads the major and minor of a cast_build_revision. Real
+// devices report two very different shapes - "1.56.291998" on a dongle and
+// "1.68.cast_20250829_0200_RC13.800768591" on a webOS panel - so everything past
+// the minor is ignored rather than parsed.
+func parseBuildRevision(revision string) (major, minor int, ok bool) {
+	fields := strings.Split(strings.TrimSpace(revision), ".")
+	if len(fields) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(strings.TrimSpace(fields[0]))
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(strings.TrimSpace(fields[1]))
+	if err != nil {
+		return 0, 0, false
+	}
+	if major < 0 || minor < 0 {
+		return 0, 0, false
+	}
+	return major, minor, true
+}

--- a/backend/services/castcaps/priors_test.go
+++ b/backend/services/castcaps/priors_test.go
@@ -1,0 +1,145 @@
+package castcaps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBuildRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		major    int
+		minor    int
+		ok       bool
+	}{
+		// Both shapes are recorded from real hardware.
+		{"webos panel", "1.68.cast_20250829_0200_RC13.800768591", 1, 68, true},
+		{"legacy dongle", "1.56.291998", 1, 56, true},
+		{"two components only", "1.60", 1, 60, true},
+		{"padded", " 2.4.7 ", 2, 4, true},
+		{"empty", "", 0, 0, false},
+		{"single component", "1", 0, 0, false},
+		{"non numeric major", "cast.68.1", 0, 0, false},
+		{"non numeric minor", "1.x68.3", 0, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			major, minor, ok := parseBuildRevision(tc.revision)
+			if major != tc.major || minor != tc.minor || ok != tc.ok {
+				t.Fatalf("parseBuildRevision(%q) = (%d, %d, %v), want (%d, %d, %v)",
+					tc.revision, major, minor, ok, tc.major, tc.minor, tc.ok)
+			}
+		})
+	}
+}
+
+func TestBuildRevisionAtLeast(t *testing.T) {
+	tests := []struct {
+		revision string
+		major    int
+		minor    int
+		want     bool
+	}{
+		{"1.68.cast_20250829_0200_RC13.800768591", 1, 60, true},
+		{"1.56.291998", 1, 60, false},
+		{"1.60.1", 1, 60, true},
+		{"2.0.0", 1, 60, true},
+		{"0.99.0", 1, 60, false},
+		{"", 1, 60, false},
+		{"garbage", 1, 60, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.revision, func(t *testing.T) {
+			if got := buildRevisionAtLeast(tc.revision, tc.major, tc.minor); got != tc.want {
+				t.Fatalf("buildRevisionAtLeast(%q, %d, %d) = %v, want %v",
+					tc.revision, tc.major, tc.minor, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPriorFor(t *testing.T) {
+	legacyEnvelope := map[Variant]Verdict{
+		VariantTSAACStereo:       VerdictAssumed,
+		VariantFMP4:              VerdictRejected,
+		VariantHEVCFMP4:          VerdictRejected,
+		VariantTSAC3:             VerdictRejected,
+		VariantTSAACMultichannel: VerdictRejected,
+	}
+	// There is no "modern envelope". The only modern receiver measured (a 1.68
+	// webOS panel) rejected fMP4 with an explicit ERROR, so a newer build earns
+	// no assumption beyond the baseline every device has been seen to play.
+	baselineOnly := map[Variant]Verdict{VariantTSAACStereo: VerdictAssumed}
+
+	tests := []struct {
+		name string
+		id   Identity
+		want map[Variant]Verdict
+	}{
+		{
+			// 192.168.8.108, hardware-confirmed: TS/AAC plays, fMP4 stalls.
+			name: "legacy dongle by model and build",
+			id:   Identity{Host: "192.168.8.108", Name: "Avery's room TV", ModelName: "Eureka Dongle", BuildRevision: "1.56.291998"},
+			want: legacyEnvelope,
+		},
+		{
+			name: "legacy by model name alone",
+			id:   Identity{ModelName: "eureka dongle"},
+			want: legacyEnvelope,
+		},
+		{
+			name: "legacy by old build alone",
+			id:   Identity{Name: "Living Room", BuildRevision: "1.56.291998"},
+			want: legacyEnvelope,
+		},
+		{
+			// 192.168.8.105. Modern build, and it still rejected fMP4 on real
+			// hardware. A new firmware is not evidence of anything.
+			name: "webos panel gets no upgrade from its build revision",
+			id:   Identity{Host: "192.168.8.105", Name: "[LG] webOS TV OLED65C2PUA", BuildRevision: "1.68.cast_20250829_0200_RC13.800768591"},
+			want: baselineOnly,
+		},
+		{
+			name: "modern build alone assumes nothing extra",
+			id:   Identity{Name: "Bedroom", BuildRevision: "1.68.cast_20250829_0200_RC13.800768591"},
+			want: baselineOnly,
+		},
+		{
+			name: "recognizable modern model still assumes nothing extra",
+			id:   Identity{ModelName: "Chromecast Ultra"},
+			want: baselineOnly,
+		},
+		{
+			name: "unidentifiable receiver assumes the baseline only",
+			id:   Identity{Host: "10.0.0.9", Name: "10.0.0.9"},
+			want: baselineOnly,
+		},
+		{
+			name: "bare chromecast is not promoted",
+			id:   Identity{Name: "Chromecast"},
+			want: baselineOnly,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PriorFor(tc.id)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("PriorFor(%#v) = %v, want %v", tc.id, got, tc.want)
+			}
+			if got[VariantTSAC3] == VerdictAssumed {
+				t.Fatal("AC-3 passthrough must never be assumed: both measured devices rejected it")
+			}
+		})
+	}
+}
+
+func TestPriorFor_ModernLeavesAC3Unknown(t *testing.T) {
+	prior := PriorFor(Identity{Name: "[LG] webOS TV OLED65C2PUA", BuildRevision: "1.68.cast_20250829_0200_RC13.800768591"})
+	if verdict, present := prior[VariantTSAC3]; present || verdict != VerdictUnknown {
+		t.Fatalf("ts-ac3 prior = %q (present %v), want unknown and absent", verdict, present)
+	}
+}

--- a/backend/services/castcaps/store.go
+++ b/backend/services/castcaps/store.go
@@ -1,0 +1,332 @@
+package castcaps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// recordPrefix/recordSuffix bracket the per-receiver cache file name.
+	recordPrefix = "receiver-"
+	recordSuffix = ".json"
+	// legacyCacheFile is the single-file cache the probing version of this
+	// package wrote. Read once for its host and variant verdicts, never written.
+	legacyCacheFile = "cast-capabilities.json"
+)
+
+// Store keeps what is known about each receiver across restarts.
+//
+// Everything it does is passive: it reads identity over HTTP and accepts
+// observations from real playback. No method here can start playback.
+type Store struct {
+	dir string
+
+	mu     sync.RWMutex
+	byHost map[string]Capabilities
+
+	// describeFn is the identity source, swapped in tests so the suite never
+	// touches a receiver somebody is watching.
+	describeFn func(ctx context.Context, host string) (Identity, error)
+}
+
+// NewStore opens (and creates on first write) a capability cache in dir.
+func NewStore(dir string) *Store {
+	store := &Store{
+		dir:        dir,
+		byHost:     map[string]Capabilities{},
+		describeFn: Describe,
+	}
+	store.load()
+	return store
+}
+
+// legacyRecord reads a cache entry written by the probing version of this
+// package. Its identity fields had different names and its timestamp was
+// probedAt; the embedded Capabilities picks up everything that did not move.
+type legacyRecord struct {
+	Capabilities
+	Model        string    `json:"model"`
+	BuildVersion string    `json:"buildVersion"`
+	ProbedAt     time.Time `json:"probedAt"`
+}
+
+func (s *Store) load() {
+	entries, err := os.ReadDir(s.dir)
+	if err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasPrefix(name, recordPrefix) || !strings.HasSuffix(name, recordSuffix) {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(s.dir, name))
+			if err != nil {
+				continue
+			}
+			var record Capabilities
+			if err := json.Unmarshal(data, &record); err != nil {
+				log.Printf("[castcaps] ignoring unreadable capability cache %s: %v", name, err)
+				continue
+			}
+			s.adopt(record)
+		}
+	}
+	s.loadLegacy()
+	if len(s.byHost) > 0 {
+		log.Printf("[castcaps] loaded capabilities for %d receiver(s)", len(s.byHost))
+	}
+}
+
+// loadLegacy folds in the old single-file cache. Entries that also exist as a
+// per-receiver file lose: that file is newer by construction.
+func (s *Store) loadLegacy() {
+	data, err := os.ReadFile(filepath.Join(s.dir, legacyCacheFile))
+	if err != nil {
+		return
+	}
+	var records []legacyRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		log.Printf("[castcaps] ignoring unreadable legacy capability cache: %v", err)
+		return
+	}
+	for _, record := range records {
+		caps := record.Capabilities
+		if caps.ModelName == "" {
+			caps.ModelName = record.Model
+		}
+		if caps.BuildRevision == "" {
+			caps.BuildRevision = record.BuildVersion
+		}
+		if caps.UpdatedAt.IsZero() {
+			caps.UpdatedAt = record.ProbedAt
+		}
+		if _, exists := s.byHost[strings.TrimSpace(caps.Host)]; exists {
+			continue
+		}
+		s.adopt(caps)
+	}
+}
+
+// adopt normalizes a decoded record into the cache. Verdict strings from older
+// builds - "unknown", or anything a future build invents - degrade to
+// VerdictUnknown rather than leaking through as a fourth state.
+func (s *Store) adopt(record Capabilities) {
+	host := strings.TrimSpace(record.Host)
+	if host == "" {
+		return
+	}
+	record.Host = host
+	normalized := make(map[Variant]Verdict, len(record.Variants))
+	for variant, verdict := range record.Variants {
+		if strings.TrimSpace(string(variant)) == "" {
+			continue
+		}
+		normalized[variant] = normalizeVerdict(verdict)
+	}
+	record.Variants = normalized
+	s.byHost[host] = record
+}
+
+func (s *Store) persist(record Capabilities) {
+	if s.dir == "" {
+		return
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		log.Printf("[castcaps] failed to create cache dir: %v", err)
+		return
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return
+	}
+	path := filepath.Join(s.dir, recordFileName(record.Host))
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		log.Printf("[castcaps] failed to write capability cache: %v", err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		log.Printf("[castcaps] failed to replace capability cache: %v", err)
+	}
+}
+
+// recordFileName keeps one file per receiver, named after its address with
+// anything path-unsafe folded to an underscore.
+func recordFileName(host string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '.' || r == '-':
+			return r
+		default:
+			return '_'
+		}
+	}, host)
+	return recordPrefix + safe + recordSuffix
+}
+
+// Lookup returns cached capabilities for a receiver address, or nil. It never
+// performs I/O, so the path that starts a cast can call it freely.
+func (s *Store) Lookup(host string) *Capabilities {
+	if s == nil {
+		return nil
+	}
+	host = strings.TrimSpace(host)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.byHost[host]
+	if !ok {
+		return nil
+	}
+	copied := record.clone()
+	return &copied
+}
+
+// All returns every cached record.
+func (s *Store) All() []Capabilities {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	records := make([]Capabilities, 0, len(s.byHost))
+	for _, record := range s.byHost {
+		records = append(records, record.clone())
+	}
+	return records
+}
+
+// Ensure reads a receiver's identity, folds in the prior it implies, and caches
+// the result. Observed verdicts always survive: a prior can fill a gap but never
+// argue with a measurement.
+//
+// A receiver that answers nothing is not written to the cache - there is no
+// identity to attach - but a record already on file is returned instead, since a
+// sleeping TV does not forget what it played yesterday.
+func (s *Store) Ensure(ctx context.Context, host string) (*Capabilities, error) {
+	if s == nil {
+		return nil, errors.New("castcaps: nil store")
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil, errors.New("castcaps: empty receiver host")
+	}
+	identity, err := s.describe(ctx, host)
+	if err != nil {
+		if cached := s.Lookup(host); cached != nil {
+			return cached, nil
+		}
+		return nil, err
+	}
+	caps := s.applyIdentity(identity)
+	return &caps, nil
+}
+
+func (s *Store) describe(ctx context.Context, host string) (Identity, error) {
+	if s.describeFn == nil {
+		return Describe(ctx, host)
+	}
+	return s.describeFn(ctx, host)
+}
+
+// applyIdentity refreshes identity and priors for one receiver and persists it.
+func (s *Store) applyIdentity(identity Identity) Capabilities {
+	s.mu.Lock()
+	record, existed := s.byHost[identity.Host]
+	if record.Variants == nil {
+		record.Variants = map[Variant]Verdict{}
+	}
+	// A firmware update changes what a receiver accepts, which is the only
+	// honest way out of a recorded rejection. Start the observations over.
+	if existed && record.BuildRevision != "" && identity.BuildRevision != "" && record.BuildRevision != identity.BuildRevision {
+		log.Printf("[castcaps] %s firmware changed %s -> %s: discarding observed verdicts",
+			identity.Host, record.BuildRevision, identity.BuildRevision)
+		record.Variants = map[Variant]Verdict{}
+	}
+	record.Identity = identity
+	for variant, prior := range PriorFor(identity) {
+		if observed(normalizeVerdict(record.Variants[variant])) {
+			continue
+		}
+		record.Variants[variant] = prior
+	}
+	record.UpdatedAt = time.Now().UTC()
+	s.byHost[identity.Host] = record
+	copied := record.clone()
+	s.mu.Unlock()
+
+	s.persist(copied)
+	return copied
+}
+
+// Record folds an observation from real playback into the cache.
+//
+// Precedence, in one sentence: a verdict only ever wins if it is more certain
+// than what is already on file, ordered unknown < assumed < supported <
+// rejected. So an observation overwrites a prior, a prior never overwrites an
+// observation, and a rejection sticks even over an earlier success - a stall is
+// a stall, and the user watches it happen. Ensure clears observations when the
+// firmware revision changes, which is how a fixed receiver recovers.
+func (s *Store) Record(host string, variant Variant, verdict Verdict) {
+	if s == nil {
+		return
+	}
+	host = strings.TrimSpace(host)
+	if host == "" || strings.TrimSpace(string(variant)) == "" {
+		return
+	}
+	verdict = normalizeVerdict(verdict)
+	if verdict == VerdictUnknown {
+		return // learned nothing
+	}
+
+	s.mu.Lock()
+	record, existed := s.byHost[host]
+	if !existed {
+		record.Identity = Identity{Host: host, Name: host}
+	}
+	if record.Variants == nil {
+		record.Variants = map[Variant]Verdict{}
+	}
+	current := normalizeVerdict(record.Variants[variant])
+	if verdictRank(verdict) <= verdictRank(current) {
+		s.mu.Unlock()
+		return
+	}
+	record.Variants[variant] = verdict
+	record.UpdatedAt = time.Now().UTC()
+	s.byHost[host] = record
+	copied := record.clone()
+	s.mu.Unlock()
+
+	log.Printf("[castcaps] %s: %s %s -> %s", host, variant, orUnknown(current), verdict)
+	s.persist(copied)
+}
+
+func orUnknown(v Verdict) Verdict {
+	if v == VerdictUnknown {
+		return "unknown"
+	}
+	return v
+}
+
+// RefreshInBackground describes every receiver it can find on cidr and caches
+// the priors their identities imply. Safe to run at any time, including mid-cast:
+// it only issues HTTP GETs.
+func (s *Store) RefreshInBackground(ctx context.Context, cidr string) {
+	if s == nil {
+		return
+	}
+	identities := Discover(ctx, cidr)
+	log.Printf("[castcaps] discovery found %d Cast receiver(s) on %s", len(identities), cidr)
+	for _, identity := range identities {
+		s.applyIdentity(identity)
+	}
+}

--- a/backend/services/castcaps/store_test.go
+++ b/backend/services/castcaps/store_test.go
@@ -1,0 +1,333 @@
+package castcaps
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	lgHost     = "192.168.8.105"
+	dongleHost = "192.168.8.108"
+)
+
+var (
+	lgIdentity = Identity{
+		Host:          lgHost,
+		Name:          "[LG] webOS TV OLED65C2PUA",
+		BuildRevision: "1.68.cast_20250829_0200_RC13.800768591",
+		UDN:           "1b2c3d4e-5f60-4718-8293-a4b5c6d7e8f9",
+	}
+	dongleIdentity = Identity{
+		Host:          dongleHost,
+		Name:          "Avery's room TV",
+		ModelName:     "Eureka Dongle",
+		Manufacturer:  "Google Inc.",
+		BuildRevision: "1.56.291998",
+		UDN:           "9f8e7d6c-5b4a-4392-8170-6f5e4d3c2b1a",
+	}
+)
+
+// storeWith returns a store in a temp dir whose identity source is canned, so
+// no test ever contacts a receiver.
+func storeWith(t *testing.T, identities ...Identity) *Store {
+	t.Helper()
+	store := NewStore(t.TempDir())
+	byHost := map[string]Identity{}
+	for _, identity := range identities {
+		byHost[identity.Host] = identity
+	}
+	store.describeFn = func(_ context.Context, host string) (Identity, error) {
+		identity, ok := byHost[host]
+		if !ok {
+			return Identity{}, errors.New("no receiver answered")
+		}
+		return identity, nil
+	}
+	return store
+}
+
+func TestStore_Record_Precedence(t *testing.T) {
+	tests := []struct {
+		name  string
+		seed  []Verdict // applied in order before the verdict under test
+		apply Verdict
+		want  Verdict
+	}{
+		{"observation over nothing", nil, VerdictSupported, VerdictSupported},
+		{"prior over nothing", nil, VerdictAssumed, VerdictAssumed},
+		{"observation over prior", []Verdict{VerdictAssumed}, VerdictSupported, VerdictSupported},
+		{"rejection over prior", []Verdict{VerdictAssumed}, VerdictRejected, VerdictRejected},
+		{"prior never overwrites a proven variant", []Verdict{VerdictSupported}, VerdictAssumed, VerdictSupported},
+		{"prior never overwrites a rejection", []Verdict{VerdictRejected}, VerdictAssumed, VerdictRejected},
+		{"rejection overwrites proven support", []Verdict{VerdictSupported}, VerdictRejected, VerdictRejected},
+		{"support does not undo a rejection", []Verdict{VerdictRejected}, VerdictSupported, VerdictRejected},
+		{"unknown records nothing", []Verdict{VerdictAssumed}, VerdictUnknown, VerdictAssumed},
+		{"unrecognized verdict records nothing", []Verdict{VerdictSupported}, "bogus", VerdictSupported},
+		{"repeat observation is a no-op", []Verdict{VerdictSupported}, VerdictSupported, VerdictSupported},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := storeWith(t)
+			for _, seed := range tc.seed {
+				store.Record(lgHost, VariantFMP4, seed)
+			}
+			store.Record(lgHost, VariantFMP4, tc.apply)
+
+			if got := store.Lookup(lgHost).Verdict(VariantFMP4); got != tc.want {
+				t.Fatalf("verdict = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStore_Record_PersistsAndReloads(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	store.Record(dongleHost, VariantTSAACStereo, VerdictSupported)
+	store.Record(dongleHost, VariantFMP4, VerdictRejected)
+
+	reopened := NewStore(dir)
+	caps := reopened.Lookup(dongleHost)
+	if caps == nil {
+		t.Fatal("record did not survive a reopen")
+	}
+	if !caps.Supports(VariantTSAACStereo) {
+		t.Fatal("supported verdict lost")
+	}
+	if caps.Verdict(VariantFMP4) != VerdictRejected {
+		t.Fatalf("fmp4 = %q, want rejected", caps.Verdict(VariantFMP4))
+	}
+	if caps.UpdatedAt.IsZero() {
+		t.Fatal("UpdatedAt not set")
+	}
+}
+
+func TestStore_Record_IgnoresEmptyInput(t *testing.T) {
+	store := storeWith(t)
+	store.Record("", VariantFMP4, VerdictSupported)
+	store.Record("  ", VariantFMP4, VerdictSupported)
+	store.Record(lgHost, "", VerdictSupported)
+	if len(store.All()) != 0 {
+		t.Fatalf("expected no records, got %v", store.All())
+	}
+}
+
+func TestStore_Ensure_AppliesPriorsWithoutClobberingObservations(t *testing.T) {
+	store := storeWith(t, lgIdentity)
+	// A real cast proved fMP4 works and HEVC did not, before we ever described
+	// the panel.
+	store.Record(lgHost, VariantFMP4, VerdictSupported)
+	store.Record(lgHost, VariantHEVCFMP4, VerdictRejected)
+
+	caps, err := store.Ensure(context.Background(), lgHost)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if caps.Identity != lgIdentity {
+		t.Fatalf("identity = %#v, want %#v", caps.Identity, lgIdentity)
+	}
+	if caps.Verdict(VariantFMP4) != VerdictSupported {
+		t.Fatalf("prior clobbered an observation: fmp4 = %q", caps.Verdict(VariantFMP4))
+	}
+	if caps.Verdict(VariantHEVCFMP4) != VerdictRejected {
+		t.Fatalf("prior clobbered a rejection: hevc = %q", caps.Verdict(VariantHEVCFMP4))
+	}
+	// Gaps are filled from the prior, which for any non-legacy receiver is the
+	// baseline alone: a modern build earns no assumption, so 5.1 AAC and AC-3
+	// both stay unknown until a real session proves them.
+	if caps.Verdict(VariantTSAACMultichannel) != VerdictUnknown {
+		t.Fatalf("aac51 = %q, want unknown", caps.Verdict(VariantTSAACMultichannel))
+	}
+	if caps.Verdict(VariantTSAC3) != VerdictUnknown {
+		t.Fatalf("ts-ac3 = %q, want unknown", caps.Verdict(VariantTSAC3))
+	}
+	if !caps.Allows(VariantTSAACStereo) || caps.Supports(VariantTSAACStereo) {
+		t.Fatal("an assumed variant must be allowed but not supported")
+	}
+}
+
+func TestStore_Ensure_LegacyDongleEnvelope(t *testing.T) {
+	store := storeWith(t, dongleIdentity)
+	caps, err := store.Ensure(context.Background(), dongleHost)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if !caps.Allows(VariantTSAACStereo) || caps.Supports(VariantTSAACStereo) {
+		t.Fatal("baseline should be assumed, not proven")
+	}
+	for _, variant := range []Variant{VariantFMP4, VariantHEVCFMP4, VariantTSAC3, VariantTSAACMultichannel} {
+		if caps.Allows(variant) {
+			t.Fatalf("legacy dongle must not allow %s", variant)
+		}
+	}
+}
+
+func TestStore_Ensure_FirmwareChangeDiscardsObservations(t *testing.T) {
+	store := storeWith(t, dongleIdentity)
+	if _, err := store.Ensure(context.Background(), dongleHost); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	store.Record(dongleHost, VariantFMP4, VerdictRejected)
+
+	// Same box, new firmware. The observed rejection is discarded because the
+	// firmware that earned it is gone, but a newer build is still not evidence:
+	// the variant returns to unknown, not to assumed.
+	upgraded := dongleIdentity
+	upgraded.ModelName = "Chromecast HD"
+	upgraded.BuildRevision = "1.68.cast_20250829_0200_RC13.800768591"
+	store.describeFn = func(context.Context, string) (Identity, error) { return upgraded, nil }
+
+	caps, err := store.Ensure(context.Background(), dongleHost)
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if caps.Verdict(VariantFMP4) != VerdictUnknown {
+		t.Fatalf("fmp4 = %q, want unknown after the firmware that rejected it was replaced", caps.Verdict(VariantFMP4))
+	}
+	if caps.Allows(VariantFMP4) {
+		t.Fatal("a discarded rejection must not become permission")
+	}
+	if caps.BuildRevision != upgraded.BuildRevision {
+		t.Fatalf("build revision = %q, want %q", caps.BuildRevision, upgraded.BuildRevision)
+	}
+}
+
+func TestStore_Ensure_UnreachableReceiver(t *testing.T) {
+	store := storeWith(t)
+	if _, err := store.Ensure(context.Background(), "10.0.0.99"); err == nil {
+		t.Fatal("expected an error when nothing answers and nothing is cached")
+	}
+	if store.Lookup("10.0.0.99") != nil {
+		t.Fatal("a receiver that never answered must not be cached")
+	}
+
+	// With something on file, a silent receiver falls back to what we know.
+	store.Record("10.0.0.99", VariantTSAACStereo, VerdictSupported)
+	caps, err := store.Ensure(context.Background(), "10.0.0.99")
+	if err != nil {
+		t.Fatalf("Ensure with cache: %v", err)
+	}
+	if !caps.Supports(VariantTSAACStereo) {
+		t.Fatal("cached observation lost")
+	}
+}
+
+func TestStore_Ensure_EmptyHost(t *testing.T) {
+	if _, err := storeWith(t).Ensure(context.Background(), "   "); err == nil {
+		t.Fatal("expected an error for an empty host")
+	}
+}
+
+func TestStore_LookupReturnsACopy(t *testing.T) {
+	store := storeWith(t)
+	store.Record(lgHost, VariantFMP4, VerdictSupported)
+
+	caps := store.Lookup(lgHost)
+	caps.Variants[VariantFMP4] = VerdictRejected
+
+	if !store.Lookup(lgHost).Supports(VariantFMP4) {
+		t.Fatal("mutating a lookup result must not corrupt the cache")
+	}
+	if store.Lookup("10.0.0.1") != nil {
+		t.Fatal("unknown host must look up nil")
+	}
+}
+
+func TestStore_NilReceiverIsSafe(t *testing.T) {
+	var store *Store
+	if store.Lookup(lgHost) != nil {
+		t.Fatal("nil store must look up nil")
+	}
+	if store.All() != nil {
+		t.Fatal("nil store must have no records")
+	}
+	store.Record(lgHost, VariantFMP4, VerdictSupported)
+	store.RefreshInBackground(context.Background(), "192.168.8.0/24")
+	if _, err := store.Ensure(context.Background(), lgHost); err == nil {
+		t.Fatal("nil store must fail Ensure")
+	}
+}
+
+func TestStore_LoadsLegacyCacheFile(t *testing.T) {
+	dir := t.TempDir()
+	// Exactly the shape the probing version of this package wrote, including a
+	// verdict string that no longer exists.
+	legacy := `[
+	  {
+	    "receiverId": "uuid-1",
+	    "host": "192.168.8.108",
+	    "name": "Avery's room TV",
+	    "model": "Eureka Dongle",
+	    "buildVersion": "1.56.291998",
+	    "variants": {
+	      "ts-aac-stereo": "supported",
+	      "fmp4-aac-stereo": "rejected",
+	      "fmp4-hevc": "unknown"
+	    },
+	    "probedAt": "2026-08-01T22:14:05Z",
+	    "partial": true,
+	    "error": "baseline variant did not play"
+	  }
+	]`
+	if err := os.WriteFile(filepath.Join(dir, legacyCacheFile), []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed legacy cache: %v", err)
+	}
+
+	caps := NewStore(dir).Lookup(dongleHost)
+	if caps == nil {
+		t.Fatal("legacy cache entry was dropped")
+	}
+	if !caps.Supports(VariantTSAACStereo) || caps.Verdict(VariantFMP4) != VerdictRejected {
+		t.Fatalf("legacy verdicts lost: %v", caps.Variants)
+	}
+	if caps.Verdict(VariantHEVCFMP4) != VerdictUnknown {
+		t.Fatalf(`legacy "unknown" must normalize to the empty verdict, got %q`, caps.Verdict(VariantHEVCFMP4))
+	}
+	if caps.ModelName != "Eureka Dongle" || caps.BuildRevision != "1.56.291998" {
+		t.Fatalf("legacy identity lost: %#v", caps.Identity)
+	}
+	if caps.UpdatedAt.IsZero() {
+		t.Fatal("legacy probedAt should carry over as UpdatedAt")
+	}
+}
+
+func TestStore_ToleratesUnreadableCache(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, recordFileName(lgHost)), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, legacyCacheFile), []byte("nope"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	store := NewStore(dir)
+	if len(store.All()) != 0 {
+		t.Fatalf("expected the corrupt entries to be ignored, got %v", store.All())
+	}
+	// A missing directory is equally fine: nothing has been cached yet.
+	fresh := NewStore(filepath.Join(dir, "does-not-exist"))
+	if len(fresh.All()) != 0 {
+		t.Fatal("expected an empty store")
+	}
+	fresh.Record(lgHost, VariantTSAACStereo, VerdictSupported)
+	if !fresh.Lookup(lgHost).Supports(VariantTSAACStereo) {
+		t.Fatal("store should create its directory on first write")
+	}
+}
+
+func TestRecordFileName(t *testing.T) {
+	tests := map[string]string{
+		"192.168.8.105":     "receiver-192.168.8.105.json",
+		"fe80::1%25en0":     "receiver-fe80__1_25en0.json",
+		"living-room.local": "receiver-living-room.local.json",
+		"../escape":         "receiver-.._escape.json",
+	}
+	for host, want := range tests {
+		if got := recordFileName(host); got != want {
+			t.Fatalf("recordFileName(%q) = %q, want %q", host, got, want)
+		}
+	}
+}

--- a/backend/services/castcaps/testdata/device_desc_dongle.xml
+++ b/backend/services/castcaps/testdata/device_desc_dongle.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:r="urn:restful-tv-org:schemas:upnp-dd">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <URLBase>http://192.168.8.108:8008</URLBase>
+  <device>
+    <deviceType>urn:dial-multiscreen-org:device:dial:1</deviceType>
+    <friendlyName>Avery's room TV</friendlyName>
+    <manufacturer>Google Inc.</manufacturer>
+    <modelName>Eureka Dongle</modelName>
+    <UDN>uuid:9f8e7d6c-5b4a-4392-8170-6f5e4d3c2b1a</UDN>
+    <iconList>
+      <icon>
+        <mimetype>image/png</mimetype>
+        <width>98</width>
+        <height>55</height>
+        <depth>32</depth>
+        <url>/setup/icon.png</url>
+      </icon>
+    </iconList>
+    <serviceList>
+      <service>
+        <serviceType>urn:dial-multiscreen-org:service:dial:1</serviceType>
+        <serviceId>urn:dial-multiscreen-org:serviceId:dial</serviceId>
+        <controlURL>/ssdp/notfound</controlURL>
+        <eventSubURL>/ssdp/notfound</eventSubURL>
+        <SCPDURL>/ssdp/notfound</SCPDURL>
+      </service>
+    </serviceList>
+  </device>
+</root>

--- a/backend/services/castcaps/testdata/eureka_info_dongle.json
+++ b/backend/services/castcaps/testdata/eureka_info_dongle.json
@@ -1,0 +1,18 @@
+{
+  "build_version": "291998",
+  "cast_build_revision": "1.56.291998",
+  "closed_caption": {},
+  "connected": true,
+  "has_update": false,
+  "locale": "en-US",
+  "name": "Avery's room TV",
+  "release_track": "stable-channel",
+  "ssdp_udn": "9f8e7d6c-5b4a-4392-8170-6f5e4d3c2b1a",
+  "settings": {
+    "name": "Avery's room TV"
+  },
+  "time_format": 1,
+  "timezone": "America/Los_Angeles",
+  "uptime": 903412.0,
+  "version": 8
+}

--- a/backend/services/castcaps/testdata/eureka_info_lg_c2.json
+++ b/backend/services/castcaps/testdata/eureka_info_lg_c2.json
@@ -1,0 +1,16 @@
+{
+  "build_version": "270120",
+  "cast_build_revision": "1.68.cast_20250829_0200_RC13.800768591",
+  "closed_caption": {},
+  "connected": true,
+  "has_update": false,
+  "locale": "en-US",
+  "name": "[LG] webOS TV OLED65C2PUA",
+  "public_key": "trimmed",
+  "release_track": "stable-channel",
+  "ssdp_udn": "1b2c3d4e-5f60-4718-8293-a4b5c6d7e8f9",
+  "time_format": 1,
+  "timezone": "America/Los_Angeles",
+  "uptime": 48213.5,
+  "version": 9
+}


### PR DESCRIPTION
Backend support for the casting work being upstreamed on the frontend side
(godver3-org/mediastorm-frontend#7 → #10). **Independent of it** — nothing here
requires a client change to keep working, and no existing endpoint changes shape.

### What's here

- **`services/castcaps`** probes a receiver (Eureka info, UPnP device
  description), classifies it, and caches what it can decode, with priors for
  known models. `handlers/cast_capabilities` exposes that to clients.
- **`video.go`** grows an **avc-ts DLNA output**: H.264 + AC3 in a 188-byte
  transport stream for renderers that accept nothing else, plus the duration
  headers a legacy renderer needs to classify end-of-media instead of treating
  it as a user stop.
- **`hls.go`** learns cast-mode sessions: transport-stream segments, a stable
  cast timeline across transcoding jumps, and segment retention for receiver
  re-reads.
- **`hls_probe`** captures width, height, and H.264 level, so a receiver
  envelope can be evaluated before a cast starts.
- **`playback_observer`** generalises the single playback observer into a list
  so notifications and cast telemetry can both watch playback. `main.go` and the
  stream tracker move from `SetPlaybackActivityObserver` to `Add…` accordingly —
  that is the only caller-visible change, and both call sites are updated here.

### Scope
The PearTube/p2p integration this fork also carries is **deliberately excluded**;
where it touched shared files (`video.go`'s SSRF origin allowlist, the stream
tracker's auto-seeder hook) those hooks were removed rather than carried along.

### Verification
`go build ./...`, `go vet ./...`, and `go test ./...` all pass — **71 packages**,
including new tests for castcaps classification, DLNA headers, the MPEG-TS
plan, and cast-mode HLS.