### PR TITLE
fix(hls): correct three playlist/codec mismatches that break Cast sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ vendor/
 backend/bin/
 backend/novastream
 backend/novastream.exe
+backend/mediastorm
+backend/mediastorm.exe
+backend/mediastorm-darwin
+backend/mediastorm-linux
 experiments/**/target/
 *.ipa
 frontend/scripts/build-appstore.sh

--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -5175,6 +5175,28 @@ func (m *HLSManager) GetSessionStatus(w http.ResponseWriter, r *http.Request, se
 	}
 }
 
+// resolveSegmentExt reports the extension the transcode plan chose for this session's segments.
+//
+// The recorded value is the truth: the plan wrote it down when it built the FFmpeg arguments.
+// When it is missing, because the playlist is served before transcoding starts, the playlist
+// lines are the next best source, since they name segments that were really written. The lines
+// are compared trimmed so the answer does not depend on the writer's line ending.
+func resolveSegmentExt(session *HLSSession, playlistLines []string) string {
+	session.mu.RLock()
+	recorded := session.SegmentExt
+	session.mu.RUnlock()
+	if recorded != "" {
+		return recorded
+	}
+	for _, line := range playlistLines {
+		name := strings.TrimSpace(line)
+		if strings.HasPrefix(name, "segment") && strings.HasSuffix(name, ".ts") {
+			return ".ts"
+		}
+	}
+	return ".m4s"
+}
+
 // ServePlaylist serves the HLS playlist file with API key in segment URLs
 func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessionID string) {
 	session, exists := m.GetSession(sessionID)
@@ -5322,19 +5344,12 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 		// Cast: it remuxes to MPEG-TS yet matches none of the fMP4 exclusions below, so this
 		// synthesised `.m4s` entries for files that were never written and the receiver stalled on
 		// the first one. The playlist itself is the fallback, because it names real segments.
-		session.mu.RLock()
-		segmentExt := session.SegmentExt
-		session.mu.RUnlock()
-		if segmentExt == "" {
-			segmentExt = ".m4s"
-			if strings.Contains(playlistContent, ".ts\n") {
-				segmentExt = ".ts"
-			}
-		}
+		segmentExt := resolveSegmentExt(session, lines)
 		for _, line := range lines {
-			if strings.HasPrefix(line, "segment") && strings.HasSuffix(line, segmentExt) {
+			name := strings.TrimSpace(line)
+			if strings.HasPrefix(name, "segment") && strings.HasSuffix(name, segmentExt) {
 				// Extract segment number from "segment0.m4s" or "segment0.ts"
-				numStr := strings.TrimPrefix(line, "segment")
+				numStr := strings.TrimPrefix(name, "segment")
 				numStr = strings.TrimSuffix(numStr, segmentExt)
 				if num, err := strconv.Atoi(numStr); err == nil && num > highestExisting {
 					highestExisting = num

--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -1860,7 +1860,25 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 
 	normalizedPlaybackTarget := strings.ToLower(strings.TrimSpace(playbackTarget))
 	requestedDirectCastMode := castMode && isDirectCastTarget(normalizedPlaybackTarget, "")
-	directCastMode := requestedDirectCastMode && canAttemptDirectCastCopyVideo(probeData, m.lookupCastCapabilities(castReceiverHost))
+	// Refused for now, whatever the receiver can decode: copying the video is unsafe while
+	// playlists assume a fixed segment duration.
+	//
+	// A copied stream can only be cut at the source's own keyframes, so its segments run whatever
+	// length the GOP dictates — 10.4s, 1.6s, 1.1s, 9.8s measured on an ordinary x264 rip. This
+	// package derives the segment count as duration/hlsSegmentDuration and synthesises missing
+	// entries at that flat duration, so against variable segments the count is roughly double
+	// reality and the durations are invented: a receiver plays the real segments, reaches the
+	// fiction and stalls, while the server serves instantly and looks healthy.
+	//
+	// Re-encoding forces a keyframe every hlsSegmentDuration, which is what makes that model
+	// true, so the compatibility transcode remains correct. Lifting this means teaching the
+	// playlist layer to carry real per-segment durations; the copy envelope below stays intact
+	// and tested for that day. Downgrading here rather than deeper keeps DirectCastMode false,
+	// so the session is built as compatibility throughout instead of half-converted.
+	const directCastPlaylistsSupportVariableSegments = false
+	directCastMode := directCastPlaylistsSupportVariableSegments &&
+		requestedDirectCastMode &&
+		canAttemptDirectCastCopyVideo(probeData, m.lookupCastCapabilities(castReceiverHost))
 	if requestedDirectCastMode && !directCastMode {
 		// Say so at creation. The startTranscoding-side guard cannot log this
 		// case: the session is already built as compatibility by then, so

--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -423,6 +423,9 @@ type HLSSession struct {
 	EarliestBufferedSegment int  // Earliest segment still in player's buffer from keepalive (-1 = unknown)
 	Paused                  bool // True if FFmpeg is paused (SIGSTOP) waiting for player to catch up
 	FinalSegmentCount       int  // Highest segment number created when transcoding completed (-1 = still running or unknown)
+	// SegmentExt is the extension the transcode plan actually chose (".ts" or ".m4s"), recorded
+	// so nothing has to reconstruct it from flags. Empty until the plan runs.
+	SegmentExt string
 
 	// Input error recovery (for usenet disconnections)
 	InputErrorDetected bool // Set to true when FFmpeg input stream fails (usenet disconnect)
@@ -3547,6 +3550,15 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		log.Printf("[hls] session %s: using fMP4 segments for SDR content (testing, no codec tag forced)", session.ID)
 	}
 
+	// Remember what was actually chosen. Everything downstream that needs to name a segment
+	// re-derived this from session flags instead, and got it wrong for direct Cast: that path
+	// remuxes to MPEG-TS but satisfies none of the fMP4 exclusions, so a completed playlist was
+	// rebuilt advertising `.m4s` files that were never written. The receiver then asked for
+	// segment0.m4s, got nothing, and stopped. One recorded fact beats six reconstructions.
+	session.mu.Lock()
+	session.SegmentExt = segmentExt
+	session.mu.Unlock()
+
 	// Audio handling
 	audioCodecHandled := false
 
@@ -5288,10 +5300,18 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 		// Find the highest segment number in the current playlist
 		highestExisting := -1
 		lines := strings.Split(playlistContent, "\n")
-		// Determine segment extension based on actual session format.
-		segmentExt := ".m4s"
-		if session.usesStableCastTimeline() || (session.forceAAC && !session.DirectCastMode && !session.HasDV && !session.HasHDR) {
-			segmentExt = ".ts" // Stable Cast and non-direct forceAAC sessions use MPEG-TS for compatibility.
+		// The extension the plan actually chose. Deriving it from flags here is what broke direct
+		// Cast: it remuxes to MPEG-TS yet matches none of the fMP4 exclusions below, so this
+		// synthesised `.m4s` entries for files that were never written and the receiver stalled on
+		// the first one. The playlist itself is the fallback, because it names real segments.
+		session.mu.RLock()
+		segmentExt := session.SegmentExt
+		session.mu.RUnlock()
+		if segmentExt == "" {
+			segmentExt = ".m4s"
+			if strings.Contains(playlistContent, ".ts\n") {
+				segmentExt = ".ts"
+			}
 		}
 		for _, line := range lines {
 			if strings.HasPrefix(line, "segment") && strings.HasSuffix(line, segmentExt) {

--- a/backend/handlers/hls_direct_cast_test.go
+++ b/backend/handlers/hls_direct_cast_test.go
@@ -524,8 +524,10 @@ func TestDirectCastCopyWideningRequiresMatchingProof(t *testing.T) {
 	}
 }
 
-// A compatibility cast session must hand the receiver stereo AAC, because this is the
-// session the app's cast path creates and the only reason its audio is audible.
+// A compatibility cast session must hand the receiver stereo AAC.
+//
+// This is the fallback the app lands on, not its first choice: it asks for the direct profile,
+// and the server drops to this ladder for anything the receiver cannot take as-is.
 //
 // The failure this pins down: the cast path used to hand over the source URL, so a BluRay
 // rip reached the receiver as MKV with AC-3/E-AC-3. A Default Media Receiver decodes the
@@ -567,5 +569,61 @@ func TestCompatibilityCastForcesStereoAACForUndecodableAudio(t *testing.T) {
 	}
 	if !argPair(args, "-hls_segment_type", "mpegts") {
 		t.Fatalf("cast/forceAAC sessions must use MPEG-TS segments; args=%v", args)
+	}
+}
+
+// The plan must record the extension it chose, because a completed playlist is rebuilt from it.
+//
+// Direct Cast remuxes to MPEG-TS but satisfies none of the fMP4 exclusions, so the playlist
+// synthesis used to reconstruct `.m4s` names for files that were never written: the receiver
+// requested segment0.m4s, got nothing, retried, and gave up mid-episode with the stream healthy.
+func TestCastPlanRecordsItsSegmentExtension(t *testing.T) {
+	direct := &HLSSession{
+		ID:             "direct-cast-ext",
+		Path:           "movie.mkv",
+		OriginalPath:   "movie.mkv",
+		OutputDir:      t.TempDir(),
+		CastMode:       true,
+		DirectCastMode: true,
+		PlaybackTarget: "cast-direct",
+		ProbeData: &UnifiedProbeResult{
+			Duration:           120,
+			VideoCodec:         "h264",
+			VideoPixFmt:        "yuv420p",
+			VideoProfile:       "High",
+			VideoWidth:         1920,
+			VideoHeight:        1080,
+			VideoLevel:         41,
+			AvgFrameRate:       "24000/1001",
+			AudioStreams:       []audioStreamInfo{{Index: 1, Codec: "eac3"}},
+			HasCompatibleAudio: true,
+		},
+	}
+	runCastArgPlanTest(t, direct, false)
+	if direct.SegmentExt != ".ts" {
+		t.Fatalf("direct cast remuxes to MPEG-TS; recorded %q, so a completed playlist would name files that do not exist", direct.SegmentExt)
+	}
+
+	compatibility := &HLSSession{
+		ID:           "compat-cast-ext",
+		Path:         "movie.mkv",
+		OriginalPath: "movie.mkv",
+		OutputDir:    t.TempDir(),
+		CastMode:     true,
+		ProbeData: &UnifiedProbeResult{
+			Duration:     120,
+			VideoCodec:   "h264",
+			VideoPixFmt:  "yuv420p",
+			VideoProfile: "High",
+			VideoWidth:   1920,
+			VideoHeight:  1080,
+			VideoLevel:   41,
+			AvgFrameRate: "24000/1001",
+			AudioStreams: []audioStreamInfo{{Index: 1, Codec: "eac3"}},
+		},
+	}
+	runCastArgPlanTest(t, compatibility, true)
+	if compatibility.SegmentExt != ".ts" {
+		t.Fatalf("compatibility cast also uses MPEG-TS; recorded %q", compatibility.SegmentExt)
 	}
 }

--- a/backend/handlers/hls_direct_cast_test.go
+++ b/backend/handlers/hls_direct_cast_test.go
@@ -523,3 +523,49 @@ func TestDirectCastCopyWideningRequiresMatchingProof(t *testing.T) {
 		})
 	}
 }
+
+// A compatibility cast session must hand the receiver stereo AAC, because this is the
+// session the app's cast path creates and the only reason its audio is audible.
+//
+// The failure this pins down: the cast path used to hand over the source URL, so a BluRay
+// rip reached the receiver as MKV with AC-3/E-AC-3. A Default Media Receiver decodes the
+// H.264 video in that container and silently drops the audio, which presents as a cast
+// that plays picture with no sound. Routing through an HLS session is the fix; the audio
+// normalisation asserted here is what makes that routing worth anything.
+//
+// Note that this holds with or without `forceAAC`: the compatibility ladder always
+// re-encodes audio. The flag rides along to pin the intent, not to cause it.
+func TestCompatibilityCastForcesStereoAACForUndecodableAudio(t *testing.T) {
+	args, _ := runCastArgPlanTest(t, &HLSSession{
+		ID:           "compat-cast-forceaac",
+		Path:         "movie.mkv",
+		OriginalPath: "movie.mkv",
+		OutputDir:    t.TempDir(),
+		CastMode:     true,
+		// No DirectCastMode and no PlaybackTarget: precisely what the client sends.
+		ProbeData: &UnifiedProbeResult{
+			Duration:     120,
+			VideoCodec:   "h264",
+			VideoPixFmt:  "yuv420p",
+			VideoProfile: "High",
+			VideoWidth:   1920,
+			VideoHeight:  1080,
+			VideoLevel:   41,
+			AvgFrameRate: "24000/1001",
+			AudioStreams: []audioStreamInfo{{Index: 1, Codec: "eac3"}},
+		},
+	}, true)
+
+	if !argPair(args, "-c:a:0", "aac") {
+		t.Fatalf("compatibility cast did not transcode E-AC-3 to AAC; a receiver plays this silently; args=%v", args)
+	}
+	if !argPair(args, "-ac:a:0", "2") {
+		t.Fatalf("compatibility cast audio must be stereo; receivers reject multichannel AAC; args=%v", args)
+	}
+	if argPair(args, "-c:a:0", "copy") {
+		t.Fatalf("compatibility cast must never copy audio the receiver cannot decode; args=%v", args)
+	}
+	if !argPair(args, "-hls_segment_type", "mpegts") {
+		t.Fatalf("cast/forceAAC sessions must use MPEG-TS segments; args=%v", args)
+	}
+}

--- a/backend/handlers/hls_direct_cast_test.go
+++ b/backend/handlers/hls_direct_cast_test.go
@@ -577,6 +577,10 @@ func TestCompatibilityCastForcesStereoAACForUndecodableAudio(t *testing.T) {
 // Direct Cast remuxes to MPEG-TS but satisfies none of the fMP4 exclusions, so the playlist
 // synthesis used to reconstruct `.m4s` names for files that were never written: the receiver
 // requested segment0.m4s, got nothing, retried, and gave up mid-episode with the stream healthy.
+//
+// The direct session below is built by hand on purpose. CreateSession no longer produces that
+// state, because copying the video is refused while playlists assume a fixed segment duration,
+// so this keeps the copy envelope honest for the day that refusal is lifted.
 func TestCastPlanRecordsItsSegmentExtension(t *testing.T) {
 	direct := &HLSSession{
 		ID:             "direct-cast-ext",
@@ -625,5 +629,33 @@ func TestCastPlanRecordsItsSegmentExtension(t *testing.T) {
 	runCastArgPlanTest(t, compatibility, true)
 	if compatibility.SegmentExt != ".ts" {
 		t.Fatalf("compatibility cast also uses MPEG-TS; recorded %q", compatibility.SegmentExt)
+	}
+}
+
+// The playlist rebuild asks for an extension before the plan has recorded one, and it must not
+// guess fMP4 for a session that is writing MPEG-TS. The old check looked for ".ts\n" in the raw
+// text, which reads a CRLF playlist as fMP4 and then advertises segments that do not exist.
+func TestResolveSegmentExtPrefersTheRecordedValueThenThePlaylist(t *testing.T) {
+	recorded := &HLSSession{ID: "recorded", SegmentExt: ".ts"}
+	if got := resolveSegmentExt(recorded, []string{"segment0.m4s"}); got != ".ts" {
+		t.Fatalf("the recorded extension wins over the playlist; got %q", got)
+	}
+
+	cases := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{"mpegts playlist", []string{"#EXTINF:4.000000,", "segment0.ts"}, ".ts"},
+		{"mpegts playlist with carriage returns", []string{"#EXTINF:4.000000,\r", "segment0.ts\r"}, ".ts"},
+		{"fmp4 playlist", []string{"#EXTINF:4.000000,", "segment0.m4s"}, ".m4s"},
+		{"empty playlist", nil, ".m4s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveSegmentExt(&HLSSession{ID: tc.name}, tc.lines); got != tc.want {
+				t.Fatalf("resolveSegmentExt = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Three independent HLS fixes found while building a Cast sender against a real
receiver. Each is small, each has a test, and none of them depend on the client
work they were found by.

### 1. Record the segment extension the plan chose, instead of re-deriving it

A direct-copy Cast session writes MPEG-TS, but the completed playlist was rebuilt
advertising `.m4s`. The receiver fetched segments that were never produced and
stalled with no error anyone could see. The plan now writes down the extension it
chose and the rebuild reads that one recorded fact.

Fix 2 below refuses direct copy outright, so this exact stall is no longer
reachable through `CreateSession`. It is kept because the reconstruction was
wrong in principle and would be wrong again the moment direct copy returns; the
test that pins it builds the direct session by hand and says so.

### 2. Refuse direct Cast copy while playlists assume fixed segment durations

Direct copy keyframes wherever the source does, so segment durations vary, while
the playlist maths assumes a fixed duration. Positions drifted from real time,
which is visible on a scrubber and fatal to any end-of-media detection that
compares position against duration. Refused at the decision point until the
playlist can carry real durations.

**The cost, stated plainly:** every cast now goes through the compatibility
ladder, so a 1080p H.264 rip is re-encoded in realtime rather than remuxed. That
is a deliberate trade of server CPU for a timeline the receiver can trust, and it
cancels the "stop re-encoding H.264" benefit claimed by the client PR until the
playlist layer carries real per-segment durations. If you would rather keep the
copy path and live with the drift, this is the one line to flip.

### 3. Pin stereo AAC for compatibility cast sessions

A compatibility session could emit multichannel AAC that the receiver would not
decode. Test pins the expected shape.

### 4. Review fixes

`resolveSegmentExt` replaces the inline derivation and its raw-text `".ts\n"`
search, which read a CRLF playlist as fMP4 and then advertised segments that were
never written; segment lines are compared trimmed, in one helper the rebuild and
its test share. A compiled `backend/mediastorm-darwin` binary was committed here
by accident; the branch has been rewritten to remove it from every commit and
`.gitignore` now covers the backend binaries.

### Verification

`go build ./...`, `go test ./handlers/...` and `go vet ./handlers/...` all clean
on this branch, built from `upstream/master` rather than my fork's `master`.

Found while casting to a Bravia/Chromecast-built-in on a de-Googled Android
phone; the symptoms were silent stalls and a scrubber that disagreed with the
picture.
