### PR TITLE
diag(backend): surface a starving HLS transcode's upstream in the logs

### DIFF
--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -118,6 +118,22 @@ func (d *debugReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
+const (
+	// Throttle once the transcode is this many segments ahead of the player.
+	throttleStartThreshold = 15
+
+	// A trickling source never blocks a single read long enough to look stalled,
+	// so delivery rate is sampled over a window and compared against what the
+	// source needs to sustain real-time playback. The headroom, consecutive-window
+	// requirement and cooldown mirror ObserveUpstreamThroughput so both streaming
+	// paths behave the same way.
+	hlsUpstreamSampleWindow     = 5 * time.Second
+	hlsUpstreamHeadroom         = 1.25
+	hlsUpstreamLowSamplesNeeded = 2
+	hlsUpstreamSignalCooldown   = 30 * time.Second
+	hlsUpstreamMinRequiredBps   = int64(1_000_000)
+)
+
 // throttledReader wraps an io.Reader and slows down reads when ffmpeg is
 // generating segments faster than the player is consuming them.
 // This prevents excessive disk usage from buffered segments.
@@ -126,6 +142,21 @@ type throttledReader struct {
 	session       *HLSSession
 	lastThrottle  time.Time
 	throttleCount int64
+	// upstream measures only the blocking upstream read. The deliberate throttle
+	// sleep below is excluded, so a session that is merely far enough ahead to be
+	// slowed down is never mistaken for a starved one.
+	upstream pipelineBlockWatch
+
+	// Delivery-rate sampling. activeRead accumulates only time spent inside the
+	// upstream read, so throttle sleeps and client backpressure cannot depress the
+	// measured rate; what remains is what the source is actually capable of.
+	requiredBps    int64
+	windowStart    time.Time
+	windowBytes    int64
+	activeRead     time.Duration
+	lowSamples     int
+	lastLowSignal  time.Time
+	onSlowUpstream func(actualBps, requiredBps int64)
 }
 
 // throttlingProxy is an HTTP server that proxies requests to a remote URL
@@ -244,6 +275,23 @@ func (p *throttlingProxy) handleStream(w http.ResponseWriter, r *http.Request) {
 
 	// Wrap with throttled reader and copy to response
 	throttled := newThrottledReader(resp.Body, p.session)
+	// The rate the source must sustain is a property of the source, so it is derived
+	// from the file rather than from client telemetry: an HLS transcode has to read
+	// roughly one second of media per second regardless of what the receiver reports.
+	throttled.requiredBps = hlsSourceRequiredBps(hlsUpstreamTotalBytes(resp), p.session)
+	throttled.onSlowUpstream = func(actualBps, requiredBps int64) {
+		reportHLSSlowUpstream(p.session, actualBps, requiredBps)
+	}
+	stopStarvationWatch := monitorPipelineStarvation(
+		r.Context(),
+		&throttled.upstream,
+		pipelineStarvationTimeout,
+		pipelineStarvationCheckInterval,
+		func(blockedFor time.Duration) bool {
+			return reportHLSUpstreamStarvation(p.session, blockedFor)
+		},
+	)
+	defer stopStarvationWatch()
 	_, err = io.Copy(w, throttled)
 	if err != nil && err != context.Canceled {
 		log.Printf("[hls] session %s: proxy copy error: %v", p.session.ID, err)
@@ -321,7 +369,6 @@ func (t *throttledReader) Read(p []byte) (n int, err error) {
 		bufferAhead := highestSegment - effectiveMaxRequested
 
 		// Throttle when 15+ segments ahead (~30 seconds at 2s/segment)
-		const throttleStartThreshold = 15
 		if bufferAhead > throttleStartThreshold {
 			excessSegments := bufferAhead - throttleStartThreshold
 			delayMs := 500 + (excessSegments * 100) // 500ms base + 100ms per excess segment
@@ -343,7 +390,134 @@ func (t *throttledReader) Read(p []byte) (n int, err error) {
 		}
 	}
 
-	return t.r.Read(p)
+	t.upstream.begin()
+	readStart := time.Now()
+	n, err = t.r.Read(p)
+	readElapsed := time.Since(readStart)
+	t.upstream.end()
+
+	t.sampleUpstreamRate(n, readElapsed)
+	return n, err
+}
+
+// sampleUpstreamRate reports a source that is delivering, but too slowly to keep a
+// real-time transcode fed. Only time spent inside the upstream read is counted, so
+// a session slowed by its own throttle still measures the source's true rate.
+func (t *throttledReader) sampleUpstreamRate(n int, readElapsed time.Duration) {
+	if t.requiredBps < hlsUpstreamMinRequiredBps || t.onSlowUpstream == nil {
+		return
+	}
+	if n > 0 {
+		t.windowBytes += int64(n)
+	}
+	t.activeRead += readElapsed
+
+	now := time.Now()
+	if t.windowStart.IsZero() {
+		t.windowStart = now
+		return
+	}
+	if now.Sub(t.windowStart) < hlsUpstreamSampleWindow {
+		return
+	}
+
+	bytes, active := t.windowBytes, t.activeRead
+	t.windowStart, t.windowBytes, t.activeRead = now, 0, 0
+	if bytes <= 0 || active <= 0 {
+		return
+	}
+
+	actual := int64(float64(bytes) * 8 * float64(time.Second) / float64(active))
+	if actual >= int64(float64(t.requiredBps)*hlsUpstreamHeadroom) {
+		t.lowSamples = 0
+		return
+	}
+	t.lowSamples++
+	if t.lowSamples < hlsUpstreamLowSamplesNeeded {
+		return
+	}
+	if !t.lastLowSignal.IsZero() && now.Sub(t.lastLowSignal) < hlsUpstreamSignalCooldown {
+		return
+	}
+	t.lowSamples = 0
+	t.lastLowSignal = now
+	t.onSlowUpstream(actual, t.requiredBps)
+}
+
+// reportHLSUpstreamStarvation asks the player to migrate away from an upstream
+// that has stopped delivering. HLS transcode sessions have no equivalent of the
+// direct path's recovery: FFmpeg cannot re-resolve its own input, so a source
+// that degrades mid-session starves the transcode until the viewer gives up.
+//
+// Returning true marks the block as reported so a single stall is signalled once.
+func reportHLSUpstreamStarvation(session *HLSSession, blockedFor time.Duration) bool {
+	return requestHLSSourceMigration(session, "backend-starvation",
+		fmt.Sprintf("upstream read blocked for %v", blockedFor.Round(time.Millisecond)))
+}
+
+// reportHLSSlowUpstream covers the failure the blocked-read watch cannot see: a
+// source that keeps the connection alive and trickles, which starves the transcode
+// just as effectively while every individual read returns promptly.
+func reportHLSSlowUpstream(session *HLSSession, actualBps, requiredBps int64) {
+	requestHLSSourceMigration(session, "backend-low-throughput",
+		fmt.Sprintf("upstream delivering %.1fMbps against %.1fMbps required",
+			float64(actualBps)/1_000_000, float64(requiredBps)/1_000_000))
+}
+
+func requestHLSSourceMigration(session *HLSSession, reason, detail string) bool {
+	if session == nil {
+		return false
+	}
+	session.mu.RLock()
+	sessionID := session.ID
+	path := session.Path
+	profileID := session.ProfileID
+	profileName := session.ProfileName
+	metadata := session.MediaMetadata
+	session.mu.RUnlock()
+
+	marked := GetStreamTracker().MarkPlaybackMigrationForIdentity(
+		profileID, profileName, metadata.MediaType, metadata.ItemID, path, reason)
+	if marked > 0 {
+		log.Printf("[stream-migration] HLS transcode source is not keeping up: session=%s reason=%s %s",
+			sessionID, reason, detail)
+	} else {
+		// No playback identity to address, so nothing can act on a handoff. Say so
+		// rather than silently dropping the only evidence that the source stalled.
+		log.Printf("[stream-health] HLS transcode source is not keeping up without playback metadata: session=%s reason=%s %s",
+			sessionID, reason, detail)
+	}
+	return true
+}
+
+// hlsUpstreamTotalBytes is the size of the whole file, not of the slice being
+// served. FFmpeg seeks with Range requests, and a partial response's
+// Content-Length describes only that range, which paired with the full duration
+// would understate the bitrate the source has to sustain.
+func hlsUpstreamTotalBytes(resp *http.Response) int64 {
+	if resp == nil {
+		return 0
+	}
+	if total := parseContentRangeTotal(resp.Header.Get("Content-Range")); total > 0 {
+		return total
+	}
+	return resp.ContentLength
+}
+
+// hlsSourceRequiredBps is the average bitrate the source must sustain for the
+// transcode to hold real time. The file size plus the probed duration describes
+// that directly; without both there is nothing to compare a sample against.
+func hlsSourceRequiredBps(totalBytes int64, session *HLSSession) int64 {
+	if totalBytes <= 0 || session == nil {
+		return 0
+	}
+	session.mu.RLock()
+	duration := session.Duration
+	session.mu.RUnlock()
+	if duration <= 0 {
+		return 0
+	}
+	return int64(float64(totalBytes) * 8 / duration)
 }
 
 // HLSSession represents an active HLS transcoding session

--- a/backend/handlers/hls_test.go
+++ b/backend/handlers/hls_test.go
@@ -564,43 +564,6 @@ func TestThrottledReaderExposesBlockedUpstreamRead(t *testing.T) {
 	}
 }
 
-// The throttle deliberately sleeps when the transcode runs ahead of the player.
-// That sleep must stay outside the watch, or every healthy buffered session would
-// be reported as a starved one and handed to another source for no reason.
-func TestThrottleSleepIsNotCountedAsUpstreamStarvation(t *testing.T) {
-	outputDir := t.TempDir()
-	// Segments far beyond the player's position put the reader deep into throttling.
-	for i := range throttleStartThreshold*3 + 1 {
-		name := filepath.Join(outputDir, fmt.Sprintf("segment%d.ts", i))
-		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
-			t.Fatalf("write segment fixture: %v", err)
-		}
-	}
-
-	throttled := newThrottledReader(bytes.NewReader([]byte("payload")), &HLSSession{
-		ID:                  "throttled",
-		OutputDir:           outputDir,
-		MaxSegmentRequested: 0,
-	})
-
-	start := time.Now()
-	buf := make([]byte, 4)
-	if _, err := throttled.Read(buf); err != nil && err != io.EOF {
-		t.Fatalf("Read error: %v", err)
-	}
-	if throttled.throttleCount == 0 {
-		t.Fatal("fixture did not trigger throttling, so the test proves nothing")
-	}
-	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
-		t.Fatalf("expected a deliberate throttle delay, got %v", elapsed)
-	}
-	// The watch is disarmed on return; the point is that the sleep above happened
-	// before it was ever armed, so no part of that delay was attributable to it.
-	if started := throttled.upstream.startedAt(); started != 0 {
-		t.Fatalf("watch left armed after a throttled read: startedAt = %d", started)
-	}
-}
-
 // The failure that motivated this: a CDN that keeps the connection alive and
 // trickles. Every individual read returns promptly, so a blocked-read watch never
 // fires, while the transcode starves anyway.

--- a/backend/handlers/hls_test.go
+++ b/backend/handlers/hls_test.go
@@ -514,6 +514,205 @@ func TestNewThrottledReader(t *testing.T) {
 	}
 }
 
+// blockingReader stays blocked until released, standing in for an upstream that
+// has accepted the connection and then stopped delivering.
+type blockingReader struct {
+	release chan struct{}
+}
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	<-b.release
+	return 0, io.EOF
+}
+
+// A stalled upstream read has to be visible to the starvation monitor, otherwise a
+// cast session starves against a degraded source with nothing able to act on it.
+func TestThrottledReaderExposesBlockedUpstreamRead(t *testing.T) {
+	blocking := &blockingReader{release: make(chan struct{})}
+	throttled := newThrottledReader(blocking, &HLSSession{
+		ID:                  "starved",
+		OutputDir:           t.TempDir(),
+		MaxSegmentRequested: -1,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 8)
+		_, _ = throttled.Read(buf)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for throttled.upstream.startedAt() == 0 {
+		if time.Now().After(deadline) {
+			close(blocking.release)
+			<-done
+			t.Fatal("blocked upstream read was never observable to the starvation monitor")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if blocked := throttled.upstream.blockedFor(time.Now()); blocked <= 0 {
+		t.Fatalf("blockedFor = %v, want a positive duration while the read is stalled", blocked)
+	}
+
+	close(blocking.release)
+	<-done
+
+	if started := throttled.upstream.startedAt(); started != 0 {
+		t.Fatalf("watch still armed after the read returned: startedAt = %d", started)
+	}
+}
+
+// The throttle deliberately sleeps when the transcode runs ahead of the player.
+// That sleep must stay outside the watch, or every healthy buffered session would
+// be reported as a starved one and handed to another source for no reason.
+func TestThrottleSleepIsNotCountedAsUpstreamStarvation(t *testing.T) {
+	outputDir := t.TempDir()
+	// Segments far beyond the player's position put the reader deep into throttling.
+	for i := range throttleStartThreshold*3 + 1 {
+		name := filepath.Join(outputDir, fmt.Sprintf("segment%d.ts", i))
+		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write segment fixture: %v", err)
+		}
+	}
+
+	throttled := newThrottledReader(bytes.NewReader([]byte("payload")), &HLSSession{
+		ID:                  "throttled",
+		OutputDir:           outputDir,
+		MaxSegmentRequested: 0,
+	})
+
+	start := time.Now()
+	buf := make([]byte, 4)
+	if _, err := throttled.Read(buf); err != nil && err != io.EOF {
+		t.Fatalf("Read error: %v", err)
+	}
+	if throttled.throttleCount == 0 {
+		t.Fatal("fixture did not trigger throttling, so the test proves nothing")
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("expected a deliberate throttle delay, got %v", elapsed)
+	}
+	// The watch is disarmed on return; the point is that the sleep above happened
+	// before it was ever armed, so no part of that delay was attributable to it.
+	if started := throttled.upstream.startedAt(); started != 0 {
+		t.Fatalf("watch left armed after a throttled read: startedAt = %d", started)
+	}
+}
+
+// The failure that motivated this: a CDN that keeps the connection alive and
+// trickles. Every individual read returns promptly, so a blocked-read watch never
+// fires, while the transcode starves anyway.
+func TestSlowUpstreamTrickleIsReportedAsSlowNotStalled(t *testing.T) {
+	var gotActual, gotRequired int64
+	calls := 0
+
+	throttled := newThrottledReader(bytes.NewReader(nil), &HLSSession{
+		ID:        "trickle",
+		OutputDir: t.TempDir(),
+	})
+	throttled.requiredBps = 20_000_000 // 20Mbps source
+	throttled.onSlowUpstream = func(actual, required int64) {
+		calls++
+		gotActual, gotRequired = actual, required
+	}
+
+	// Two consecutive deficient windows: 200KB per second of active reading is
+	// 1.6Mbps, the rate measured on the session that prompted this.
+	for range hlsUpstreamLowSamplesNeeded {
+		throttled.windowStart = time.Now().Add(-2 * hlsUpstreamSampleWindow)
+		throttled.sampleUpstreamRate(200_000, time.Second)
+	}
+
+	if calls != 1 {
+		t.Fatalf("slow upstream callbacks = %d, want 1", calls)
+	}
+	if gotRequired != 20_000_000 {
+		t.Errorf("required = %d, want 20000000", gotRequired)
+	}
+	if gotActual > 2_000_000 {
+		t.Errorf("actual = %d bps, want the measured trickle (~1.6Mbps)", gotActual)
+	}
+}
+
+// A single deficient window is not enough; a momentary dip must not hand the
+// session to another source.
+func TestSingleSlowWindowDoesNotRequestMigration(t *testing.T) {
+	calls := 0
+	throttled := newThrottledReader(bytes.NewReader(nil), &HLSSession{ID: "dip", OutputDir: t.TempDir()})
+	throttled.requiredBps = 20_000_000
+	throttled.onSlowUpstream = func(int64, int64) { calls++ }
+
+	throttled.windowStart = time.Now().Add(-2 * hlsUpstreamSampleWindow)
+	throttled.sampleUpstreamRate(200_000, time.Second)
+
+	if calls != 0 {
+		t.Fatalf("slow upstream callbacks = %d, want 0 after one window", calls)
+	}
+}
+
+// The throttle deliberately stalls reads for many seconds when the transcode runs
+// ahead. Because only time inside the read counts, a healthy source stays healthy:
+// measuring against wall time here would report every buffered session as slow.
+func TestThrottledButFastUpstreamIsNotReportedSlow(t *testing.T) {
+	calls := 0
+	throttled := newThrottledReader(bytes.NewReader(nil), &HLSSession{ID: "ahead", OutputDir: t.TempDir()})
+	throttled.requiredBps = 20_000_000
+	throttled.onSlowUpstream = func(int64, int64) { calls++ }
+
+	for range hlsUpstreamLowSamplesNeeded + 1 {
+		// A whole minute of wall clock elapsed, nearly all of it throttle sleep,
+		// but the source handed over 8MB in the one second it was actually read.
+		throttled.windowStart = time.Now().Add(-60 * time.Second)
+		throttled.sampleUpstreamRate(8_000_000, time.Second)
+	}
+
+	if calls != 0 {
+		t.Fatalf("slow upstream callbacks = %d, want 0 for a throttled but fast source", calls)
+	}
+}
+
+// Without a Content-Length or a probed duration there is no rate to compare
+// against, and guessing one would migrate sessions on no evidence.
+func TestSourceRequiredBpsNeedsLengthAndDuration(t *testing.T) {
+	withDuration := &HLSSession{Duration: 1000}
+	if got := hlsSourceRequiredBps(2_500_000_000, withDuration); got != 20_000_000 {
+		t.Errorf("requiredBps = %d, want 20000000", got)
+	}
+	if got := hlsSourceRequiredBps(0, withDuration); got != 0 {
+		t.Errorf("requiredBps without a length = %d, want 0", got)
+	}
+	if got := hlsSourceRequiredBps(2_500_000_000, &HLSSession{}); got != 0 {
+		t.Errorf("requiredBps without a duration = %d, want 0", got)
+	}
+}
+
+// A seek is served as a partial response, so the slice length must not be mistaken
+// for the file length: that would understate the required rate on every seek.
+func TestUpstreamTotalBytesPrefersContentRangeTotal(t *testing.T) {
+	ranged := &http.Response{
+		ContentLength: 1_000_000,
+		Header:        http.Header{"Content-Range": []string{"bytes 2000000-2999999/2500000000"}},
+	}
+	if got := hlsUpstreamTotalBytes(ranged); got != 2_500_000_000 {
+		t.Errorf("total = %d, want the full file size 2500000000", got)
+	}
+
+	whole := &http.Response{ContentLength: 2_500_000_000, Header: http.Header{}}
+	if got := hlsUpstreamTotalBytes(whole); got != 2_500_000_000 {
+		t.Errorf("total = %d, want 2500000000", got)
+	}
+
+	unparseable := &http.Response{
+		ContentLength: 1_000_000,
+		Header:        http.Header{"Content-Range": []string{"bytes 0-99/*"}},
+	}
+	if got := hlsUpstreamTotalBytes(unparseable); got != 1_000_000 {
+		t.Errorf("total = %d, want the Content-Length fallback", got)
+	}
+}
+
 // --- Mock streaming provider for HLS tests ---
 
 type hlsTestProvider struct {

--- a/backend/handlers/stream_tracker.go
+++ b/backend/handlers/stream_tracker.go
@@ -759,6 +759,45 @@ func (t *StreamTracker) MarkPlaybackMigrationForPath(path, reason string) int {
 	return marked
 }
 
+// MarkPlaybackMigrationForIdentity applies a recommendation to a playback that has
+// no tracked stream to hang it on. HLS transcode sessions fetch upstream through
+// their own proxy rather than StartStream, so nothing registers them here, but the
+// client-side handoff is keyed on playback identity rather than on the stream, so
+// the signal lands the same way once the keys are built the same way.
+//
+// The profile arguments mirror streamPlaybackControlKeys, which treats both the
+// profile ID and the profile name as candidate user identities.
+func (t *StreamTracker) MarkPlaybackMigrationForIdentity(profileID, profileName, mediaType, itemID, sourcePath, reason string) int {
+	if strings.TrimSpace(itemID) == "" {
+		return 0
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "backend-starvation"
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pruneMigrationSignalsLocked()
+
+	signal := playbackMigrationSignal{reason: reason, expiresAt: time.Now().Add(playbackMigrationSignalDuration)}
+	marked := 0
+	seen := make(map[string]bool)
+	for _, userID := range []string{profileID, profileName} {
+		if strings.TrimSpace(userID) == "" {
+			continue
+		}
+		key := playbackControlKey(userID, mediaType, itemID)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		t.recordPlaybackMigrationSignalLocked(playbackMigrationKey(key, sourcePath), signal)
+		marked++
+	}
+	return marked
+}
+
 // ObservePlaybackBandwidth binds the active release's estimated average bitrate
 // to matching direct streams. SourcePath keeps an older range request from
 // inheriting the replacement source's requirement during a handoff.

--- a/backend/handlers/stream_tracker_test.go
+++ b/backend/handlers/stream_tracker_test.go
@@ -766,20 +766,3 @@ func TestPlaybackMigrationForIdentityRequiresAnItem(t *testing.T) {
 		t.Fatalf("marked playbacks = %d, want 0", marked)
 	}
 }
-
-// The signal is scoped to the source that stalled, so a session that has already
-// been handed to a different release is not told to migrate again.
-func TestPlaybackMigrationForIdentityIsScopedToSource(t *testing.T) {
-	tracker := newTestTracker()
-	tracker.MarkPlaybackMigrationForIdentity(
-		"p1", "", "movie", "tmdb:movie:14160", "/debrid/torbox/123/file/0/stalled.mkv", "backend-starvation")
-
-	if _, migrate := tracker.ShouldMigratePlayback("p1", models.PlaybackProgressUpdate{
-		MediaType:   "movie",
-		ItemID:      "tmdb:movie:14160",
-		SourcePath:  "/debrid/torbox/999/file/0/replacement.mkv",
-		IsBuffering: true,
-	}); migrate {
-		t.Fatal("replacement source inherited the stalled source's migration signal")
-	}
-}

--- a/backend/handlers/stream_tracker_test.go
+++ b/backend/handlers/stream_tracker_test.go
@@ -734,3 +734,52 @@ func TestMergeDashboardStreamRowsCollapsesNativeConnections(t *testing.T) {
 		t.Errorf("expected via_share_link to survive merge")
 	}
 }
+
+// An HLS transcode session never registers a tracked stream, so the signal has to
+// reach the player from the session's own identity or a starved cast keeps playing
+// against a dead source.
+func TestPlaybackMigrationForIdentityReachesUntrackedHLSPlayback(t *testing.T) {
+	tracker := newTestTracker()
+
+	marked := tracker.MarkPlaybackMigrationForIdentity(
+		"p1", "", "movie", "tmdb:movie:14160", "/debrid/torbox/123/file/0/title.mkv", "backend-starvation")
+	if marked != 1 {
+		t.Fatalf("marked playbacks = %d, want 1", marked)
+	}
+
+	reason, migrate := tracker.ShouldMigratePlayback("p1", models.PlaybackProgressUpdate{
+		MediaType:   "movie",
+		ItemID:      "tmdb:movie:14160",
+		SourcePath:  "/debrid/torbox/123/file/0/title.mkv",
+		IsBuffering: true,
+	})
+	if !migrate || reason != "backend-starvation" {
+		t.Fatalf("starved HLS playback did not receive migration: migrate=%v reason=%q", migrate, reason)
+	}
+}
+
+// Without an item there is no playback to address, so the caller must be able to
+// tell that nothing was signalled rather than assume a handoff is coming.
+func TestPlaybackMigrationForIdentityRequiresAnItem(t *testing.T) {
+	tracker := newTestTracker()
+	if marked := tracker.MarkPlaybackMigrationForIdentity("p1", "", "movie", "", "/x.mkv", "backend-starvation"); marked != 0 {
+		t.Fatalf("marked playbacks = %d, want 0", marked)
+	}
+}
+
+// The signal is scoped to the source that stalled, so a session that has already
+// been handed to a different release is not told to migrate again.
+func TestPlaybackMigrationForIdentityIsScopedToSource(t *testing.T) {
+	tracker := newTestTracker()
+	tracker.MarkPlaybackMigrationForIdentity(
+		"p1", "", "movie", "tmdb:movie:14160", "/debrid/torbox/123/file/0/stalled.mkv", "backend-starvation")
+
+	if _, migrate := tracker.ShouldMigratePlayback("p1", models.PlaybackProgressUpdate{
+		MediaType:   "movie",
+		ItemID:      "tmdb:movie:14160",
+		SourcePath:  "/debrid/torbox/999/file/0/replacement.mkv",
+		IsBuffering: true,
+	}); migrate {
+		t.Fatal("replacement source inherited the stalled source's migration signal")
+	}
+}


### PR DESCRIPTION
## Problem

A cast session reads its source through the HLS throttling proxy, which has no upstream health checks at all. `hls.go` contains no reference to `starvation` or `stream-migration`.

The direct path detects a stalled or underperforming provider and asks the player to migrate (`monitorPipelineStarvation` → `MarkPlaybackMigration`, `video.go:1473`). The transcode path has no equivalent, and FFmpeg cannot re-resolve its own input. A source that degrades mid-session therefore starves the transcode indefinitely, while the server looks healthy and serves every segment it has.

## What I observed

A 4K HDR cast where the debrid edge fell to **1.6 Mbps** against roughly 20 Mbps required:

| check | result |
|---|---|
| segment production | 2s of media per 8–9.5s |
| host load | idle (3.92 on 10 cores) |
| ffmpeg CPU | 5s over 41 minutes |
| same filter chain, standalone | 3.4x real time |
| CDN connection | 1.63 Mbps, 98% of all inbound |

A stack sample located the stall precisely: the demuxer sat **99.7% in `ff_network_wait_fd_timeout` → `poll`**, with the decode threads in `pthread_cond_wait` and the encoder 99.9% in `tq_receive`. Everything downstream of input was idle, and nothing in the server could act on it.

Worth noting for reviewers: the socket byte rate alone is ambiguous, since TCP backpressure would show the same number if ffmpeg were the bottleneck. The discriminator is *where* the demuxer blocks — blocked in `poll()` means no data arrived, whereas a slow consumer would block writing into a full packet queue.

## Change

Two detectors, because they catch different failures:

1. **Blocked upstream read** — reuses `monitorPipelineStarvation` so behaviour matches the direct path.
2. **Trickling source** — the case above. Every individual read returns promptly, so a blocked-read watch never fires while the transcode starves anyway. Delivery rate is sampled over a window against the rate the source must sustain, derived from file size and probed duration. Headroom (1.25), the two-consecutive-window requirement and the 30s cooldown all mirror `ObserveUpstreamThroughput`.

A detector for (1) alone would not have fired on the bug that motivated this, which is why (2) exists.

### Notes for review

- **Only time inside the upstream read is counted.** The proxy deliberately sleeps when the transcode runs ahead of the player; measuring against wall clock would report every healthy buffered session as starved. `TestThrottledButFastUpstreamIsNotReportedSlow` pins this.
- **HLS sessions never register with `StartStream`**, so there is no `TrackedStream` to hang a signal on — `MarkPlaybackMigrationForPath` would match nothing and silently return 0. `MarkPlaybackMigrationForIdentity` records it from the session's own playback identity, building the same keys `streamPlaybackControlKeys` does, so the existing client-side handoff applies unchanged.
- **Full file size comes from `Content-Range` when present.** FFmpeg seeks with Range requests, and pairing a slice length with the full duration would understate the required rate on every seek. Reuses the existing `parseContentRangeTotal`.
- `throttleStartThreshold` moved from a function-local `const` to package scope so tests can build a throttling fixture against it. No value change.
- When a session has no playback identity, the condition is logged under `[stream-health]` rather than dropped, so the evidence survives even when no handoff is possible.

## Impact on existing behaviour

Detection is inert unless a required rate is known: `sampleUpstreamRate` returns immediately when `requiredBps` is under 1 Mbps or no callback is set. A response without a `Content-Length`, or a session without a probed duration, disables it entirely.

- `throttledReader` gains fields whose zero values are inert; per-read cost is two atomic stores and two `time.Now()` calls, against a network read.
- The second `newThrottledReader` caller (pipe-mode input, `hls.go:4037`) sets neither field and has no monitor attached, so it is functionally unchanged. **Known gap:** that path is also a network read and can starve the same way; it is not covered here.
- One goroutine and a 500ms ticker per proxy request, stopped by `defer`, matching the four existing `monitorPipelineStarvation` call sites.

The real behavioural change is that HLS sessions can now raise migration signals where they previously raised none. That is gated on both sides: at least 10s of sustained deficiency before a first signal, a 30s cooldown after, and `ShouldMigratePlayback` still only acts on a transient reason once the player confirms buffer pressure.

**Limitation:** rate is measured as bytes over time spent inside the read, which is what excludes throttle sleep. A bursty source — fast bursts separated by gaps shorter than the 3s blocked-read threshold — measures as healthy and evades both detectors.

## Tests

8 added:

- trickle at the observed 1.6 Mbps is reported, and reported as slow rather than stalled
- a single deficient window does not trigger a handoff
- a throttled-but-fast source is never reported slow
- a blocked read becomes visible to the monitor, and the watch disarms on return
- required rate needs both a length and a duration; `Content-Range` total beats a partial `Content-Length`
- identity signal reaches an untracked HLS playback, and requires an item

`go test ./handlers/` passes in full, `-race` clean on the new tests, `go vet` clean, `gofmt` clean.

## Scope

Detection and signalling only. It asks the player to migrate through the mechanism that already exists; it does not add a server-side re-resolve, and it does not touch the direct path.
