### PR TITLE
fix(cast): preserve Dolby Vision tone mapping on encoder fallback

### DIFF
--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -62,6 +62,7 @@ var hlsRedirectHTTPClient = &http.Client{
 }
 
 var errExternalStreamPlaceholder = errors.New("external stream resolved to unavailable-content placeholder")
+var errDolbyVisionToneMapUnavailable = errors.New("Dolby Vision Profile 5 tone mapping unavailable")
 
 func isHTTPDirectURL(raw string) bool {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
@@ -1904,6 +1905,15 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 			duration = pd.Duration
 			log.Printf("[hls] unified probe for session %s: duration=%.2fs startTime=%.3fs colorTransfer=%q audioStreams=%d",
 				sessionID, duration, pd.StartTime, pd.ColorTransfer, len(pd.AudioStreams))
+			if hasDV != pd.HasDolbyVision || dvProfile != pd.DolbyVisionProfile || hasHDR != pd.HasHDR10 {
+				log.Printf(
+					"[hls] session %s: replacing caller HDR hints DV=%v profile=%q HDR10=%v with probe DV=%v profile=%q HDR10=%v",
+					sessionID, hasDV, dvProfile, hasHDR, pd.HasDolbyVision, pd.DolbyVisionProfile, pd.HasHDR10,
+				)
+			}
+			hasDV = pd.HasDolbyVision
+			dvProfile = pd.DolbyVisionProfile
+			hasHDR = pd.HasHDR10
 
 			// Check for incorrect color tagging on DV Profile 8 content
 			// Some re-encodes (e.g., YTS) have DV RPU data but wrong color metadata (bt709 instead of smpte2084)
@@ -1964,6 +1974,18 @@ func (m *HLSManager) CreateSession(ctx context.Context, path string, originalPat
 		normalizedPlaybackTarget = "web"
 	}
 	stableCastMode := castMode && !directCastMode
+	if stableCastMode && hasDV {
+		caps := m.hwAccelCaps()
+		if !supportsDolbyVisionToneMap(caps, dvProfile) {
+			cancel()
+			_ = os.RemoveAll(outputDir)
+			return nil, fmt.Errorf(
+				"%w: %s is available; Cast requires libplacebo, so trying another release",
+				errDolbyVisionToneMapUnavailable,
+				effectiveTonemapName(caps),
+			)
+		}
+	}
 	subtitleStreamsForSeek := []subtitleStreamInfo(nil)
 	if probeData != nil {
 		subtitleStreamsForSeek = probeData.SubtitleStreams
@@ -4596,7 +4618,7 @@ func (m *HLSManager) startTranscoding(ctx context.Context, session *HLSSession, 
 	) {
 		log.Printf("[hls] session %s: hardware encoder %s failed before producing a segment; retrying with software encoding",
 			session.ID, webEncodePlan.Kind)
-		m.markHWAccelFailed(webEncodePlan.Kind)
+		m.markHWAccelFailed(webEncodePlan.Kind, session.HasDV && IsDVProfile5(session.DVProfile))
 		files, _ := filepath.Glob(filepath.Join(session.OutputDir, "*"))
 		for _, file := range files {
 			_ = os.Remove(file)

--- a/backend/handlers/hwaccel.go
+++ b/backend/handlers/hwaccel.go
@@ -117,7 +117,7 @@ func (m *HLSManager) hwAccelCaps() HWAccelCaps {
 // markHWAccelFailed moves subsequent sessions to software encoding after a
 // real media graph fails on the selected hardware path. Auto detection is
 // retried later in case the failure was a transient driver/session-limit issue.
-func (m *HLSManager) markHWAccelFailed(kind HWAccelKind) {
+func (m *HLSManager) markHWAccelFailed(kind HWAccelKind, retainToneMapper bool) {
 	if kind == HWNone {
 		return
 	}
@@ -128,15 +128,19 @@ func (m *HLSManager) markHWAccelFailed(kind HWAccelKind) {
 			kind, m.hwAccel.Encode, m.hwAccelReady)
 		return
 	}
-	log.Printf("[hwaccel] quarantining failed encoder=%s for %s; subsequent web transcodes will use software encoding",
-		kind, hwAccelFailureRetryDelay)
-	m.hwAccel = detectHWAccel(m.ffmpegPath, string(HWNone))
+	if retainToneMapper {
+		log.Printf("[hwaccel] quarantining failed encoder=%s for %s; retaining tone mapper=%s",
+			kind, hwAccelFailureRetryDelay, effectiveTonemapName(m.hwAccel))
+		m.hwAccel.Encode = HWNone
+		m.hwAccel.EncodeDevice = ""
+	} else {
+		log.Printf("[hwaccel] quarantining failed encoder=%s for %s; using software fallback",
+			kind, hwAccelFailureRetryDelay)
+		m.hwAccel = detectHWAccel(m.ffmpegPath, string(HWNone))
+	}
 	m.hwAccelPref = currentHWAccelPreference(m.configManager)
 	m.hwAccelReady = true
 	m.hwAccelRetryAfter = time.Now().Add(hwAccelFailureRetryDelay)
-	log.Printf("[hwaccel] software fallback active: configuredPreference=%s encoder=%s tonemap=%s retryAfter=%s",
-		m.hwAccelPref, effectiveEncoderName(m.hwAccel), effectiveTonemapName(m.hwAccel),
-		formatHWAccelRetryTime(m.hwAccelRetryAfter))
 }
 
 func currentHWAccelPreference(provider ConfigProvider) string {
@@ -188,6 +192,10 @@ func effectiveTonemapName(caps HWAccelCaps) string {
 		return "none"
 	}
 	return caps.Tonemap
+}
+
+func supportsDolbyVisionToneMap(caps HWAccelCaps, profile string) bool {
+	return !IsDVProfile5(profile) || caps.Tonemap == "libplacebo"
 }
 
 func formatHWAccelRetryTime(retryAfter time.Time) string {
@@ -331,7 +339,7 @@ func libplaceboUsable(ffmpegPath string) bool {
 	ok, output, err := runFilterProbeWithOutput(ffmpegPath,
 		[]string{"-init_hw_device", "vulkan=vk", "-filter_hw_device", "vk"},
 		"color=c=black:s=128x128:d=0.1",
-		"libplacebo=format=yuv420p",
+		"libplacebo=format=yuv420p:apply_dolbyvision=true",
 		"verbose")
 	if !ok {
 		log.Printf("[hwaccel] tone mapper candidate rejected: kind=libplacebo reason=probe failed error=%v output=%q",

--- a/backend/handlers/hwaccel_test.go
+++ b/backend/handlers/hwaccel_test.go
@@ -77,6 +77,28 @@ func TestBuildVideoEncodePlanLibplaceboTonemap(t *testing.T) {
 	}
 }
 
+func TestSupportsDolbyVisionToneMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		caps    HWAccelCaps
+		profile string
+		want    bool
+	}{
+		{name: "profile 5 with libplacebo", caps: HWAccelCaps{Tonemap: "libplacebo"}, profile: "dvhe.05.06", want: true},
+		{name: "profile 5 with zscale", caps: HWAccelCaps{Tonemap: "zscale"}, profile: "dvhe.05.06", want: false},
+		{name: "profile 5 with OpenCL", caps: HWAccelCaps{Tonemap: "opencl"}, profile: "dvhe.05.09", want: false},
+		{name: "profile 8 with zscale fallback", caps: HWAccelCaps{Tonemap: "zscale"}, profile: "dvhe.08.06", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportsDolbyVisionToneMap(tt.caps, tt.profile); got != tt.want {
+				t.Fatalf("supportsDolbyVisionToneMap(%q) = %v, want %v", tt.profile, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildVideoEncodePlanOpenCLTonemap(t *testing.T) {
 	plan := buildVideoEncodePlan(HWAccelCaps{Encode: HWNVENC, Tonemap: "opencl"}, true)
 	if !strings.Contains(plan.Filter, "tonemap_opencl") {
@@ -279,7 +301,7 @@ func TestHWAccelCacheRefreshesWhenPreferenceChanges(t *testing.T) {
 	}
 }
 
-func TestMarkHWAccelFailedQuarantinesHardware(t *testing.T) {
+func TestMarkHWAccelFailedPreservesProfile5ToneMapper(t *testing.T) {
 	provider := &mutableHWAccelConfigProvider{settings: config.DefaultSettings()}
 	provider.settings.Transmux.HardwareAcceleration = "auto"
 	manager := NewHLSManager(t.TempDir(), "", "", nil)
@@ -288,13 +310,39 @@ func TestMarkHWAccelFailedQuarantinesHardware(t *testing.T) {
 	manager.hwAccelPref = "auto"
 	manager.hwAccelReady = true
 
-	manager.markHWAccelFailed(HWNVENC)
+	manager.markHWAccelFailed(HWNVENC, true)
 	status := manager.HardwareAccelerationStatus()
 	if status.EffectiveEncoder != "libx264" || status.HardwareEncode {
 		t.Fatalf("status after failure = %+v, want software fallback", status)
 	}
+	if status.ToneMapper != "libplacebo" {
+		t.Fatalf("hardware encoder failure discarded tone mapper: %+v", status)
+	}
 	if status.RetryAfter == "" {
 		t.Fatal("expected failed hardware path to have a retry time")
+	}
+	plan := buildVideoEncodePlan(manager.hwAccel, true)
+	if plan.HardwareEncode || !strings.Contains(plan.Filter, "libplacebo") {
+		t.Fatalf("fallback plan = %+v, want libx264 with libplacebo", plan)
+	}
+	if strings.Contains(joinArgs(plan.GlobalArgs), "-hwaccel videotoolbox") {
+		t.Fatalf("fallback must disable VideoToolbox decode too: %v", plan.GlobalArgs)
+	}
+}
+
+func TestMarkHWAccelFailedResetsToneMapperForOtherSources(t *testing.T) {
+	provider := &mutableHWAccelConfigProvider{settings: config.DefaultSettings()}
+	provider.settings.Transmux.HardwareAcceleration = "auto"
+	manager := NewHLSManager(t.TempDir(), "", "", nil)
+	manager.SetConfigManager(provider)
+	manager.hwAccel = HWAccelCaps{Encode: HWNVENC, Tonemap: "libplacebo"}
+	manager.hwAccelPref = "auto"
+	manager.hwAccelReady = true
+
+	manager.markHWAccelFailed(HWNVENC, false)
+	status := manager.HardwareAccelerationStatus()
+	if status.EffectiveEncoder != "libx264" || status.HardwareEncode || status.ToneMapper != "" {
+		t.Fatalf("status after ordinary failure = %+v, want original software fallback", status)
 	}
 }
 

--- a/backend/handlers/video.go
+++ b/backend/handlers/video.go
@@ -4319,6 +4319,13 @@ func (h *VideoHandler) StartHLSSession(w http.ResponseWriter, r *http.Request) {
 		} else if errors.Is(err, errExternalStreamPlaceholder) {
 			h.invalidatePrequeuesForFailedPath(path)
 			http.Error(w, "external stream expired — please re-resolve", http.StatusGone)
+		} else if errors.Is(err, errDolbyVisionToneMapUnavailable) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"code":    "DOLBY_VISION_TONEMAP_UNAVAILABLE",
+				"message": err.Error(),
+			})
 		} else {
 			http.Error(w, fmt.Sprintf("failed to create HLS session: %v", err), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
## Problem

A Chromecast compatibility transcode of a Dolby Vision Profile 5 source could produce blue/purple skin after an early hardware-encoder failure. The retry disabled the encoder **and** the verified `libplacebo` tone mapper, then treated Profile 5's IPT base layer as ordinary PQ/BT.2020 through `zscale`.

## Changes

- Treat the successful ffprobe result as authoritative for DV/HDR flags instead of stale caller hints.
- Verify that the libplacebo runtime accepts `apply_dolbyvision=true`, not merely that the filter starts.
- Require verified libplacebo for Profile 5 Cast sessions and return a typed 422 rather than emitting corrupt color.
- For Profile 5 only, quarantine failed hardware decode/encode while retaining libplacebo for the `libx264` retry. Other HDR and SDR hardware-failure behavior is unchanged.

## Scope

Backend tone-map selection and Profile 5 recovery only. No player UI, release ranking, packaging, or unrelated Cast behavior.

## Verification

- `go test ./handlers`
- `go build ./...`