### PR TITLE
fix(admin): polish dashboard update and scope controls

### DIFF
--- a/backend/handlers/admin_templates/settings.html
+++ b/backend/handlers/admin_templates/settings.html
@@ -570,6 +570,11 @@
     font-size: 0.75rem;
     font-weight: 600;
     cursor: pointer;
+    color-scheme: dark;
+}
+.settings-scope-select-wrap option {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
 }
 .settings-scope-server-btn.active,
 .settings-scope-select-wrap.active {

--- a/backend/handlers/admin_templates/status.html
+++ b/backend/handlers/admin_templates/status.html
@@ -153,9 +153,10 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin: 0 0 0.25rem;
-    font-size: 0.95rem;
+    margin: 0 0 0.5rem;
+    font-size: 0.8125rem;
     font-weight: 700;
+    line-height: 1.25;
 }
 
 .dashboard-update-title svg {
@@ -165,10 +166,41 @@
     flex: 0 0 auto;
 }
 
-.dashboard-update-banner p {
-    margin: 0;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+.dashboard-update-versions {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    flex-wrap: wrap;
+}
+
+.dashboard-update-version {
+    display: inline-grid;
+    gap: 0.0625rem;
+}
+
+.dashboard-update-version-label {
+    color: var(--text-muted);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.dashboard-update-version strong {
+    color: var(--text-primary);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.dashboard-update-arrow {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.dashboard-update-instruction {
+    margin: 0.4rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.6875rem;
 }
 
 .dashboard-update-dismiss {
@@ -740,6 +772,31 @@ body.numbers-station-open {
     gap: 1.25rem;
 }
 
+.active-streams-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+}
+
+.active-streams-scroll::-webkit-scrollbar {
+    height: 8px;
+}
+
+.active-streams-scroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.active-streams-scroll::-webkit-scrollbar-thumb {
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background: var(--border);
+    background-clip: padding-box;
+}
+
+.active-streams-scroll::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+    background-clip: padding-box;
+}
+
 @media (max-width: 760px) {
     .donation-banner {
         grid-template-columns: 1fr;
@@ -842,11 +899,22 @@ body.numbers-station-open {
                 <path d="M21 12a9 9 0 1 1-2.64-6.36"/>
                 <polyline points="21 3 21 9 15 9"/>
             </svg>
-            Backend update available
+            Backend update
         </h2>
-        <p id="dashboardUpdateMessage">A newer backend release is available.</p>
+        <div class="dashboard-update-versions" aria-label="Backend version change">
+            <span class="dashboard-update-version">
+                <span class="dashboard-update-version-label">Current</span>
+                <strong id="dashboardUpdateCurrent">—</strong>
+            </span>
+            <span class="dashboard-update-arrow" aria-hidden="true">→</span>
+            <span class="dashboard-update-version">
+                <span class="dashboard-update-version-label">Latest</span>
+                <strong id="dashboardUpdateLatest">—</strong>
+            </span>
+        </div>
+        <p class="dashboard-update-instruction">Update through Docker.</p>
     </div>
-    <span class="status-badge warning">Update Available</span>
+    <span class="status-badge warning">Available</span>
     <button class="dashboard-update-dismiss" type="button" aria-label="Dismiss backend update notification" title="Dismiss" onclick="dismissDashboardUpdateBanner()">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <line x1="18" y1="6" x2="6" y2="18"/>
@@ -2347,8 +2415,9 @@ body.numbers-station-open {
 
     async function loadDashboardUpdateNotification() {
         const banner = document.getElementById('dashboardUpdateBanner');
-        const message = document.getElementById('dashboardUpdateMessage');
-        if (!banner || !message) return;
+        const current = document.getElementById('dashboardUpdateCurrent');
+        const latest = document.getElementById('dashboardUpdateLatest');
+        if (!banner || !current || !latest) return;
         try {
             const response = await fetch(basePath + '/api/updates/status', { credentials: 'same-origin' });
             if (!response.ok) return;
@@ -2372,7 +2441,8 @@ body.numbers-station-open {
                 return;
             }
 
-            message.textContent = `Running backend ${currentLabel}; latest release is ${latestLabel}. Update through Docker or your deployment tooling.`;
+            current.textContent = currentLabel;
+            latest.textContent = latestLabel;
             banner.hidden = false;
         } catch (error) {
             console.warn('Failed to load dashboard update status:', error);
@@ -2732,7 +2802,7 @@ body.numbers-station-open {
     }
 
     function renderTableView(streams) {
-        return '<div class="table-container"><table><thead><tr><th>Media</th><th>Service</th><th>Filename</th><th>Profile(s)</th><th>Status</th><th>Progress</th><th>Speed</th><th>Transferred</th><th>Started</th><th></th></tr></thead><tbody>' +
+        return '<div class="table-container active-streams-scroll"><table><thead><tr><th>Media</th><th>Service</th><th>Filename</th><th>Profile(s)</th><th>Status</th><th>Progress</th><th>Speed</th><th>Transferred</th><th>Started</th><th></th></tr></thead><tbody>' +
             streams.map(stream => {
                 const streamId = stream.id || '';
                 const progress = stream.percent_watched || 0;

--- a/backend/handlers/admin_ui_internal_test.go
+++ b/backend/handlers/admin_ui_internal_test.go
@@ -724,6 +724,67 @@ func TestAdminDashboardBasicViewKeepsOnlyUserActivityCards(t *testing.T) {
 	}
 }
 
+func TestAdminDashboardUpdateNoticeUsesCompactVersionFields(t *testing.T) {
+	templateBytes, err := adminTemplates.ReadFile("admin_templates/status.html")
+	if err != nil {
+		t.Fatalf("read status template: %v", err)
+	}
+	source := string(templateBytes)
+
+	for _, marker := range []string{
+		`class="dashboard-update-versions"`,
+		`id="dashboardUpdateCurrent"`,
+		`id="dashboardUpdateLatest"`,
+		`class="dashboard-update-instruction">Update through Docker.`,
+		`current.textContent = currentLabel;`,
+		`latest.textContent = latestLabel;`,
+	} {
+		if !strings.Contains(source, marker) {
+			t.Fatalf("status template missing compact update marker %q", marker)
+		}
+	}
+	if strings.Contains(source, `message.textContent = `) {
+		t.Fatal("dashboard update notice still builds an unstructured sentence")
+	}
+}
+
+func TestAdminDashboardStylesOnlyActiveStreamScrollbar(t *testing.T) {
+	templateBytes, err := adminTemplates.ReadFile("admin_templates/status.html")
+	if err != nil {
+		t.Fatalf("read status template: %v", err)
+	}
+	source := string(templateBytes)
+
+	for _, marker := range []string{
+		`class="table-container active-streams-scroll"`,
+		`.active-streams-scroll {`,
+		`scrollbar-color: var(--border) transparent;`,
+		`.active-streams-scroll::-webkit-scrollbar-thumb`,
+	} {
+		if !strings.Contains(source, marker) {
+			t.Fatalf("status template missing scoped active-stream scrollbar marker %q", marker)
+		}
+	}
+}
+
+func TestAdminSettingsScopeOptionsKeepDarkThemeContrast(t *testing.T) {
+	templateBytes, err := adminTemplates.ReadFile("admin_templates/settings.html")
+	if err != nil {
+		t.Fatalf("read settings template: %v", err)
+	}
+	source := string(templateBytes)
+
+	for _, marker := range []string{
+		`.settings-scope-select-wrap option {`,
+		`background: var(--bg-secondary);`,
+		`color: var(--text-primary);`,
+	} {
+		if !strings.Contains(source, marker) {
+			t.Fatalf("settings template missing scope-option contrast marker %q", marker)
+		}
+	}
+}
+
 func TestAdminDashboardWatchTimeStacksOnNarrowViewports(t *testing.T) {
 	templateBytes, err := adminTemplates.ReadFile("admin_templates/status.html")
 	if err != nil {


### PR DESCRIPTION
## Summary

- replace the verbose backend update sentence with compact current/latest version fields
- style only the active-stream table scrollbar to match the admin theme
- keep native person/device dropdown options readable against the dark settings UI
- add regression coverage for each UI behavior

## Testing

- `go test ./handlers -run 'TestAdminDashboard(UpdateNoticeUsesCompactVersionFields|StylesOnlyActiveStreamScrollbar)|TestAdminSettingsScopeOptionsKeepDarkThemeContrast'`
- `go test ./...` progressed through handlers and the reported service packages without failures, but a later package did not complete and the run was stopped after several minutes

## Scope

The notification navigation cleanup is intentionally excluded because upstream already contains it in `518fd1a`.
