### PR TITLE
fix(hls): state the WebVTT-to-MPEG-TS offset a cast receiver cannot guess

### DIFF
--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -427,6 +427,15 @@ type HLSSession struct {
 	// so nothing has to reconstruct it from flags. Empty until the plan runs.
 	SegmentExt string
 
+	// SubtitleTimestampBaseSeconds is where this session's MPEG-TS timeline starts, which is not
+	// where its sidecar WebVTT starts. FFmpeg's TS muxer preloads by 1.4s unless told otherwise,
+	// while an extracted VTT is always 0-based, so a player that maps WebVTT 0 onto TS 0 shows
+	// every cue 1.4s early. The web path avoids it by pinning the video to a zero origin
+	// (`-muxpreload 0`); a cast cannot, because a stable receiver timeline needs
+	// `-output_ts_offset`. Recorded here so the subtitle response can state the offset
+	// explicitly, rather than have anything reconstruct it from ffmpeg flags.
+	SubtitleTimestampBaseSeconds float64
+
 	// Input error recovery (for usenet disconnections)
 	InputErrorDetected bool // Set to true when FFmpeg input stream fails (usenet disconnect)
 	RecoveryAttempts   int  // Number of times we've attempted to recover this session
@@ -562,6 +571,10 @@ const (
 
 	// Matroska-specific tuning for pipe-based seeks
 	matroskaHeaderPrefixBytes int64 = 2 * 1024 * 1024 // copy 2MB of header metadata
+	// mpegtsDefaultPreloadSeconds is where FFmpeg's MPEG-TS muxer starts its clock when nothing
+	// overrides it: 1.4s, i.e. a first PTS of 126000 at 90kHz. Verified against a produced
+	// segment (`audio start_pts=126000`), not assumed.
+	mpegtsDefaultPreloadSeconds = 1.4
 	matroskaSeekBackoffBytes  int64 = 8 * 1024 * 1024 // request a little earlier to land on cluster boundary
 	matroskaMaxClusterScan    int64 = 32 * 1024 * 1024
 
@@ -3649,6 +3662,21 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 		args = append(args, "-muxpreload", "0", "-muxdelay", "0")
 	}
 
+	// Whatever the flags above settled on, state the resulting TS origin once. `-muxpreload 0`
+	// pins it to zero; otherwise the muxer preloads by its default 1.4s, and a stable cast
+	// timeline adds the `-output_ts_offset` applied earlier. A sidecar VTT is 0-based either way,
+	// so this is exactly the correction its response has to carry.
+	subtitleTimestampBase := mpegtsDefaultPreloadSeconds
+	if webSubtitleRendition {
+		subtitleTimestampBase = 0
+	}
+	if stableCastMode && castSegmentStartNumber > 0 {
+		subtitleTimestampBase += float64(castSegmentStartNumber) * hlsSegmentDuration
+	}
+	session.mu.Lock()
+	session.SubtitleTimestampBaseSeconds = subtitleTimestampBase
+	session.mu.Unlock()
+
 	// Subtitle handling: All subtitles are served via sidecar VTT files for consistent overlay rendering.
 	// - fMP4 (Dolby Vision/HDR): Extract ALL text-based tracks upfront as additional ffmpeg outputs
 	// - MPEG-TS: On-demand extraction via extractSubtitleTrack when a track is requested
@@ -6077,7 +6105,7 @@ func (m *HLSManager) ServeSubtitleTrack(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Post-process VTT to merge karaoke character cues (from ASS conversion)
-	processedContent := mergeKaraokeCues(string(content))
+	processedContent := withWebVTTTimestampMap(mergeKaraokeCues(string(content)), session.subtitleTimestampBase())
 
 	w.Header().Set("Content-Type", "text/vtt; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache") // Don't cache since file is growing
@@ -6094,6 +6122,37 @@ func (m *HLSManager) ServeSubtitleTrack(w http.ResponseWriter, r *http.Request, 
 
 	w.Write([]byte(processedContent))
 	log.Printf("[hls] served subtitles for session %s track %d, size=%d bytes", sessionID, requestedTrack, len(processedContent))
+}
+
+// subtitleTimestampBase reports where this session's MPEG-TS clock starts, in seconds.
+func (s *HLSSession) subtitleTimestampBase() float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.SubtitleTimestampBaseSeconds
+}
+
+// withWebVTTTimestampMap states the WebVTT-to-MPEG-TS alignment inside the cue file, which is the
+// only way an HLS client can learn it.
+//
+// Our own overlay is told the same thing out of band, through `X-Subtitle-Start-Offset`, but a
+// Cast receiver never sees our headers: it reads the playlist and the VTT and nothing else. With
+// no `X-TIMESTAMP-MAP` it assumes WebVTT zero is TS zero, and since the muxer's clock starts at
+// 1.4s every cue lands 1.4s early — visible on screen, and worse on a stable cast timeline where
+// the offset is a whole run of segments.
+//
+// Left alone when the file already carries a map, or when it has no header to attach one to.
+func withWebVTTTimestampMap(content string, baseSeconds float64) string {
+	if baseSeconds <= 0 || strings.Contains(content, "X-TIMESTAMP-MAP") {
+		return content
+	}
+	trimmed := strings.TrimLeft(content, "\ufeff")
+	if !strings.HasPrefix(trimmed, "WEBVTT") {
+		return content
+	}
+	rest := trimmed[len("WEBVTT"):]
+	// 90kHz is the MPEG-TS clock WebVTT maps onto, fixed by the container.
+	mapping := fmt.Sprintf("\nX-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:%d", int64(math.Round(baseSeconds*90000)))
+	return "WEBVTT" + mapping + rest
 }
 
 func (s *HLSSession) subtitleExtractionOffset(track int) (float64, bool) {

--- a/backend/handlers/hls_subtitle_timestamp_map_test.go
+++ b/backend/handlers/hls_subtitle_timestamp_map_test.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// A Cast receiver reads the playlist and the VTT and nothing else: our X-Subtitle-Start-Offset
+// header is invisible to it. Without an in-band map it assumes WebVTT zero is TS zero, and the
+// muxer's clock starts at 1.4s, so every cue lands 1.4s early on the screen.
+func TestSubtitleResponseStatesItsTimestampBase(t *testing.T) {
+	const cues = "WEBVTT\n\n00:08.989 --> 00:10.574\nWhat's up, guys?\n"
+
+	mapped := withWebVTTTimestampMap(cues, mpegtsDefaultPreloadSeconds)
+	want := "WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:126000\n\n00:08.989 --> 00:10.574\nWhat's up, guys?\n"
+	if mapped != want {
+		t.Fatalf("expected the 1.4s preload stated as 126000 ticks:\n got %q\nwant %q", mapped, want)
+	}
+
+	// A stable cast timeline starts a whole run of segments in, and the same correction has to
+	// carry that too, or the drift is seconds rather than milliseconds.
+	stable := withWebVTTTimestampMap(cues, mpegtsDefaultPreloadSeconds+10*hlsSegmentDuration)
+	if want := "MPEGTS:1926000"; !strings.Contains(stable, want) {
+		t.Fatalf("stable-timeline base not carried; wanted %s in %q", want, stable)
+	}
+}
+
+func TestSubtitleResponseLeavesAlreadyAlignedContentAlone(t *testing.T) {
+	// The web path pins the video to a zero origin, so its VTT needs no correction at all.
+	zeroBased := "WEBVTT\n\n00:01.000 --> 00:02.000\nhello\n"
+	if got := withWebVTTTimestampMap(zeroBased, 0); got != zeroBased {
+		t.Fatalf("a zero-origin session must not be rewritten; got %q", got)
+	}
+
+	already := "WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:900000\n\n00:01.000 --> 00:02.000\nhi\n"
+	if got := withWebVTTTimestampMap(already, mpegtsDefaultPreloadSeconds); got != already {
+		t.Fatalf("an existing map must win; got %q", got)
+	}
+
+	// Extraction has produced nothing parseable yet: there is no header to attach a map to.
+	if got := withWebVTTTimestampMap("", mpegtsDefaultPreloadSeconds); got != "" {
+		t.Fatalf("empty content must be left as is; got %q", got)
+	}
+}


### PR DESCRIPTION
Subtitles cast to a Chromecast render about 1.4 seconds early. The same file is correctly timed in the app, so it is not the subtitle track.

## Why

Sidecar VTTs are 0-based. The MPEG-TS muxer starts its clock at 1.4s — measured, not assumed:

```
$ ffprobe -show_entries stream=codec_type,start_pts,start_time segment0.ts
video,127920,1.421333
audio,126000,1.400000
```

Anything that maps WebVTT zero onto TS zero therefore shows every cue 1.4s early. This codebase already solves that for the web player, by pinning the video to a zero origin:

```go
// Pin the video PTS to a ~0 origin so the same-pass WebVTT (also 0-based) aligns with the
// video timeline the player exposes.
if webSubtitleRendition {
	args = append(args, "-muxpreload", "0", "-muxdelay", "0")
}
```

A cast cannot take that branch, because a stable receiver timeline needs `-output_ts_offset`.

The offset is already communicated to *our* overlay out of band, through the `X-Subtitle-Start-Offset` response header. A Cast receiver never sees our headers — it reads the playlist and the VTT and nothing else. `X-TIMESTAMP-MAP` is the in-band mechanism for exactly this, and it was not emitted anywhere in the tree.

## What this does

Records the TS origin when the transcode plan runs, rather than reconstructing it from ffmpeg flags at serve time: zero when `-muxpreload 0` pinned it, otherwise the muxer's 1.4s default, **plus** any `-output_ts_offset`. That last term matters — on a stable cast timeline the offset is a whole run of segments, so the drift there is seconds rather than milliseconds.

The subtitle response then states it:

```
WEBVTT
X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:126000
```

Files that already carry a map are left alone, as are zero-origin sessions (so the web path is untouched). Our own overlay is unaffected: its parser skips header lines until the first cue.

## Verification

`go build ./...`, `go vet ./handlers/` and `go test ./handlers/...` all clean on this branch, built from `upstream/master` rather than my fork's master.

Three assertions added, covering the 1.4s default, the stable-timeline case, and the leave-alone paths. One of them caught an arithmetic mistake in my own expected value while I wrote it, which is why the stable-timeline case is pinned explicitly.

Found and confirmed on hardware: casting to a Chromecast built-in TV from a de-Googled Android phone, subtitles were visibly early before and line up with the audio after.

## Note on scope

The sender-side half of this — a receiver has to be *told* to activate a text track, since a `DEFAULT=YES,AUTOSELECT=YES` rendition is enumerated inactive and never fetched — is a client change and is not in this PR. Without both, cast subtitles either do not appear at all or appear early.
