### PR TITLE
feat(admin): refine the admin workspace

### DIFF
--- a/backend/handlers/admin_templates/accounts.html
+++ b/backend/handlers/admin_templates/accounts.html
@@ -5,17 +5,20 @@
 {{define "title"}}Users - {{if .IsAdmin}}mediastorm Admin{{else}}mediastorm account{{end}}{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Users</h1>
-    <p>Manage sign-in, people, and registered devices{{if not .IsAdmin}} for your household{{end}}</p>
+<div class="page-header" data-page-group="People &amp; communication">
+    <div class="page-header-copy">
+        <div class="page-kicker">People &amp; communication</div>
+        <h1>Users</h1>
+        <p>Manage sign-in accounts, viewer profiles, registered devices, and access{{if not .IsAdmin}} for your household{{end}}.</p>
+    </div>
 </div>
 
-<div class="tabs" style="margin-bottom: 1.5rem;">
-    <button class="tab active" onclick="switchTab('households')" id="tab-households">{{if .IsAdmin}}Households{{else}}Household{{end}}</button>
-    <button class="tab" onclick="switchTab('tasks')" id="tab-tasks">Automations</button>
+<div class="tabs" style="margin-bottom: 1.5rem;" role="tablist" aria-label="People and access areas">
+    <button class="tab active" onclick="switchTab('households')" id="tab-households" role="tab" aria-selected="true">{{if .IsAdmin}}Households{{else}}Household{{end}}</button>
+    <button class="tab" onclick="switchTab('tasks')" id="tab-tasks" role="tab" aria-selected="false">Automations</button>
     {{if .IsAdmin}}
-    <button class="tab" onclick="switchTab('invitations')" id="tab-invitations">Invitations</button>
-    <button class="tab" onclick="switchTab('connections')" id="tab-connections">Remote Access</button>
+    <button class="tab" onclick="switchTab('invitations')" id="tab-invitations" role="tab" aria-selected="false">Invitations</button>
+    <button class="tab" onclick="switchTab('connections')" id="tab-connections" role="tab" aria-selected="false">Remote access</button>
     {{end}}
 </div>
 
@@ -292,9 +295,14 @@ async function saveGlobalMaxStreams() {
 }
 
 function switchTab(tab) {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.tab').forEach(t => {
+        t.classList.remove('active');
+        t.setAttribute('aria-selected', 'false');
+    });
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-    document.getElementById('tab-' + tab).classList.add('active');
+    const activeTab = document.getElementById('tab-' + tab);
+    activeTab.classList.add('active');
+    activeTab.setAttribute('aria-selected', 'true');
     document.getElementById('content-' + tab).classList.add('active');
 }
 

--- a/backend/handlers/admin_templates/backup.html
+++ b/backend/handlers/admin_templates/backup.html
@@ -3,9 +3,12 @@
 {{define "title"}}Backup - mediastorm Admin{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>System Backup</h1>
-    <p>Create, download, and restore system backups</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Backup</h1>
+        <p>Create and download recovery points, or restore the server from an existing backup.</p>
+    </div>
 </div>
 
 <div class="settings-group">
@@ -50,7 +53,7 @@
     </div>
 
     <!-- Restore From File Section -->
-    <div class="section open" id="restoreFileSection">
+    <div class="section is-destructive" id="restoreFileSection">
         <div class="section-header" onclick="toggleSection(this)">
             <div class="section-title">
                 <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">

--- a/backend/handlers/admin_templates/bad_streams.html
+++ b/backend/handlers/admin_templates/bad_streams.html
@@ -89,9 +89,12 @@
     }
 </style>
 
-<div class="page-header">
-    <h1>Bad Streams</h1>
-    <p>Streams skipped during playback migration and prequeue resolution</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Bad streams</h1>
+        <p>Review streams skipped during playback migration and prequeue resolution.</p>
+    </div>
 </div>
 
 <div class="settings-group">

--- a/backend/handlers/admin_templates/base.html
+++ b/backend/handlers/admin_templates/base.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="format-detection" content="telephone=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -38,7 +38,6 @@
             box-sizing: border-box;
         }
 
-        /* Prevent zooming on mobile */
         html {
             touch-action: manipulation;
         }
@@ -341,6 +340,50 @@
             margin-bottom: 1.5rem;
         }
 
+        .page-header[data-page-group] {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+            gap: 1rem 1.5rem;
+            padding-bottom: 1.25rem;
+            border-bottom: 1px solid rgba(42, 42, 54, 0.72);
+        }
+
+        .page-header-copy {
+            min-width: 0;
+            max-width: 760px;
+        }
+
+        .page-kicker {
+            margin-bottom: 0.35rem;
+            color: var(--accent-hover);
+            font-size: 0.6875rem;
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .page-header-actions,
+        .page-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 0.625rem;
+            flex-wrap: wrap;
+        }
+
+        .page-header-actions {
+            flex: 0 0 auto;
+        }
+
+        .page-toolbar {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            background: rgba(22, 22, 30, 0.72);
+        }
+
         .page-header h1 {
             font-size: 1.75rem;
             font-weight: 600;
@@ -357,6 +400,63 @@
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
             overflow: hidden;
+        }
+
+        .card-subtitle,
+        .section-summary {
+            margin-top: 0.25rem;
+            color: var(--text-muted);
+            font-size: 0.8125rem;
+            font-weight: 400;
+            line-height: 1.45;
+        }
+
+        .disclosure-card > summary,
+        .form-disclosure > summary {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            min-height: 48px;
+            padding: 0.875rem 1.25rem;
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 600;
+            list-style: none;
+        }
+
+        .disclosure-card > summary::-webkit-details-marker,
+        .form-disclosure > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .disclosure-card > summary::after,
+        .form-disclosure > summary::after {
+            content: '+';
+            color: var(--text-muted);
+            font-size: 1.1rem;
+            font-weight: 400;
+        }
+
+        .disclosure-card[open] > summary,
+        .form-disclosure[open] > summary {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .disclosure-card[open] > summary::after,
+        .form-disclosure[open] > summary::after {
+            content: '−';
+        }
+
+        .form-disclosure {
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: rgba(28, 28, 38, 0.5);
+        }
+
+        .form-disclosure-content {
+            padding: 1rem;
         }
 
         .card-header {
@@ -564,8 +664,9 @@
 
         .form-input:focus,
         .form-select:focus {
-            outline: none;
+            outline: 2px solid transparent;
             border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(95, 98, 237, 0.18);
         }
 
         .form-input::placeholder {
@@ -643,6 +744,19 @@
             transition: all 0.2s;
             border: none;
             text-decoration: none;
+            min-height: 40px;
+        }
+
+        .btn:focus-visible,
+        .form-input:focus-visible,
+        .form-select:focus-visible,
+        textarea:focus-visible,
+        .section-header:focus-visible,
+        .tab:focus-visible,
+        button:focus-visible,
+        a:focus-visible {
+            outline: 2px solid var(--accent-hover);
+            outline-offset: 2px;
         }
 
         .btn svg {
@@ -742,6 +856,7 @@
 
         .table-container {
             overflow-x: auto;
+            scrollbar-gutter: stable;
         }
 
         table {
@@ -793,6 +908,16 @@
             border-radius: var(--radius-lg);
             margin-bottom: 1rem;
             overflow: hidden;
+        }
+
+        .section.is-destructive,
+        .card.is-destructive {
+            border-color: rgba(239, 68, 68, 0.38);
+        }
+
+        .section.is-destructive .section-title svg,
+        .card.is-destructive .card-header svg {
+            color: var(--danger);
         }
 
         .section-header {
@@ -2003,29 +2128,28 @@
             inset: 0 auto 0 0;
             z-index: 300;
             display: flex;
-            width: 240px;
+            width: 248px;
             min-height: 100vh;
             flex-direction: column;
             border-right: 1px solid var(--border);
-            background: #111118;
+            background: var(--bg-secondary);
         }
 
         .admin-sidebar-brand {
             display: flex;
-            min-height: 56px;
+            min-height: 72px;
             align-items: center;
-            gap: 0.625rem;
+            gap: 0.75rem;
             padding: 0.75rem 1rem;
             color: var(--text-primary);
             text-decoration: none;
-            border-bottom: 1px solid rgba(42, 42, 54, 0.55);
         }
 
         .admin-sidebar-brand img {
-            width: 24px;
-            height: 24px;
+            width: 40px;
+            height: 40px;
             flex: 0 0 auto;
-            border-radius: 6px;
+            border-radius: 10px;
         }
 
         .admin-sidebar-brand-copy {
@@ -2036,21 +2160,25 @@
         }
 
         .admin-sidebar-brand-title {
-            font-size: 1rem;
+            font-size: 0.9375rem;
             font-weight: 700;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
         }
 
         .admin-sidebar-brand-build {
             color: var(--text-muted);
             font-size: 0.6875rem;
             font-weight: 400;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
         }
 
         .admin-sidebar-nav {
             flex: 1 1 auto;
             min-height: 0;
             overflow-y: auto;
-            padding: 0.5rem 0.75rem 1rem;
+            padding: 0.125rem 0.75rem 1rem;
             scrollbar-width: thin;
             scrollbar-color: var(--border) transparent;
         }
@@ -2059,20 +2187,40 @@
             margin: 0;
         }
 
+        .sidebar-section-label,
+        .sidebar-subgroup-label {
+            color: var(--text-muted);
+            font-size: 0.625rem;
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .sidebar-section-label {
+            padding: 0.5rem 0.5rem 0.25rem;
+        }
+
+        .sidebar-section-label:not(:first-child) {
+            margin-top: 0.5rem;
+        }
+
+        .sidebar-subgroup-label {
+            padding: 0.625rem 0.75rem 0.25rem 2.75rem;
+        }
+
         .sidebar-group > summary {
             display: flex;
-            min-height: 32px;
+            min-height: 44px;
             cursor: pointer;
             list-style: none;
             align-items: center;
             justify-content: space-between;
-            padding: 0.45rem 0.75rem;
-            color: var(--text-muted);
-            border-radius: 6px;
-            font-size: 0.6875rem;
-            font-weight: 700;
-            letter-spacing: 0.1em;
-            text-transform: uppercase;
+            gap: 0.5rem;
+            padding: 0.625rem 0.75rem;
+            color: var(--text-secondary);
+            border-radius: 8px;
+            font-size: 0.875rem;
+            font-weight: 500;
         }
 
         .sidebar-group > summary::-webkit-details-marker {
@@ -2081,13 +2229,38 @@
 
         .sidebar-group > summary:hover,
         .sidebar-group > summary:focus-visible {
-            background: rgba(255, 255, 255, 0.025);
-            color: var(--text-secondary);
-            outline: none;
+            background: var(--bg-hover);
+            color: var(--text-primary);
+        }
+
+        .sidebar-group.current > summary {
+            color: var(--text-primary);
+            background: var(--bg-hover);
+        }
+
+        .sidebar-group.current > summary::before {
+            content: '';
+            position: absolute;
+            inset: 8px auto 8px 0;
+            width: 3px;
+            border-radius: 3px;
+            background: var(--accent);
+        }
+
+        .sidebar-group-summary-main {
+            display: flex;
+            min-width: 0;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .sidebar-group > summary {
+            position: relative;
         }
 
         .sidebar-group-chevron {
-            font-size: 0.625rem;
+            color: var(--text-muted);
+            font-size: 0.75rem;
             transition: transform 0.16s ease;
         }
 
@@ -2098,19 +2271,49 @@
         .sidebar-group-items {
             display: grid;
             gap: 0.125rem;
-            padding-bottom: 0.25rem;
+            margin: 0 0 0.25rem 1.3rem;
+            padding: 0.125rem 0 0.25rem 0.45rem;
+            border-left: 1px solid var(--border);
+        }
+
+        .sidebar-group-items .sidebar-nav-link {
+            width: 100%;
+            margin-left: 0;
+            padding-left: 0.7rem;
+            font-size: 0.8125rem;
+        }
+
+        .sidebar-group-items .sidebar-nav-link .sidebar-nav-icon {
+            width: 16px;
+            height: 16px;
+            opacity: 0.78;
+        }
+
+        .sidebar-group-items .sidebar-nav-link.active .sidebar-nav-icon {
+            opacity: 1;
+        }
+
+        .sidebar-primary-link + .sidebar-secondary-link {
+            margin-top: -0.125rem;
+        }
+
+        .sidebar-secondary-link {
+            min-height: 36px !important;
+            padding-left: 2.75rem !important;
+            color: var(--text-muted);
+            font-size: 0.75rem !important;
         }
 
         .sidebar-nav-link {
             position: relative;
             display: flex;
-            min-height: 36px;
+            min-height: 44px;
             align-items: center;
             gap: 0.625rem;
             padding: 0.5rem 0.75rem;
             color: var(--text-secondary);
             text-decoration: none;
-            border-radius: 6px;
+            border-radius: 8px;
             font-size: 0.875rem;
             font-weight: 500;
             line-height: 1.2;
@@ -2120,12 +2323,11 @@
         .sidebar-nav-link:focus-visible {
             color: var(--text-primary);
             background: var(--bg-hover);
-            outline: none;
         }
 
         .sidebar-nav-link.active {
             color: var(--text-primary);
-            background: rgba(99, 102, 241, 0.14);
+            background: var(--bg-hover);
         }
 
         .sidebar-nav-link.active::before {
@@ -2155,6 +2357,18 @@
             color: var(--accent-hover);
         }
 
+        .sidebar-admin-badge {
+            margin-left: auto;
+            padding: 0.2rem 0.4rem;
+            color: var(--text-muted);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--bg-tertiary);
+            font-size: 0.5625rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+        }
+
         .admin-sidebar-footer {
             flex: 0 0 auto;
             padding: 0.75rem;
@@ -2163,15 +2377,15 @@
 
         .admin-sidebar-user {
             display: grid;
-            grid-template-columns: 32px minmax(0, 1fr) auto;
+            grid-template-columns: 36px minmax(0, 1fr) 44px;
             align-items: center;
             gap: 0.625rem;
         }
 
         .admin-avatar {
             display: inline-flex;
-            width: 32px;
-            height: 32px;
+            width: 36px;
+            height: 36px;
             align-items: center;
             justify-content: center;
             flex: 0 0 auto;
@@ -2200,9 +2414,23 @@
         }
 
         .admin-sidebar-logout {
-            color: #9ca3f1;
-            font-size: 0.75rem;
+            display: inline-flex;
+            width: 44px;
+            height: 44px;
+            align-items: center;
+            justify-content: center;
+            color: var(--text-secondary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--bg-secondary);
+            font-size: 1rem;
             text-decoration: none;
+        }
+
+        .admin-sidebar-logout:hover,
+        .admin-sidebar-logout:focus-visible {
+            color: var(--text-primary);
+            background: var(--bg-hover);
         }
 
         .admin-sidebar-version {
@@ -2212,10 +2440,10 @@
 
         .admin-workspace {
             display: flex;
-            width: calc(100% - 240px);
+            width: calc(100% - 248px);
             min-width: 0;
             min-height: 100vh;
-            margin-left: 240px;
+            margin-left: 248px;
             flex-direction: column;
         }
 
@@ -2223,8 +2451,8 @@
             position: sticky;
             top: 0;
             z-index: 250;
-            display: flex;
-            min-height: 48px;
+            display: none;
+            min-height: 64px;
             align-items: center;
             justify-content: space-between;
             gap: 1rem;
@@ -2264,14 +2492,14 @@
 
         .admin-mobile-menu {
             display: none;
-            width: 36px;
-            height: 36px;
+            width: 44px;
+            height: 44px;
             align-items: center;
             justify-content: center;
             padding: 0;
             color: var(--text-primary);
             border: 1px solid var(--border);
-            border-radius: 6px;
+            border-radius: 8px;
             background: var(--bg-tertiary);
             cursor: pointer;
         }
@@ -2280,8 +2508,31 @@
             width: 100%;
             max-width: none;
             margin: 0;
-            padding: 1.5rem 2rem 2rem;
+            padding: 1.75rem 2.5rem 2rem;
             flex: 1 1 auto;
+        }
+
+        .admin-mobile-brand {
+            display: none;
+            min-width: 0;
+            overflow: hidden;
+            color: var(--text-primary);
+            font-size: 0.875rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-overflow: ellipsis;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .sidebar-nav-link:focus-visible,
+        .sidebar-group > summary:focus-visible,
+        .admin-sidebar-brand:focus-visible,
+        .admin-sidebar-logout:focus-visible,
+        .admin-mobile-menu:focus-visible,
+        .admin-topbar-search:focus-visible {
+            outline: 2px solid var(--accent-hover);
+            outline-offset: 2px;
         }
 
         .admin-statusbar {
@@ -2403,16 +2654,60 @@
             }
 
             .admin-topbar {
+                display: flex;
                 padding-inline: 1rem;
+            }
+
+            .admin-mobile-brand {
+                display: block;
             }
 
             .admin-topbar-search {
                 min-width: 0;
-                margin-right: auto;
+                margin-left: auto;
+                padding: 0.5rem;
+            }
+
+            .admin-topbar-search span {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+                clip: rect(0 0 0 0);
+                white-space: nowrap;
             }
 
             .main-content {
                 padding: 1.25rem 1rem 1.5rem;
+            }
+
+            .page-header[data-page-group] {
+                align-items: stretch;
+                flex-direction: column;
+                padding-bottom: 1rem;
+            }
+
+            .page-header-actions,
+            .page-toolbar {
+                width: 100%;
+                justify-content: flex-start;
+            }
+
+            .page-header-actions > .btn,
+            .page-toolbar > .btn {
+                min-height: 44px;
+            }
+
+            .page-header-actions > .form-select,
+            .page-toolbar > .form-select,
+            .page-toolbar > .form-input {
+                flex: 1 1 180px;
+                min-height: 44px;
+            }
+
+            th,
+            td {
+                padding: 0.75rem;
             }
         }
 
@@ -2446,76 +2741,88 @@
                 <img src="{{brandingURL "web-icon" "icon-rounded.png"}}" alt="">
                 <span class="admin-sidebar-brand-copy">
                     <span class="admin-sidebar-brand-title">Mediastorm</span>
-                    <span class="admin-sidebar-brand-build">build {{.BuildID}}</span>
+                    <span class="admin-sidebar-brand-build">{{if .IsAdmin}}Admin{{else}}Account{{end}} · build {{.BuildID}}</span>
                 </span>
             </a>
 
             <nav class="admin-sidebar-nav" id="navMenu">
-                <details class="sidebar-group" {{if or (hasSuffix .CurrentPath "/status") (eq .CurrentPath .BasePath)}}open{{end}}>
-                    <summary><span>Overview</span><span class="sidebar-group-chevron">›</span></summary>
+                <a href="{{.BasePath}}" class="sidebar-nav-link sidebar-primary-link {{if or (hasSuffix .CurrentPath "/status") (eq .CurrentPath .BasePath)}}active{{end}}" {{if or (hasSuffix .CurrentPath "/status") (eq .CurrentPath .BasePath)}}aria-current="page"{{end}} data-walkthrough-target="dashboard">
+                    <svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V21h14V9.5"/><path d="M9 21v-7h6v7"/></svg><span>Dashboard</span>
+                </a>
+
+                <details class="sidebar-group {{if hasSuffix .CurrentPath "/playback"}}current{{end}}" {{if hasSuffix .CurrentPath "/playback"}}open{{end}}>
+                    <summary><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m10 8 6 4-6 4Z"/></svg><span>Playback</span></span><span class="sidebar-group-chevron">›</span></summary>
                     <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}" class="sidebar-nav-link {{if or (hasSuffix .CurrentPath "/status") (eq .CurrentPath .BasePath)}}active{{end}}" data-walkthrough-target="dashboard">
-                            <svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V21h14V9.5"/><path d="M9 21v-7h6v7"/></svg><span>Dashboard</span>
-                        </a>
+                        <a href="{{.BasePath}}/playback" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/playback"}}active{{end}}" {{if hasSuffix .CurrentPath "/playback"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m10 8 6 4-6 4Z"/></svg><span>Web Player</span></a>
+                        <a href="{{.ServerBasePath}}/watch" class="sidebar-nav-link"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="13" rx="2"/><path d="M8 21h8M12 17v4"/></svg><span>Web App</span></a>
+                        <a href="{{.ServerBasePath}}/watch-party" class="sidebar-nav-link"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="9" r="3"/><circle cx="17" cy="8" r="2"/><path d="M3 20v-1a6 6 0 0 1 12 0v1M15 14a4 4 0 0 1 6 3.5V19"/></svg><span>Watch Together</span></a>
                     </div>
                 </details>
 
-                <details class="sidebar-group" {{if hasSuffix .CurrentPath "/playback"}}open{{end}}>
-                    <summary><span>Playback</span><span class="sidebar-group-chevron">›</span></summary>
+                <details class="sidebar-group {{if or (hasSuffix .CurrentPath "/history") (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule") (hasSuffix .CurrentPath "/recordings") (hasSuffix .CurrentPath "/library")}}current{{end}}" {{if or (hasSuffix .CurrentPath "/history") (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule") (hasSuffix .CurrentPath "/recordings") (hasSuffix .CurrentPath "/library")}}open{{end}}>
+                    <summary data-walkthrough-target="media" data-walkthrough-mobile-target="media"><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h6l2 2h8v12H4Z"/></svg><span>Library &amp; activity</span></span><span class="sidebar-group-chevron">›</span></summary>
                     <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}/playback" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/playback"}}active{{end}}">
-                            <svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m10 8 6 4-6 4Z"/></svg><span>Admin Player</span>
-                        </a>
-                        <a href="{{.ServerBasePath}}/watch" class="sidebar-nav-link">
-                            <svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="13" rx="2"/><path d="M8 21h8M12 17v4"/></svg><span>Web App</span>
-                        </a>
+                        {{if .IsAdmin}}<a href="{{.BasePath}}/library" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/library"}}active{{end}}" {{if hasSuffix .CurrentPath "/library"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h6l2 2h8v12H4Z"/></svg><span>Library</span></a>{{end}}
+                        <a href="{{.BasePath}}/history" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/history"}}active{{end}}" {{if hasSuffix .CurrentPath "/history"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><span>Watch history</span></a>
+                        <a href="{{.BasePath}}/schedule" class="sidebar-nav-link {{if or (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule")}}active{{end}}" {{if or (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule")}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg><span>Schedule</span></a>
+                        <a href="{{.BasePath}}/recordings" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/recordings"}}active{{end}}" {{if hasSuffix .CurrentPath "/recordings"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg><span>Recordings</span></a>
                     </div>
                 </details>
 
-                <details class="sidebar-group" {{if or (hasSuffix .CurrentPath "/settings") (hasSuffix .CurrentPath "/tasks") (hasSuffix .CurrentPath "/integrations")}}open{{end}}>
-                    <summary data-walkthrough-target="settings"><span>Manage</span><span class="sidebar-group-chevron">›</span></summary>
+                <details class="sidebar-group {{if hasSuffix .CurrentPath "/accounts"}}current{{end}}" {{if hasSuffix .CurrentPath "/accounts"}}open{{end}}>
+                    <summary><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 20v-1.5a3.5 3.5 0 0 0-3.5-3.5h-5A3.5 3.5 0 0 0 4 18.5V20"/><circle cx="10" cy="8" r="4"/><path d="M17 11a3 3 0 0 1 0 6M20 20v-1.5a3.5 3.5 0 0 0-2-3.2"/></svg><span>People &amp; access</span></span><span class="sidebar-group-chevron">›</span></summary>
                     <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}/settings" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/settings"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.86 2.86-.06-.06A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.1V21H9.6v-.1A1.7 1.7 0 0 0 8.6 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.86-2.86.06-.06A1.7 1.7 0 0 0 4.2 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.1-.4H2.4V9.6h.1A1.7 1.7 0 0 0 4.2 8.6a1.7 1.7 0 0 0-.34-1.88l-.06-.06L6.66 3.8l.06.06A1.7 1.7 0 0 0 8.6 4.2a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.1V2.4h4v.1a1.7 1.7 0 0 0 1 1.7 1.7 1.7 0 0 0 1.88-.34l.06-.06 2.86 2.86-.06.06A1.7 1.7 0 0 0 19.4 8.6a1.7 1.7 0 0 0 .6 1 1.7 1.7 0 0 0 1.1.4h.1v4h-.1a1.7 1.7 0 0 0-1.7 1Z"/></svg><span>Settings</span></a>
-                        <a href="{{.BasePath}}/tasks" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/tasks"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 7h-5V2"/><path d="M20 7a9 9 0 1 0 1 8"/></svg><span>Automations</span></a>
-                        <a href="{{.BasePath}}/integrations" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/integrations"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 12h8M9 7V3M15 7V3M7 7h10v4a5 5 0 0 1-10 0Z"/><path d="M12 16v5"/></svg><span>Integrations</span></a>
+                        <a href="{{.BasePath}}/accounts" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/accounts"}}active{{end}}" {{if hasSuffix .CurrentPath "/accounts"}}aria-current="page"{{end}} data-walkthrough-target="accounts"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 20v-1.5a3.5 3.5 0 0 0-3.5-3.5h-5A3.5 3.5 0 0 0 4 18.5V20"/><circle cx="10" cy="8" r="4"/><path d="M17 11a3 3 0 0 1 0 6M20 20v-1.5a3.5 3.5 0 0 0-2-3.2"/></svg><span>Households &amp; people</span></a>
                     </div>
                 </details>
 
-                <details class="sidebar-group" {{if or (hasSuffix .CurrentPath "/history") (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule") (hasSuffix .CurrentPath "/recordings") (hasSuffix .CurrentPath "/library") (hasSuffix .CurrentPath "/prequeue")}}open{{end}}>
-                    <summary data-walkthrough-target="media" data-walkthrough-mobile-target="media"><span>Media</span><span class="sidebar-group-chevron">›</span></summary>
+                <details class="sidebar-group {{if or (hasSuffix .CurrentPath "/settings") (hasSuffix .CurrentPath "/tasks") (hasSuffix .CurrentPath "/integrations")}}current{{end}}" {{if or (hasSuffix .CurrentPath "/settings") (hasSuffix .CurrentPath "/tasks") (hasSuffix .CurrentPath "/integrations")}}open{{end}}>
+                    <summary data-walkthrough-target="settings"><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.86 2.86-.06-.06A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.1V21H9.6v-.1A1.7 1.7 0 0 0 8.6 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.86-2.86.06-.06A1.7 1.7 0 0 0 4.2 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.1-.4H2.4V9.6h.1A1.7 1.7 0 0 0 4.2 8.6a1.7 1.7 0 0 0-.34-1.88l-.06-.06L6.66 3.8l.06.06A1.7 1.7 0 0 0 8.6 4.2a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.1V2.4h4v.1a1.7 1.7 0 0 0 1 1.7 1.7 1.7 0 0 0 1.88-.34l.06-.06 2.86 2.86-.06.06A1.7 1.7 0 0 0 19.4 8.6a1.7 1.7 0 0 0 .6 1 1.7 1.7 0 0 0 1.1.4h.1v4h-.1a1.7 1.7 0 0 0-1.7 1Z"/></svg><span>Settings</span></span><span class="sidebar-group-chevron">›</span></summary>
                     <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}/history" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/history"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><span>Watch History</span></a>
-                        <a href="{{.BasePath}}/schedule" class="sidebar-nav-link {{if or (hasSuffix .CurrentPath "/calendar") (hasSuffix .CurrentPath "/schedule")}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M16 3v4M8 3v4M3 10h18"/></svg><span>Schedule</span></a>
-                        <a href="{{.BasePath}}/recordings" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/recordings"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg><span>Recordings</span></a>
-                        {{if .IsAdmin}}<a href="{{.BasePath}}/library" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/library"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h6l2 2h8v12H4Z"/></svg><span>Library</span></a>{{end}}
-                        {{if .IsAdmin}}<a href="{{.BasePath}}/prequeue" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/prequeue"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg><span>Prequeue</span></a>{{end}}
+                        <a href="{{.BasePath}}/settings?view=dashboard" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/settings"}}active{{end}}" {{if hasSuffix .CurrentPath "/settings"}}aria-current="page"{{end}} data-settings-destination="home"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg><span>Settings dashboard</span></a>
+                        <a href="{{.BasePath}}/settings?category=sources" class="sidebar-nav-link" data-settings-destination="sources"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v7c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12v7c0 1.7 3.6 3 8 3s8-1.3 8-3v-7"/></svg><span>Sources</span></a>
+                        <a href="{{.BasePath}}/settings?category=search" class="sidebar-nav-link" data-settings-destination="search"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10" cy="10" r="6"/><path d="m15 15 5 5M17 4v4M15 6h4"/></svg><span>Search &amp; quality</span></a>
+                        <a href="{{.BasePath}}/settings?category=playback" class="sidebar-nav-link" data-settings-destination="playback"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m10 8 6 4-6 4ZM5 19h14"/></svg><span>Playback &amp; subtitles</span></a>
+                        <a href="{{.BasePath}}/settings?category=interface" class="sidebar-nav-link" data-settings-destination="interface"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5M5 9.5V21h14V9.5"/><circle cx="16" cy="13" r="2"/></svg><span>Home</span></a>
+                        <a href="{{.BasePath}}/settings?category=appearance" class="sidebar-nav-link" data-settings-destination="appearance"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 9v12"/></svg><span>Appearance &amp; Branding</span></a>
+                        <a href="{{.BasePath}}/settings?category=metadata" class="sidebar-nav-link" data-settings-destination="metadata"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h7l9 9-7 7-9-9Z"/><circle cx="8" cy="8" r="1"/><path d="M14 7h5v5"/></svg><span>Metadata</span></a>
+                        <a href="{{.BasePath}}/settings?category=server" class="sidebar-nav-link" data-settings-destination="server"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="18" height="7" rx="2"/><rect x="3" y="14" width="18" height="7" rx="2"/><path d="M7 6.5h.01M7 17.5h.01M11 6.5h7M11 17.5h7"/></svg><span>Server &amp; network</span></a>
+                        <a href="{{.BasePath}}/integrations" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/integrations"}}active{{end}}" {{if hasSuffix .CurrentPath "/integrations"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 12h8M9 7V3M15 7V3M7 7h10v4a5 5 0 0 1-10 0Z"/><path d="M12 16v5"/></svg><span>Integrations</span></a>
+                        <a href="{{.BasePath}}/tasks" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/tasks"}}active{{end}}" {{if hasSuffix .CurrentPath "/tasks"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 7h-5V2"/><path d="M20 7a9 9 0 1 0 1 8"/></svg><span>Automations</span></a>
                     </div>
                 </details>
 
                 {{if .IsAdmin}}
-                <details class="sidebar-group" {{if or (hasSuffix .CurrentPath "/search") (hasSuffix .CurrentPath "/connections") (hasSuffix .CurrentPath "/backup") (hasSuffix .CurrentPath "/performance") (hasSuffix .CurrentPath "/tools") (hasSuffix .CurrentPath "/logs") (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")}}open{{end}}>
-                    <summary data-walkthrough-target="system" data-walkthrough-mobile-target="system"><span>System</span><span class="sidebar-group-chevron">›</span></summary>
+                <details class="sidebar-group {{if or (hasSuffix .CurrentPath "/connections") (hasSuffix .CurrentPath "/performance") (hasSuffix .CurrentPath "/logs")}}current{{end}}" {{if or (hasSuffix .CurrentPath "/connections") (hasSuffix .CurrentPath "/performance") (hasSuffix .CurrentPath "/logs")}}open{{end}}>
+                    <summary data-walkthrough-target="system" data-walkthrough-mobile-target="system"><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Operations</span></span><span class="sidebar-admin-badge">Admin</span><span class="sidebar-group-chevron">›</span></summary>
                     <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}/search" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/search"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg><span>Search Diagnostics</span></a>
-                        <a href="{{.BasePath}}/connections" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/connections"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="6" cy="12" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="18" cy="18" r="2"/><path d="m8 11 8-4M8 13l8 4"/></svg><span>Connections</span></a>
-                        <a href="{{.BasePath}}/backup" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/backup"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 16V4M7 9l5-5 5 5"/><path d="M5 13v7h14v-7"/></svg><span>Backup</span></a>
-                        <a href="{{.BasePath}}/performance" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/performance"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Performance</span></a>
-                        <a href="{{.BasePath}}/tools" class="sidebar-nav-link {{if and (hasSuffix .CurrentPath "/tools") (not (or (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")))}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m14 7 3-3 3 3-3 3M4 20l8-8"/><path d="m5 4 15 15M4 5l3-1 1 3-3 1Z"/></svg><span>Maintenance</span></a>
-                        <a href="{{.BasePath}}/logs" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/logs"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3h9l4 4v14H6Z"/><path d="M15 3v5h5M9 13h6M9 17h6"/></svg><span>Logs</span></a>
-                        <a href="{{.BasePath}}/tools/hidden-items" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/hidden-items"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3l18 18M10.5 10.7a2 2 0 0 0 2.8 2.8M9.5 5.3A10.8 10.8 0 0 1 12 5c5 0 9 7 9 7a15 15 0 0 1-2.1 2.7M6.2 6.2C4.2 7.6 3 12 3 12s4 7 9 7c1.2 0 2.4-.4 3.4-1"/></svg><span>Hidden Items</span></a>
-                        <a href="{{.BasePath}}/tools/resolved-nzbs" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/resolved-nzbs"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></svg><span>Resolved NZBs</span></a>
-                        <a href="{{.BasePath}}/tools/bad-streams" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/bad-streams"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m6 6 12 12"/></svg><span>Bad Streams</span></a>
-                        <a href="{{.BasePath}}/tools/share-links" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/share-links"}}active{{end}}"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 4h6v6M20 4l-9 9"/><path d="M18 13v7H4V6h7"/></svg><span>Share Links</span></a>
+                        <a href="{{.BasePath}}/connections" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/connections"}}active{{end}}" {{if hasSuffix .CurrentPath "/connections"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="6" cy="12" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="18" cy="18" r="2"/><path d="m8 11 8-4M8 13l8 4"/></svg><span>Connections</span></a>
+                        <a href="{{.BasePath}}/performance" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/performance"}}active{{end}}" {{if hasSuffix .CurrentPath "/performance"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Performance</span></a>
+                        <a href="{{.BasePath}}/logs" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/logs"}}active{{end}}" {{if hasSuffix .CurrentPath "/logs"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3h9l4 4v14H6Z"/><path d="M15 3v5h5M9 13h6M9 17h6"/></svg><span>Logs</span></a>
+                    </div>
+                </details>
+
+                <details class="sidebar-group {{if hasSuffix .CurrentPath "/search"}}current{{end}}" {{if hasSuffix .CurrentPath "/search"}}open{{end}}>
+                    <summary><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg><span>Search</span></span><span class="sidebar-admin-badge">Admin</span><span class="sidebar-group-chevron">›</span></summary>
+                    <div class="sidebar-group-items">
+                        <a href="{{.BasePath}}/search#content-search" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/search"}}active{{end}}" {{if hasSuffix .CurrentPath "/search"}}aria-current="page"{{end}} data-search-destination="content-search"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg><span>Content Search</span></a>
+                        <a href="{{.BasePath}}/search#searchDiagnostics" class="sidebar-nav-link" data-search-destination="searchDiagnostics"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Search Diagnostics</span></a>
+                    </div>
+                </details>
+
+                <details class="sidebar-group {{if or (hasSuffix .CurrentPath "/backup") (hasSuffix .CurrentPath "/tools") (hasSuffix .CurrentPath "/prequeue") (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")}}current{{end}}" {{if or (hasSuffix .CurrentPath "/backup") (hasSuffix .CurrentPath "/tools") (hasSuffix .CurrentPath "/prequeue") (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")}}open{{end}}>
+                    <summary><span class="sidebar-group-summary-main"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m14 7 3-3 3 3-3 3M4 20l8-8"/><path d="m5 4 15 15M4 5l3-1 1 3-3 1Z"/></svg><span>Maintenance &amp; records</span></span><span class="sidebar-admin-badge">Admin</span><span class="sidebar-group-chevron">›</span></summary>
+                    <div class="sidebar-group-items">
+                        <a href="{{.BasePath}}/tools" class="sidebar-nav-link {{if and (hasSuffix .CurrentPath "/tools") (not (or (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")))}}active{{end}}" {{if and (hasSuffix .CurrentPath "/tools") (not (or (hasSuffix .CurrentPath "/hidden-items") (hasSuffix .CurrentPath "/resolved-nzbs") (hasSuffix .CurrentPath "/bad-streams") (hasSuffix .CurrentPath "/share-links")))}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m14 7 3-3 3 3-3 3M4 20l8-8"/><path d="m5 4 15 15M4 5l3-1 1 3-3 1Z"/></svg><span>Maintenance</span></a>
+                        <a href="{{.BasePath}}/backup" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/backup"}}active{{end}}" {{if hasSuffix .CurrentPath "/backup"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 16V4M7 9l5-5 5 5"/><path d="M5 13v7h14v-7"/></svg><span>Backup</span></a>
+                        <a href="{{.BasePath}}/prequeue" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/prequeue"}}active{{end}}" {{if hasSuffix .CurrentPath "/prequeue"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg><span>Prequeue</span></a>
+                        <a href="{{.BasePath}}/tools/hidden-items" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/hidden-items"}}active{{end}}" {{if hasSuffix .CurrentPath "/hidden-items"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3l18 18M10.5 10.7a2 2 0 0 0 2.8 2.8M9.5 5.3A10.8 10.8 0 0 1 12 5c5 0 9 7 9 7a15 15 0 0 1-2.1 2.7M6.2 6.2C4.2 7.6 3 12 3 12s4 7 9 7c1.2 0 2.4-.4 3.4-1"/></svg><span>Hidden items</span></a>
+                        <a href="{{.BasePath}}/tools/resolved-nzbs" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/resolved-nzbs"}}active{{end}}" {{if hasSuffix .CurrentPath "/resolved-nzbs"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></svg><span>Resolved NZBs</span></a>
+                        <a href="{{.BasePath}}/tools/bad-streams" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/bad-streams"}}active{{end}}" {{if hasSuffix .CurrentPath "/bad-streams"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m6 6 12 12"/></svg><span>Bad streams</span></a>
+                        <a href="{{.BasePath}}/tools/share-links" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/share-links"}}active{{end}}" {{if hasSuffix .CurrentPath "/share-links"}}aria-current="page"{{end}}><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 4h6v6M20 4l-9 9"/><path d="M18 13v7H4V6h7"/></svg><span>Share links</span></a>
                     </div>
                 </details>
                 {{end}}
-
-                <details class="sidebar-group" {{if hasSuffix .CurrentPath "/accounts"}}open{{end}}>
-                    <summary><span>People</span><span class="sidebar-group-chevron">›</span></summary>
-                    <div class="sidebar-group-items">
-                        <a href="{{.BasePath}}/accounts" class="sidebar-nav-link {{if hasSuffix .CurrentPath "/accounts"}}active{{end}}" data-walkthrough-target="accounts"><svg class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 20v-1.5a3.5 3.5 0 0 0-3.5-3.5h-5A3.5 3.5 0 0 0 4 18.5V20"/><circle cx="10" cy="8" r="4"/><path d="M17 11a3 3 0 0 1 0 6M20 20v-1.5a3.5 3.5 0 0 0-2-3.2"/></svg><span>Users</span></a>
-                    </div>
-                </details>
             </nav>
 
             <footer class="admin-sidebar-footer">
@@ -2525,7 +2832,7 @@
                         <span class="admin-sidebar-user-name">{{.Username}}</span>
                         <span class="admin-sidebar-user-role">{{if .IsAdmin}}Administrator{{else}}Account{{end}}</span>
                     </span>
-                    <a href="{{.BasePath}}/logout" class="admin-sidebar-logout">Logout</a>
+                    <a href="{{.BasePath}}/logout" class="admin-sidebar-logout" aria-label="Sign out" title="Sign out">↗</a>
                 </div>
                 <div class="admin-sidebar-version">v{{.Version}}</div>
             </footer>
@@ -2538,6 +2845,7 @@
                 <button class="admin-mobile-menu" type="button" aria-label="Open navigation" aria-controls="adminSidebar" aria-expanded="false" onclick="toggleMenu()">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
                 </button>
+                <span class="admin-mobile-brand">Mediastorm</span>
                 {{if .IsAdmin}}<a href="{{.BasePath}}/search" class="admin-topbar-search" aria-label="Open search diagnostics"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg><span>Search…</span></a>{{end}}
             </header>
 
@@ -2648,8 +2956,34 @@
             return window.matchMedia('(max-width: 768px)').matches;
         }
 
+        function syncSettingsSidebarDestination(resolvedDestination = '') {
+            if (!window.location.pathname.endsWith('/settings')) return;
+            const settingsParams = new URLSearchParams(window.location.search);
+            const destination = resolvedDestination || settingsParams.get('category') || 'home';
+            document.querySelectorAll('[data-settings-destination]').forEach(link => {
+                const isActive = link.dataset.settingsDestination === destination;
+                link.classList.toggle('active', isActive);
+                if (isActive) link.setAttribute('aria-current', 'page');
+                else link.removeAttribute('aria-current');
+            });
+        }
+
+        function syncSearchSidebarDestination() {
+            if (!window.location.pathname.endsWith('/search')) return;
+            const destination = window.location.hash === '#searchDiagnostics' ? 'searchDiagnostics' : 'content-search';
+            document.querySelectorAll('[data-search-destination]').forEach(link => {
+                const isActive = link.dataset.searchDestination === destination;
+                link.classList.toggle('active', isActive);
+                if (isActive) link.setAttribute('aria-current', 'location');
+                else link.removeAttribute('aria-current');
+            });
+        }
+
         document.addEventListener('DOMContentLoaded', () => {
             syncMobileMenuAccessibility();
+            syncSettingsSidebarDestination();
+            syncSearchSidebarDestination();
+            window.addEventListener('hashchange', syncSearchSidebarDestination);
 
             document.querySelectorAll('.sidebar-group').forEach(group => {
                 group.addEventListener('toggle', () => {

--- a/backend/handlers/admin_templates/calendar.html
+++ b/backend/handlers/admin_templates/calendar.html
@@ -4,9 +4,12 @@
 
 {{define "content"}}
 {{if .NoProfiles}}
-<div class="page-header">
-    <h1>Schedule</h1>
-    <p>Upcoming episodes and movie releases</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Schedule</h1>
+        <p>See upcoming episodes and movie releases from connected sources.</p>
+    </div>
 </div>
 <div class="card" style="margin-top: 2rem;">
     <div class="card-body" style="text-align: center; padding: 3rem;">
@@ -21,12 +24,13 @@
     </div>
 </div>
 {{else}}
-<div class="page-header" style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 1rem;">
-    <div>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
         <h1>Schedule</h1>
-        <p>Upcoming episodes and movie releases from your sources</p>
+        <p>See upcoming episodes and movie releases from connected sources.</p>
     </div>
-    <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
+    <div class="page-header-actions">
         <select id="profileSelect" class="form-select" style="min-width: 200px;" onchange="loadCalendar()">
             {{range .Users}}
             <option value="{{.ID}}">{{.Name}}</option>
@@ -50,7 +54,7 @@
 </div>
 
 <!-- View Controls -->
-<div style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
+<div class="page-toolbar" style="justify-content: space-between;" aria-label="Schedule view controls">
     <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
         <button id="viewListBtn" class="btn btn-primary" onclick="setViewMode('list')">List View</button>
         <button id="viewCalendarBtn" class="btn btn-secondary" onclick="setViewMode('calendar')">Calendar View</button>

--- a/backend/handlers/admin_templates/connections.html
+++ b/backend/handlers/admin_templates/connections.html
@@ -3,73 +3,17 @@
 {{define "title"}}Connections - mediastorm Admin{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Service Connections</h1>
-    <p>Health check for all configured services</p>
-    <button class="btn btn-primary" id="retest-all-btn" onclick="runAllTests()">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-        Retest All
-    </button>
-</div>
-
-<div class="search-diagnostics">
-    <button class="collapsible-panel-toggle" type="button" aria-expanded="false" aria-controls="search-diagnostics-content" onclick="toggleConnectionsPanel(this)">
-        <div>
-            <h2>Search Diagnostics</h2>
-            <p>Run a real search against enabled indexers and torrent sources to tune search timeout.</p>
-        </div>
-        <svg class="collapsible-panel-chevron" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <polyline points="6 9 12 15 18 9"/>
-        </svg>
-    </button>
-    <div id="search-diagnostics-content" class="collapsible-panel-content" hidden>
-        <div class="search-diagnostics-actions">
-            <button class="btn btn-secondary" id="save-timeout-btn" onclick="saveSearchTimeout()">Save Timeout</button>
-            <button class="btn btn-primary" id="run-search-diagnostics-btn" onclick="runSearchDiagnostics()">Run Search Test</button>
-        </div>
-        <div class="search-diagnostics-controls">
-            <label>
-                <span>Query</span>
-                <input type="text" id="diag-query" value="The Matrix" autocomplete="off">
-            </label>
-            <label>
-                <span>IMDb ID</span>
-                <input type="text" id="diag-imdb" value="tt0133093" autocomplete="off">
-            </label>
-            <label>
-                <span>Year</span>
-                <input type="number" id="diag-year" value="1999" min="1900" max="2100">
-            </label>
-            <label>
-                <span>Type</span>
-                <select id="diag-media-type">
-                    <option value="movie" selected>Movie</option>
-                    <option value="series">Series</option>
-                </select>
-            </label>
-            <label>
-                <span>Timeout</span>
-                <input type="number" id="diag-timeout" min="0.1" max="120" step="0.1" value="{{.Settings.Streaming.IndexerTimeoutSec}}">
-            </label>
-        </div>
-        <div id="search-diagnostics-summary" class="search-diagnostics-summary">Not run yet.</div>
-        <div id="search-timeout-recommendation" class="search-timeout-recommendation"></div>
-        <div class="search-diagnostics-table-wrap">
-            <table class="search-diagnostics-table">
-                <thead>
-                    <tr>
-                        <th>Source</th>
-                        <th>Kind</th>
-                        <th>Results</th>
-                        <th>Time</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody id="search-diagnostics-results">
-                    <tr><td colspan="5" class="empty-row">Run a search test to compare enabled sources.</td></tr>
-                </tbody>
-            </table>
-        </div>
+<div class="page-header" data-page-group="Configuration &amp; operations">
+    <div class="page-header-copy">
+        <div class="page-kicker">Configuration &amp; operations</div>
+        <h1>Connections</h1>
+        <p>Check configured services and review outbound API use.</p>
+    </div>
+    <div class="page-header-actions">
+        <button class="btn btn-primary" id="retest-all-btn" onclick="runAllTests()">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+            Retest all
+        </button>
     </div>
 </div>
 
@@ -116,7 +60,6 @@
 .page-header { display: flex; align-items: center; gap: 16px; margin-bottom: 24px; flex-wrap: wrap; }
 .page-header h1 { margin: 0; }
 .page-header p { margin: 0; color: var(--text-secondary, #888); flex: 1; }
-.search-diagnostics { background: var(--card-bg, #1a1a2e); border: 1px solid var(--border-color, #333); border-radius: 8px; padding: 16px; margin-bottom: 24px; }
 .collapsible-panel-toggle { width: 100%; display: flex; justify-content: space-between; align-items: center; gap: 16px; border: 0; padding: 0; background: transparent; color: inherit; text-align: left; cursor: pointer; font: inherit; }
 .collapsible-panel-toggle h2 { margin: 0 0 4px 0; font-size: 18px; }
 .collapsible-panel-toggle p { margin: 0; color: var(--text-secondary, #888); font-size: 13px; }
@@ -125,25 +68,7 @@
 .collapsible-panel-toggle[aria-expanded="true"] .collapsible-panel-chevron { transform: rotate(180deg); }
 .collapsible-panel-content { display: flex; flex-direction: column; gap: 14px; margin-top: 14px; }
 .collapsible-panel-content[hidden] { display: none; }
-.search-diagnostics-actions, .api-usage-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
-.search-diagnostics-controls { display: grid; grid-template-columns: minmax(220px, 2fr) minmax(120px, 1fr) 96px 110px 110px; gap: 10px; align-items: end; }
-.search-diagnostics-controls label { display: flex; flex-direction: column; gap: 5px; font-size: 12px; color: var(--text-secondary, #888); }
-.search-diagnostics-controls input,
-.search-diagnostics-controls select { width: 100%; min-height: 36px; border: 1px solid var(--border-color, #333); border-radius: 6px; background: var(--input-bg, #111827); color: var(--text-primary, #fff); padding: 7px 9px; font: inherit; }
-.search-diagnostics-summary { font-size: 13px; color: var(--text-secondary, #888); min-height: 20px; }
-.search-timeout-recommendation { display: none; align-items: center; gap: 10px; flex-wrap: wrap; font-size: 13px; color: var(--text-primary, #fff); }
-.search-timeout-recommendation.active { display: flex; }
-.search-timeout-recommendation button { min-height: 30px; padding: 4px 10px; }
-.search-diagnostics-table-wrap { overflow-x: auto; }
-.search-diagnostics-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.search-diagnostics-table th,
-.search-diagnostics-table td { text-align: left; padding: 9px 8px; border-top: 1px solid var(--border-color, #333); white-space: nowrap; }
-.search-diagnostics-table th { color: var(--text-secondary, #888); font-weight: 600; }
-.search-diagnostics-table .num { text-align: right; font-variant-numeric: tabular-nums; }
-.search-diagnostics-table .empty-row { color: var(--text-secondary, #888); text-align: center; }
-.diag-status-pass { color: var(--success-color, #4caf50); }
-.diag-status-warn { color: var(--warning-color, #ff9800); }
-.diag-status-fail { color: var(--error-color, #f44336); max-width: 360px; overflow: hidden; text-overflow: ellipsis; }
+.api-usage-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
 .api-usage-panel { background: var(--card-bg, #1a1a2e); border: 1px solid var(--border-color, #333); border-radius: 8px; padding: 16px; margin-bottom: 24px; }
 .api-usage-summary { font-size: 13px; color: var(--text-secondary, #888); min-height: 20px; }
 .api-usage-table-wrap { overflow-x: auto; }
@@ -179,16 +104,11 @@
 .conn-card-message { font-size: 12px; color: var(--text-secondary, #888); word-break: break-word; }
 .conn-card-time { font-size: 12px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-@media (max-width: 760px) {
-    .search-diagnostics-controls { grid-template-columns: 1fr 1fr; }
-    .search-diagnostics-controls label:first-child { grid-column: 1 / -1; }
-}
 </style>
 
 <script>
 let settings = {{json .Settings}};
 let testCards = [];
-let latestSearchDiagnostics = null;
 
 function toggleConnectionsPanel(button) {
     const content = document.getElementById(button.getAttribute('aria-controls'));
@@ -282,79 +202,6 @@ async function refreshConnectionsUsage() {
     } catch (err) {
         if (summary) summary.textContent = 'Failed to load API usage: ' + err.message;
     }
-}
-
-function getTimeoutProjection(timeoutSec) {
-    const sources = Array.isArray(latestSearchDiagnostics?.sources) ? latestSearchDiagnostics.sources : [];
-    const cutoffMs = timeoutSec * 1000;
-    const included = sources.filter(source => source.success && Number(source.durationMs || 0) <= cutoffMs);
-    return {
-        sourceCount: included.length,
-        totalSources: sources.length,
-        resultCount: included.reduce((sum, source) => sum + Number(source.count || 0), 0),
-    };
-}
-
-function getRecommendedTimeout() {
-    const sources = Array.isArray(latestSearchDiagnostics?.sources) ? latestSearchDiagnostics.sources : [];
-    const successful = sources
-        .filter(source => source.success && Number(source.count || 0) > 0)
-        .map(source => ({
-            count: Number(source.count || 0),
-            durationMs: Math.max(1, Number(source.durationMs || 0)),
-        }))
-        .sort((a, b) => a.durationMs - b.durationMs);
-
-    const totalResults = successful.reduce((sum, source) => sum + source.count, 0);
-    if (totalResults <= 0) return null;
-
-    const target = Math.ceil(totalResults / 2);
-    let running = 0;
-    for (const source of successful) {
-        running += source.count;
-        if (running >= target) {
-            const timeoutSec = Math.max(0.1, Math.ceil(source.durationMs / 100) / 10);
-            return {
-                timeoutSec,
-                resultCount: running,
-                totalResults,
-            };
-        }
-    }
-    return null;
-}
-
-function renderTimeoutRecommendation() {
-    const el = document.getElementById('search-timeout-recommendation');
-    if (!el) return;
-    const rec = getRecommendedTimeout();
-    if (!rec) {
-        el.className = 'search-timeout-recommendation';
-        el.innerHTML = '';
-        return;
-    }
-    el.className = 'search-timeout-recommendation active';
-    el.innerHTML = `
-        <span>Suggested timeout: <strong>${rec.timeoutSec.toFixed(1)}s</strong> captures at least half this run (${rec.resultCount}/${rec.totalResults} results).</span>
-        <button class="btn btn-secondary" type="button" onclick="applyRecommendedTimeout(${rec.timeoutSec})">Use ${rec.timeoutSec}s</button>
-    `;
-}
-
-function applyRecommendedTimeout(timeoutSec) {
-    const input = document.getElementById('diag-timeout');
-    if (!input) return;
-    input.value = timeoutSec;
-    updateSearchTimeoutProjection();
-}
-
-function updateSearchTimeoutProjection() {
-    if (!latestSearchDiagnostics) return;
-    const timeoutSec = Number(document.getElementById('diag-timeout')?.value || 0);
-    if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) return;
-    const projection = getTimeoutProjection(timeoutSec);
-    const summary = document.getElementById('search-diagnostics-summary');
-    const cap = latestSearchDiagnostics.diagnosticTimeoutSec || 10;
-    summary.textContent = `At ${timeoutSec.toFixed(1)}s, this run would have returned ${projection.resultCount} result${projection.resultCount === 1 ? '' : 's'} from ${projection.sourceCount}/${projection.totalSources} source${projection.totalSources === 1 ? '' : 's'}. Observed with a ${cap}s diagnostic cap.`;
 }
 
 function getScraperBadges(item) {
@@ -567,80 +414,6 @@ async function testPost(endpoint, payload) {
     return resp.json();
 }
 
-async function runSearchDiagnostics() {
-    const btn = document.getElementById('run-search-diagnostics-btn');
-    const summary = document.getElementById('search-diagnostics-summary');
-    const tbody = document.getElementById('search-diagnostics-results');
-    btn.disabled = true;
-    summary.textContent = 'Searching enabled sources...';
-    tbody.innerHTML = '<tr><td colspan="5" class="empty-row">Searching...</td></tr>';
-
-    const startedAt = performance.now();
-    try {
-        const result = await testPost(basePath + '/api/connections/search-diagnostics', {
-            query: document.getElementById('diag-query').value.trim(),
-            imdbId: document.getElementById('diag-imdb').value.trim(),
-            year: Number(document.getElementById('diag-year').value) || 0,
-            mediaType: document.getElementById('diag-media-type').value
-        });
-        if (result.error) throw new Error(result.error);
-
-        const sources = Array.isArray(result.sources) ? result.sources : [];
-        latestSearchDiagnostics = result;
-        if (document.getElementById('diag-timeout')) {
-            document.getElementById('diag-timeout').value = result.timeoutSec || settings.streaming?.indexerTimeoutSec || 5;
-        }
-        summary.textContent = `${result.totalResults || 0} total result${result.totalResults === 1 ? '' : 's'} across ${sources.length} source${sources.length === 1 ? '' : 's'} in ${formatDuration(result.durationMs ?? (performance.now() - startedAt))}. Observed with a ${result.diagnosticTimeoutSec || 10}s diagnostic cap.`;
-        if (!sources.length) {
-            tbody.innerHTML = '<tr><td colspan="5" class="empty-row">No enabled search sources found.</td></tr>';
-        } else {
-            const sorted = sources.slice().sort((a, b) => (b.count || 0) - (a.count || 0) || (a.durationMs || 0) - (b.durationMs || 0));
-            tbody.innerHTML = sorted.map(source => `
-                <tr>
-                    <td>${escapeHtml(source.name || 'Source')}</td>
-                    <td>${escapeHtml((source.group || '') + (source.type ? ' / ' + source.type : ''))}</td>
-                    <td class="num">${Number(source.count || 0).toLocaleString()}</td>
-                    <td class="num">${formatDuration(source.durationMs || 0)}</td>
-                    <td class="${!source.success ? 'diag-status-fail' : (source.count > 0 ? 'diag-status-pass' : 'diag-status-warn')}">${!source.success ? escapeHtml(source.error || 'Failed') : (source.count > 0 ? 'OK' : 'Reachable, 0 results')}</td>
-                </tr>
-            `).join('');
-            renderTimeoutRecommendation();
-            updateSearchTimeoutProjection();
-        }
-    } catch (err) {
-        latestSearchDiagnostics = null;
-        renderTimeoutRecommendation();
-        summary.textContent = 'Search diagnostics failed: ' + err.message;
-        tbody.innerHTML = '<tr><td colspan="5" class="empty-row">Search diagnostics failed.</td></tr>';
-    } finally {
-        btn.disabled = false;
-        refreshConnectionsUsage();
-    }
-}
-
-async function saveSearchTimeout() {
-    const btn = document.getElementById('save-timeout-btn');
-    const summary = document.getElementById('search-diagnostics-summary');
-    const timeoutSec = Number(document.getElementById('diag-timeout').value);
-    if (!Number.isFinite(timeoutSec) || timeoutSec < 0.1 || timeoutSec > 120) {
-        summary.textContent = 'Timeout must be between 0.1 and 120 seconds.';
-        return;
-    }
-    btn.disabled = true;
-    try {
-        const result = await testPost(basePath + '/api/connections/search-timeout', { timeoutSec });
-        if (!result.success) throw new Error(result.error || 'Failed to save timeout');
-        settings.streaming = settings.streaming || {};
-        settings.streaming.indexerTimeoutSec = result.timeoutSec;
-        summary.textContent = `Search timeout saved at ${result.timeoutSec}s.`;
-    } catch (err) {
-        summary.textContent = 'Failed to save timeout: ' + err.message;
-    } finally {
-        btn.disabled = false;
-        refreshConnectionsUsage();
-    }
-}
-
 async function runAllTests() {
     const btn = document.getElementById('retest-all-btn');
     btn.disabled = true;
@@ -766,14 +539,6 @@ async function runAllTests() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const timeoutInput = document.getElementById('diag-timeout');
-    if (timeoutInput && Number(timeoutInput.value) <= 0) {
-        timeoutInput.value = settings.streaming?.indexerTimeoutSec || 5;
-    }
-    if (timeoutInput) {
-        timeoutInput.addEventListener('input', updateSearchTimeoutProjection);
-        timeoutInput.addEventListener('change', updateSearchTimeoutProjection);
-    }
     buildCards();
     renderCards();
     refreshConnectionsUsage();

--- a/backend/handlers/admin_templates/hidden_items.html
+++ b/backend/handlers/admin_templates/hidden_items.html
@@ -3,9 +3,12 @@
 {{define "title"}}Hidden Items - mediastorm Admin{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Hidden Items</h1>
-    <p>Manage titles hidden from home shelves, watchlist, Explore More, and list pages.</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Hidden items</h1>
+        <p>Review titles hidden from home shelves, watchlists, Explore More, and list pages.</p>
+    </div>
 </div>
 
 <div class="settings-group">
@@ -53,7 +56,7 @@
                         <div class="text-muted" style="font-size:0.85rem;word-break:break-word;">{{.MediaType}} · {{.ID}}</div>
                         {{if .ProfileName}}<div class="text-muted" style="font-size:0.8rem;">Profile: {{.ProfileName}}</div>{{end}}
                     </div>
-                    <button class="btn btn-danger btn-sm" style="flex:0 0 auto;" data-user-id="{{.UserID}}" data-media-type="{{.MediaType}}" data-item-id="{{.ID}}" onclick="unhideItem(this.dataset.userId, this.dataset.mediaType, encodeURIComponent(this.dataset.itemId))">Unhide</button>
+                    <button class="btn btn-secondary btn-sm" style="flex:0 0 auto;" data-user-id="{{.UserID}}" data-media-type="{{.MediaType}}" data-item-id="{{.ID}}" onclick="unhideItem(this.dataset.userId, this.dataset.mediaType, encodeURIComponent(this.dataset.itemId))">Unhide</button>
                 </div>
                 {{end}}
             </div>
@@ -118,7 +121,7 @@ async function loadHiddenItems() {
                             <div class="text-muted" style="font-size:0.85rem;">${formatMediaType(item.mediaType)} · ${escapeHtml(item.id)}</div>
                             ${profile}
                         </div>
-                        <button class="btn btn-danger btn-sm" onclick="unhideItem('${jsString(item.userId || select.value)}', '${jsString(item.mediaType)}', '${encodeURIComponent(item.id)}')">Unhide</button>
+                        <button class="btn btn-secondary btn-sm" onclick="unhideItem('${jsString(item.userId || select.value)}', '${jsString(item.mediaType)}', '${encodeURIComponent(item.id)}')">Unhide</button>
                 </div>`;
         }).join('');
     } catch (error) {

--- a/backend/handlers/admin_templates/history.html
+++ b/backend/handlers/admin_templates/history.html
@@ -4,9 +4,12 @@
 
 {{define "content"}}
 {{if .NoProfiles}}
-<div class="page-header">
-    <h1>Watch History</h1>
-    <p>View watch history by profile</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Watch history</h1>
+        <p>Review recently watched movies and episodes by profile.</p>
+    </div>
 </div>
 <div class="card" style="margin-top: 2rem;">
     <div class="card-body" style="text-align: center; padding: 3rem;">
@@ -19,12 +22,13 @@
     </div>
 </div>
 {{else}}
-<div class="page-header" style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 1rem;">
-    <div>
-        <h1>Watch History</h1>
-        <p>View watch history by profile</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Watch history</h1>
+        <p>Review recently watched movies and episodes by profile.</p>
     </div>
-    <div style="display: flex; align-items: center; gap: 1rem;">
+    <div class="page-header-actions">
         <select id="profileSelect" class="form-select" style="min-width: 200px;" onchange="loadHistory()">
             <option value="all" selected>All Profiles</option>
             {{range .Users}}
@@ -62,7 +66,7 @@
 </div>
 
 <!-- Filter Tabs -->
-<div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+<div class="page-toolbar" aria-label="Watch history filters">
     <button class="btn btn-primary filter-btn active" data-filter="all" onclick="filterHistory('all', this)">All</button>
     <button class="btn btn-secondary filter-btn" data-filter="movie" onclick="filterHistory('movie', this)">Movies</button>
     <button class="btn btn-secondary filter-btn" data-filter="episode" onclick="filterHistory('episode', this)">Episodes</button>

--- a/backend/handlers/admin_templates/kids_settings.html
+++ b/backend/handlers/admin_templates/kids_settings.html
@@ -5,17 +5,20 @@
 {{define "title"}}Kids Profile Settings - {{if .IsAdmin}}mediastorm Admin{{else}}mediastorm account{{end}}{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem;">
+<div class="page-header" data-page-group="People &amp; communication">
+    <div class="page-header-copy">
+        <div class="page-kicker">People &amp; communication</div>
+        <h1>Kids profile settings</h1>
+        <p id="profile-name-display">Loading...</p>
+    </div>
+    <div class="page-header-actions">
         <a href="{{.BasePath}}/accounts" class="btn btn-secondary btn-sm">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 16px; height: 16px;">
                 <line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>
             </svg>
-            Back to Profiles
+            Back to people
         </a>
     </div>
-    <h1>Kids Profile Settings</h1>
-    <p id="profile-name-display">Loading...</p>
 </div>
 
 <div class="grid" style="gap: 1.5rem;">

--- a/backend/handlers/admin_templates/library.html
+++ b/backend/handlers/admin_templates/library.html
@@ -5,20 +5,27 @@
 {{define "title"}}Library - mediastorm Admin{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Library Management</h1>
-    <p>Add local, Plex, and Jellyfin libraries, inspect their files, and control playback sources.</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Library</h1>
+        <p>Add local or connected libraries, scan files, and manage playback sources.</p>
+    </div>
 </div>
 
-<div class="grid grid-2" style="align-items: start;">
-    <div class="card">
-        <div class="card-header">
+<div>
+    <details id="libraryFormDisclosure" class="card library-form-disclosure">
+        <summary class="card-header library-form-summary">
             <div>
                 <h2 id="libraryFormTitle">Add Library</h2>
                 <div id="libraryFormSubtitle" style="color: var(--text-muted); font-size: 0.85rem; margin-top: 0.25rem;">Create a new library root and scan profile.</div>
             </div>
-        </div>
+        </summary>
         <div class="card-body">
+            <aside style="margin-bottom: 1rem; padding: 0.8rem 0.9rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-primary); color: var(--text-secondary); font-size: 0.82rem; line-height: 1.45;">
+                <strong style="display: block; margin-bottom: 0.25rem; color: var(--text-primary);">How library scanning works</strong>
+                Movie and show libraries match filenames to metadata automatically. Other libraries are still indexed and inspected with <code>ffprobe</code>, but skipped for metadata matching. Low-confidence items remain visible for manual cleanup, and manual fixes are preserved until a later scan re-evaluates the file. File details use <code>ffprobe</code> from the configured transmux settings.
+            </aside>
             <form id="libraryForm" style="display: grid; gap: 0.875rem;">
                 <div class="form-group">
                     <label class="form-label" for="librarySource">Source</label>
@@ -84,34 +91,29 @@
                     </div>
                     <div class="form-hint">Use the browser to pick a folder on the server filesystem.</div>
                 </div>
-                <div class="form-group local-library-field">
-                    <label class="form-label" for="libraryFilterOutTerms">Filter Out Terms</label>
-                    <textarea id="libraryFilterOutTerms" class="form-input" rows="4" placeholder="Trailer&#10;Featurette&#10;Sample"></textarea>
-                    <div class="form-hint">One term per line or comma-separated. Matching is case-insensitive against the relative file path.</div>
-                </div>
-                <div class="form-group local-library-field">
-                    <label class="form-label" for="libraryMinFileSizeMb" id="libraryMinFileSizeLabel">Minimum Movie File Size (MB)</label>
-                    <input id="libraryMinFileSizeMb" class="form-input" type="number" min="0" step="1" placeholder="0">
-                    <div class="form-hint" id="libraryMinFileSizeHint">Files smaller than this are ignored during scans. Use `0` to disable the limit.</div>
-                </div>
+                <details class="form-disclosure local-library-field">
+                    <summary>Advanced scan options</summary>
+                    <div class="form-disclosure-content" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem;">
+                        <div class="form-group">
+                            <label class="form-label" for="libraryFilterOutTerms">Filter out terms</label>
+                            <textarea id="libraryFilterOutTerms" class="form-input" rows="4" placeholder="Trailer&#10;Featurette&#10;Sample"></textarea>
+                            <div class="form-hint">One term per line or comma-separated. Matching is case-insensitive against the relative file path.</div>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="libraryMinFileSizeMb" id="libraryMinFileSizeLabel">Minimum movie file size (MB)</label>
+                            <input id="libraryMinFileSizeMb" class="form-input" type="number" min="0" step="1" placeholder="0">
+                            <div class="form-hint" id="libraryMinFileSizeHint">Files smaller than this are ignored during scans. Use `0` to disable the limit.</div>
+                        </div>
+                    </div>
+                </details>
                 <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
                     <button class="btn btn-primary" type="submit" id="librarySubmitBtn">Add Library</button>
                     <button class="btn btn-secondary" type="button" id="cancelLibraryEditBtn" style="display: none;">Cancel Edit</button>
                 </div>
             </form>
         </div>
-    </div>
+    </details>
 
-    <div class="card">
-        <div class="card-header">
-            <h2>Scan Notes</h2>
-        </div>
-        <div class="card-body" style="display: grid; gap: 0.75rem; color: var(--text-secondary); font-size: 0.9rem;">
-            <p>Movie and show libraries try to match filenames to metadata automatically. Other libraries are still ffprobed and indexed, but skipped for metadata matching.</p>
-            <p>Low-confidence items stay visible for manual cleanup. Manual fixes are preserved until the next scan re-evaluates the file.</p>
-            <p>File details come from `ffprobe`, so the server needs `ffprobe` available in the configured transmux settings.</p>
-        </div>
-    </div>
 </div>
 
 <div class="card" style="margin-top: 1.25rem;">
@@ -283,6 +285,33 @@
 </div>
 
 <style>
+.library-form-disclosure {
+    overflow: hidden;
+}
+
+.library-form-summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.library-form-summary::-webkit-details-marker { display: none; }
+.library-form-summary::after {
+    content: 'Show';
+    color: var(--accent-hover);
+    font-size: 0.75rem;
+    font-weight: 650;
+}
+.library-form-disclosure[open] > .library-form-summary::after { content: 'Hide'; }
+
+.library-form-summary:focus-visible {
+    outline: 2px solid var(--accent-hover);
+    outline-offset: -2px;
+}
+
+.library-form-disclosure[open] > .library-form-summary {
+    border-bottom: 1px solid var(--border);
+}
+
 .path-picker-row {
     display: flex;
     gap: 0.5rem;
@@ -1407,8 +1436,12 @@ function editLibrary(id) {
   document.getElementById('libraryRootPath').value = library.rootPath || '';
   document.getElementById('libraryFilterOutTerms').value = formatFilterOutTerms(library.filterOutTerms);
   document.getElementById('libraryMinFileSizeMb').value = bytesToMegabytesString(library.minFileSizeBytes);
+  document.querySelector('.form-disclosure.local-library-field').open =
+    (Array.isArray(library.filterOutTerms) && library.filterOutTerms.length > 0) || Number(library.minFileSizeBytes) > 0;
   syncLibraryFormSettings();
-  document.getElementById('libraryForm').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  const disclosure = document.getElementById('libraryFormDisclosure');
+  if (disclosure) disclosure.open = true;
+  disclosure?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 async function loadItems(libraryId) {
@@ -2464,6 +2497,8 @@ function resetLibraryForm() {
   document.getElementById('librarySource').value = 'local';
   onLibrarySourceChange();
   syncLibraryFormSettings();
+  const disclosure = document.getElementById('libraryFormDisclosure');
+  if (disclosure) disclosure.open = false;
 }
 
 function syncLibraryFormSettings() {

--- a/backend/handlers/admin_templates/login.html
+++ b/backend/handlers/admin_templates/login.html
@@ -9,16 +9,16 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{brandingURL "web-icon" "favicon-16.png"}}">
     <style>
         :root {
-            --bg-primary: #0f0f0f;
-            --bg-secondary: #1a1a1a;
-            --bg-tertiary: #252525;
+            --bg-primary: #0d0d12;
+            --bg-secondary: #16161e;
+            --bg-tertiary: #1c1c26;
             --text-primary: #ffffff;
-            --text-secondary: #a0a0a0;
-            --text-muted: #666666;
-            --accent: #6366f1;
+            --text-secondary: #9ca3af;
+            --text-muted: #7d8592;
+            --accent: #5f62ed;
             --accent-hover: #818cf8;
             --danger: #ef4444;
-            --border: #333333;
+            --border: #2a2a36;
             --radius: 8px;
             --radius-lg: 12px;
         }
@@ -31,7 +31,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: var(--bg-primary);
+            background: radial-gradient(circle at 50% 0%, rgba(95, 98, 237, 0.1), transparent 34rem), var(--bg-primary);
             color: var(--text-primary);
             min-height: 100vh;
             display: flex;
@@ -42,7 +42,7 @@
 
         .login-card {
             width: 100%;
-            max-width: 400px;
+            max-width: 420px;
             background: var(--bg-secondary);
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
@@ -63,6 +63,12 @@
             text-align: center;
             margin-bottom: 1.5rem;
             padding-top: 1.25rem;
+        }
+
+        .login-header h1 {
+            margin-bottom: 0.35rem;
+            font-size: 1.35rem;
+            font-weight: 700;
         }
 
         .login-header p {
@@ -115,8 +121,9 @@
         }
 
         .form-input:focus {
-            outline: none;
+            outline: 2px solid transparent;
             border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(95, 98, 237, 0.18);
         }
 
         .btn {
@@ -132,6 +139,15 @@
             transition: all 0.2s;
             border: none;
             text-decoration: none;
+            min-height: 42px;
+        }
+
+        .btn:focus-visible,
+        .form-input:focus-visible,
+        button:focus-visible,
+        a:focus-visible {
+            outline: 2px solid var(--accent-hover);
+            outline-offset: 2px;
         }
 
         .btn svg {
@@ -308,7 +324,8 @@
         </div>
         <div class="login-body">
         <div class="login-header">
-            <p>Sign in to your account</p>
+            <h1>Sign in</h1>
+            <p>Continue to your Mediastorm account.</p>
         </div>
 
         {{if .RequirePasswordChange}}

--- a/backend/handlers/admin_templates/logs.html
+++ b/backend/handlers/admin_templates/logs.html
@@ -109,9 +109,12 @@
     }
 </style>
 
-<div class="page-header">
-    <h1>System Logs</h1>
-    <p>View combined backend and frontend logs, filter by origin, and share the latest diagnostics package from the backend.</p>
+<div class="page-header" data-page-group="Configuration &amp; operations">
+    <div class="page-header-copy">
+        <div class="page-kicker">Configuration &amp; operations</div>
+        <h1>Logs</h1>
+        <p>Filter backend and frontend events, then share a recent diagnostics package when needed.</p>
+    </div>
 </div>
 
 <div class="card">

--- a/backend/handlers/admin_templates/notifications.html
+++ b/backend/handlers/admin_templates/notifications.html
@@ -5,15 +5,15 @@
 {{define "title"}}Notifications - mediastorm{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <div>
+<div class="page-header" data-page-group="People &amp; communication">
+    <div class="page-header-copy">
+        <div class="page-kicker">People &amp; communication</div>
         <h1>Notifications</h1>
-        <p>Configure notification destinations for <strong>{{.Profile.Name}}</strong>.</p>
+        <p>Choose where updates for <strong>{{.Profile.Name}}</strong> are sent and which events trigger them.</p>
     </div>
-</div>
-
-<div style="margin-bottom: 1rem;">
-    <a class="btn btn-secondary btn-sm" href="{{.BasePath}}/accounts">← Back to Profiles</a>
+    <div class="page-header-actions">
+        <a class="btn btn-secondary btn-sm" href="{{.BasePath}}/accounts">← Back to people</a>
+    </div>
 </div>
 
 <div class="card" style="margin-bottom: 1.5rem;">

--- a/backend/handlers/admin_templates/onboarding.html
+++ b/backend/handlers/admin_templates/onboarding.html
@@ -62,12 +62,15 @@
 {{end}}
 
 {{define "content"}}
-<div class="page-header" style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
-    <div>
+<div class="page-header" data-page-group="Entry &amp; setup">
+    <div class="page-header-copy">
+        <div class="page-kicker">Entry &amp; setup</div>
         <h1>Admin Onboarding</h1>
         <p>Finish the core setup needed for accounts, profiles, and playback.</p>
     </div>
-    <button class="btn btn-secondary" onclick="skipOnboarding()">Skip for now</button>
+    <div class="page-header-actions">
+        <button class="btn btn-secondary" onclick="skipOnboarding()">Skip for now</button>
+    </div>
 </div>
 
 <div class="onboarding-shell">

--- a/backend/handlers/admin_templates/performance.html
+++ b/backend/handlers/admin_templates/performance.html
@@ -109,12 +109,18 @@
     }
 </style>
 
-<div class="perf-header">
-    <h1>Performance</h1>
-    <span class="connection-badge disconnected" id="connBadge">
-        <span class="connection-dot"></span>
-        <span id="connLabel">Connecting</span>
-    </span>
+<div class="page-header" data-page-group="Configuration &amp; operations">
+    <div class="page-header-copy">
+        <div class="page-kicker">Configuration &amp; operations</div>
+        <h1>Performance</h1>
+        <p>Monitor server resource use, runtime health, and recent activity.</p>
+    </div>
+    <div class="page-header-actions">
+        <span class="connection-badge disconnected" id="connBadge" role="status">
+            <span class="connection-dot"></span>
+            <span id="connLabel">Connecting</span>
+        </span>
+    </div>
 </div>
 
 <!-- Top stat cards -->

--- a/backend/handlers/admin_templates/playback.html
+++ b/backend/handlers/admin_templates/playback.html
@@ -3,9 +3,12 @@
 {{define "title"}}Playback - mediastorm{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Playback</h1>
-    <p>Browse shelves, resume watching, and launch streams from the web UI</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Playback</h1>
+        <p>Choose a profile, browse media or live channels, and start watching.</p>
+    </div>
 </div>
 
 {{if .NoProfiles}}
@@ -26,7 +29,7 @@
             <button id="iptvModeButton" class="playback-mode-option" type="button" onclick="setPlaybackMode('iptv')" role="tab" aria-selected="false">IPTV</button>
         </div>
         <section id="shelvesPanel">
-            <div class="toolbar search-toolbar">
+            <div class="toolbar search-toolbar page-toolbar" aria-label="Media search controls">
                 <input type="text" id="searchQuery" class="form-input search-input" placeholder="Search movies or shows" onkeydown="if(event.key==='Enter') searchMedia()">
                 <select id="searchType" class="form-select compact-select">
                     <option value="all">All</option>
@@ -55,7 +58,7 @@
         </section>
 
         <section id="iptvPanel" class="iptv-panel" style="display: none;">
-            <div class="toolbar search-toolbar iptv-toolbar">
+            <div class="toolbar search-toolbar iptv-toolbar page-toolbar" aria-label="Live TV filters">
                 <input type="text" id="iptvSearchQuery" class="form-input search-input" placeholder="Search channels" oninput="renderIptvChannels()">
                 <select id="iptvGroupFilter" class="form-select compact-select" onchange="renderIptvChannels()">
                     <option value="">All Groups</option>

--- a/backend/handlers/admin_templates/prequeue.html
+++ b/backend/handlers/admin_templates/prequeue.html
@@ -59,12 +59,13 @@
 {{end}}
 
 {{define "content"}}
-<div class="page-header page-header-flex" style="display: flex; align-items: center; justify-content: space-between;">
-    <div>
-        <h1>Active Prequeues</h1>
-        <p>Pre-resolved and in-progress playback queue entries, including permanent manual items</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Prequeue</h1>
+        <p>Review pre-resolved and in-progress playback entries, including permanent manual items.</p>
     </div>
-    <div class="page-header-controls prequeue-header-actions">
+    <div class="page-header-actions prequeue-header-actions">
         <a class="btn btn-secondary prequeue-back-button" href="{{.BasePath}}/tools">Back to Maintenance</a>
         <span class="prequeue-auto-refresh-label" id="autoRefreshLabel" style="font-size: 0.8rem; color: var(--text-muted);">Auto-refresh: on</span>
         <button class="btn btn-secondary" onclick="toggleAutoRefresh()" id="autoRefreshBtn">

--- a/backend/handlers/admin_templates/recordings.html
+++ b/backend/handlers/admin_templates/recordings.html
@@ -3,9 +3,12 @@
 {{define "title"}}Recordings - {{if .IsAdmin}}mediastorm Admin{{else}}mediastorm account{{end}}{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    <h1>Recordings</h1>
-    <p>Schedule and manage Live TV recordings</p>
+<div class="page-header" data-page-group="Media &amp; playback">
+    <div class="page-header-copy">
+        <div class="page-kicker">Media &amp; playback</div>
+        <h1>Recordings</h1>
+        <p>Schedule Live TV recordings and review upcoming or completed items.</p>
+    </div>
 </div>
 
 <div class="card" style="margin-bottom: 1.5rem;">

--- a/backend/handlers/admin_templates/register.html
+++ b/backend/handlers/admin_templates/register.html
@@ -9,17 +9,17 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{brandingURL "web-icon" "favicon-16.png"}}">
     <style>
         :root {
-            --bg-primary: #0f0f0f;
-            --bg-secondary: #1a1a1a;
-            --bg-tertiary: #252525;
+            --bg-primary: #0d0d12;
+            --bg-secondary: #16161e;
+            --bg-tertiary: #1c1c26;
             --text-primary: #ffffff;
-            --text-secondary: #a0a0a0;
-            --text-muted: #666666;
-            --accent: #6366f1;
+            --text-secondary: #9ca3af;
+            --text-muted: #7d8592;
+            --accent: #5f62ed;
             --accent-hover: #818cf8;
             --success: #22c55e;
             --danger: #ef4444;
-            --border: #333333;
+            --border: #2a2a36;
             --radius: 8px;
             --radius-lg: 12px;
         }
@@ -32,7 +32,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: var(--bg-primary);
+            background: radial-gradient(circle at 50% 0%, rgba(95, 98, 237, 0.1), transparent 34rem), var(--bg-primary);
             color: var(--text-primary);
             min-height: 100vh;
             display: flex;
@@ -43,7 +43,7 @@
 
         .register-card {
             width: 100%;
-            max-width: 400px;
+            max-width: 420px;
             background: var(--bg-secondary);
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
@@ -66,6 +66,15 @@
             font-size: 1.5rem;
             font-weight: 600;
             margin-bottom: 0.5rem;
+        }
+
+        .entry-brand {
+            margin-bottom: 0.4rem;
+            color: var(--accent-hover);
+            font-size: 0.6875rem;
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
         }
 
         .register-header p {
@@ -97,8 +106,9 @@
         }
 
         .form-input:focus {
-            outline: none;
+            outline: 2px solid transparent;
             border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(95, 98, 237, 0.18);
         }
 
         .form-input:disabled {
@@ -119,6 +129,15 @@
             transition: all 0.2s;
             border: none;
             text-decoration: none;
+            min-height: 42px;
+        }
+
+        .btn:focus-visible,
+        .form-input:focus-visible,
+        button:focus-visible,
+        a:focus-visible {
+            outline: 2px solid var(--accent-hover);
+            outline-offset: 2px;
         }
 
         .btn svg {
@@ -233,8 +252,9 @@
                 <polyline points="2 17 12 22 22 17"/>
                 <polyline points="2 12 12 17 22 12"/>
             </svg>
-            <h1>mediastorm</h1>
-            <p>Create your account</p>
+            <div class="entry-brand">Mediastorm</div>
+            <h1>Create your account</h1>
+            <p>Use the invitation details provided by your administrator.</p>
         </div>
 
         <div id="errorMessage" class="form-error {{if not .Error}}hidden{{end}}">{{.Error}}</div>

--- a/backend/handlers/admin_templates/resolved_nzbs.html
+++ b/backend/handlers/admin_templates/resolved_nzbs.html
@@ -84,9 +84,12 @@
     }
 </style>
 
-<div class="page-header">
-    <h1>Resolved NZBs</h1>
-    <p>Internal Usenet content that is ready in the metadata filesystem</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Resolved NZBs</h1>
+        <p>Inspect internal Usenet content that is ready in the metadata filesystem.</p>
+    </div>
 </div>
 
 <div class="settings-group">

--- a/backend/handlers/admin_templates/search.html
+++ b/backend/handlers/admin_templates/search.html
@@ -1,15 +1,45 @@
 {{template "base" .}}
 
-{{define "title"}}Search Test - mediastorm Admin{{end}}
+{{define "title"}}Search - mediastorm Admin{{end}}
+
+{{define "styles"}}
+<style>
+.search-diagnostics-card { margin-bottom: 1.5rem; scroll-margin-top: 1rem; }
+.search-diagnostics-copy { margin: 0.25rem 0 0; color: var(--text-muted); font-size: 0.8rem; }
+.search-diagnostics-actions { display: flex; justify-content: flex-end; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.search-diagnostics-controls { display: grid; grid-template-columns: minmax(220px, 2fr) minmax(120px, 1fr) 96px 110px 110px; gap: 0.65rem; align-items: end; }
+.search-diagnostics-controls label { display: flex; flex-direction: column; gap: 0.3rem; color: var(--text-secondary); font-size: 0.75rem; }
+.search-diagnostics-controls input, .search-diagnostics-controls select { width: 100%; min-height: 40px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-primary); color: var(--text-primary); padding: 0.45rem 0.55rem; font: inherit; }
+.search-diagnostics-summary { min-height: 20px; margin-top: 1rem; color: var(--text-secondary); font-size: 0.8rem; }
+.search-timeout-recommendation { display: none; align-items: center; gap: 0.65rem; margin-top: 0.65rem; flex-wrap: wrap; font-size: 0.8rem; }
+.search-timeout-recommendation.active { display: flex; }
+.search-diagnostics-table-wrap { overflow-x: auto; margin-top: 0.85rem; }
+.search-diagnostics-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+.search-diagnostics-table th, .search-diagnostics-table td { padding: 0.55rem 0.5rem; border-top: 1px solid var(--border); text-align: left; white-space: nowrap; }
+.search-diagnostics-table th { color: var(--text-secondary); font-weight: 600; }
+.search-diagnostics-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.search-diagnostics-table .empty-row { color: var(--text-muted); text-align: center; }
+.diag-status-pass { color: var(--success, #4caf50); }
+.diag-status-warn { color: var(--warning, #ff9800); }
+.diag-status-fail { max-width: 360px; overflow: hidden; color: var(--error, #f44336); text-overflow: ellipsis; }
+@media (max-width: 760px) {
+    .search-diagnostics-controls { grid-template-columns: 1fr 1fr; }
+    .search-diagnostics-controls label:first-child { grid-column: 1 / -1; }
+}
+</style>
+{{end}}
 
 {{define "content"}}
-<div class="page-header" id="pageTop">
-    <h1>Search Test</h1>
-    <p>Search for content and test scraping results with filtering details</p>
+<div class="page-header" id="pageTop" data-page-group="Configuration &amp; operations">
+    <div class="page-header-copy">
+        <div class="page-kicker">Configuration &amp; operations</div>
+        <h1>Search</h1>
+        <p>Find content or diagnose how enabled sources respond.</p>
+    </div>
 </div>
 
 <!-- Search Section -->
-<div class="card" style="margin-bottom: 1.5rem;">
+<div class="card" id="content-search" style="margin-bottom: 1.5rem; scroll-margin-top: 1rem;">
     <div class="card-header">
         <h2>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -46,6 +76,36 @@
         </div>
     </div>
 </div>
+
+<section id="searchDiagnostics" class="card search-diagnostics-card" aria-labelledby="searchDiagnosticsHeading">
+    <div class="card-header">
+        <div>
+            <h2 id="searchDiagnosticsHeading">Search Diagnostics</h2>
+            <p class="search-diagnostics-copy">Compare enabled indexers and torrent sources, then tune the search timeout.</p>
+        </div>
+    </div>
+    <div class="card-body">
+        <div class="search-diagnostics-actions">
+            <button class="btn btn-secondary" id="save-timeout-btn" type="button" onclick="saveSearchTimeout()">Save Timeout</button>
+            <button class="btn btn-primary" id="run-search-diagnostics-btn" type="button" onclick="runSearchDiagnostics()">Run Search Test</button>
+        </div>
+        <div class="search-diagnostics-controls">
+            <label><span>Query</span><input type="text" id="diag-query" value="The Matrix" autocomplete="off"></label>
+            <label><span>IMDb ID</span><input type="text" id="diag-imdb" value="tt0133093" autocomplete="off"></label>
+            <label><span>Year</span><input type="number" id="diag-year" value="1999" min="1900" max="2100"></label>
+            <label><span>Type</span><select id="diag-media-type"><option value="movie" selected>Movie</option><option value="series">Series</option></select></label>
+            <label><span>Timeout</span><input type="number" id="diag-timeout" min="0.1" max="120" step="0.1" value="{{.Settings.Streaming.IndexerTimeoutSec}}"></label>
+        </div>
+        <div id="search-diagnostics-summary" class="search-diagnostics-summary" role="status" aria-live="polite">Not run yet.</div>
+        <div id="search-timeout-recommendation" class="search-timeout-recommendation"></div>
+        <div class="search-diagnostics-table-wrap">
+            <table class="search-diagnostics-table">
+                <thead><tr><th>Source</th><th>Kind</th><th>Results</th><th>Time</th><th>Status</th></tr></thead>
+                <tbody id="search-diagnostics-results"><tr><td colspan="5" class="empty-row">Run a search test to compare enabled sources.</td></tr></tbody>
+            </table>
+        </div>
+    </div>
+</section>
 
 <!-- Selected Content Section -->
 <div id="selectedContent" class="card" style="margin-bottom: 1.5rem; display: none;">
@@ -165,6 +225,7 @@
 {{define "scripts"}}
 <script>
     let selectedContent = null;
+    let latestSearchDiagnostics = null;
 
     function escAttr(s) {
         if (!s) return '';
@@ -173,8 +234,121 @@
     let seriesDetails = null;
     let allScrapeResults = [];
 
+    function diagnosticEscapeHtml(value) {
+        return String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function diagnosticDuration(durationMs) {
+        if (durationMs == null || Number.isNaN(durationMs)) return '';
+        if (durationMs < 1000) return `${Math.round(durationMs)} ms`;
+        return `${(durationMs / 1000).toFixed(durationMs >= 10000 ? 0 : 1)} s`;
+    }
+
+    function diagnosticTimeoutProjection(timeoutSec) {
+        const sources = Array.isArray(latestSearchDiagnostics?.sources) ? latestSearchDiagnostics.sources : [];
+        const included = sources.filter(source => source.success && Number(source.durationMs || 0) <= timeoutSec * 1000);
+        return { sourceCount: included.length, totalSources: sources.length, resultCount: included.reduce((sum, source) => sum + Number(source.count || 0), 0) };
+    }
+
+    function recommendedSearchTimeout() {
+        const sources = (Array.isArray(latestSearchDiagnostics?.sources) ? latestSearchDiagnostics.sources : [])
+            .filter(source => source.success && Number(source.count || 0) > 0)
+            .map(source => ({ count: Number(source.count || 0), durationMs: Math.max(1, Number(source.durationMs || 0)) }))
+            .sort((a, b) => a.durationMs - b.durationMs);
+        const totalResults = sources.reduce((sum, source) => sum + source.count, 0);
+        if (!totalResults) return null;
+        const target = Math.ceil(totalResults / 2);
+        let running = 0;
+        for (const source of sources) {
+            running += source.count;
+            if (running >= target) return { timeoutSec: Math.max(0.1, Math.ceil(source.durationMs / 100) / 10), resultCount: running, totalResults };
+        }
+        return null;
+    }
+
+    function renderSearchTimeoutRecommendation() {
+        const target = document.getElementById('search-timeout-recommendation');
+        if (!target) return;
+        const recommendation = recommendedSearchTimeout();
+        target.classList.toggle('active', Boolean(recommendation));
+        target.innerHTML = recommendation
+            ? `<span>Suggested timeout: <strong>${recommendation.timeoutSec.toFixed(1)}s</strong> captures at least half this run (${recommendation.resultCount}/${recommendation.totalResults} results).</span><button class="btn btn-secondary btn-sm" type="button" onclick="applyRecommendedSearchTimeout(${recommendation.timeoutSec})">Use ${recommendation.timeoutSec}s</button>`
+            : '';
+    }
+
+    function applyRecommendedSearchTimeout(timeoutSec) {
+        const input = document.getElementById('diag-timeout');
+        if (input) input.value = timeoutSec;
+        updateSearchTimeoutProjection();
+    }
+
+    function updateSearchTimeoutProjection() {
+        if (!latestSearchDiagnostics) return;
+        const timeoutSec = Number(document.getElementById('diag-timeout')?.value || 0);
+        if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) return;
+        const projection = diagnosticTimeoutProjection(timeoutSec);
+        const cap = latestSearchDiagnostics.diagnosticTimeoutSec || 10;
+        document.getElementById('search-diagnostics-summary').textContent = `At ${timeoutSec.toFixed(1)}s, this run would have returned ${projection.resultCount} result${projection.resultCount === 1 ? '' : 's'} from ${projection.sourceCount}/${projection.totalSources} sources. Observed with a ${cap}s diagnostic cap.`;
+    }
+
+    async function searchDiagnosticPost(endpoint, payload) {
+        const response = await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+        return response.json();
+    }
+
+    async function runSearchDiagnostics() {
+        const button = document.getElementById('run-search-diagnostics-btn');
+        const summary = document.getElementById('search-diagnostics-summary');
+        const resultsBody = document.getElementById('search-diagnostics-results');
+        button.disabled = true;
+        summary.textContent = 'Searching enabled sources…';
+        resultsBody.innerHTML = '<tr><td colspan="5" class="empty-row">Searching…</td></tr>';
+        const startedAt = performance.now();
+        try {
+            const result = await searchDiagnosticPost(basePath + '/api/connections/search-diagnostics', {
+                query: document.getElementById('diag-query').value.trim(), imdbId: document.getElementById('diag-imdb').value.trim(),
+                year: Number(document.getElementById('diag-year').value) || 0, mediaType: document.getElementById('diag-media-type').value
+            });
+            if (result.error) throw new Error(result.error);
+            const sources = Array.isArray(result.sources) ? result.sources : [];
+            latestSearchDiagnostics = result;
+            document.getElementById('diag-timeout').value = result.timeoutSec || 5;
+            summary.textContent = `${result.totalResults || 0} total results across ${sources.length} sources in ${diagnosticDuration(result.durationMs ?? (performance.now() - startedAt))}.`;
+            resultsBody.innerHTML = sources.length ? sources.slice().sort((a, b) => (b.count || 0) - (a.count || 0)).map(source => `<tr><td>${diagnosticEscapeHtml(source.name || 'Source')}</td><td>${diagnosticEscapeHtml((source.group || '') + (source.type ? ' / ' + source.type : ''))}</td><td class="num">${Number(source.count || 0).toLocaleString()}</td><td class="num">${diagnosticDuration(source.durationMs || 0)}</td><td class="${!source.success ? 'diag-status-fail' : (source.count > 0 ? 'diag-status-pass' : 'diag-status-warn')}">${!source.success ? diagnosticEscapeHtml(source.error || 'Failed') : (source.count > 0 ? 'OK' : 'Reachable, 0 results')}</td></tr>`).join('') : '<tr><td colspan="5" class="empty-row">No enabled search sources found.</td></tr>';
+            renderSearchTimeoutRecommendation();
+            updateSearchTimeoutProjection();
+        } catch (error) {
+            latestSearchDiagnostics = null;
+            renderSearchTimeoutRecommendation();
+            summary.textContent = 'Search diagnostics failed: ' + error.message;
+            resultsBody.innerHTML = '<tr><td colspan="5" class="empty-row">Search diagnostics failed.</td></tr>';
+        } finally {
+            button.disabled = false;
+        }
+    }
+
+    async function saveSearchTimeout() {
+        const button = document.getElementById('save-timeout-btn');
+        const summary = document.getElementById('search-diagnostics-summary');
+        const timeoutSec = Number(document.getElementById('diag-timeout').value);
+        if (!Number.isFinite(timeoutSec) || timeoutSec < 0.1 || timeoutSec > 120) { summary.textContent = 'Timeout must be between 0.1 and 120 seconds.'; return; }
+        button.disabled = true;
+        try {
+            const result = await searchDiagnosticPost(basePath + '/api/connections/search-timeout', { timeoutSec });
+            if (!result.success) throw new Error(result.error || 'Failed to save timeout');
+            summary.textContent = `Search timeout saved at ${result.timeoutSec}s.`;
+        } catch (error) {
+            summary.textContent = 'Failed to save timeout: ' + error.message;
+        } finally {
+            button.disabled = false;
+        }
+    }
+
     // Load users on page load
-    document.addEventListener('DOMContentLoaded', loadUsers);
+    document.addEventListener('DOMContentLoaded', () => {
+        loadUsers();
+        document.getElementById('diag-timeout')?.addEventListener('input', updateSearchTimeoutProjection);
+    });
 
     async function loadUsers() {
         try {

--- a/backend/handlers/admin_templates/settings.html
+++ b/backend/handlers/admin_templates/settings.html
@@ -18,6 +18,147 @@
     background: transparent;
 }
 
+.usenet-server-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.usenet-server-card {
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-tertiary);
+}
+
+.usenet-server-card-header {
+    display: flex;
+    min-height: 58px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 0.85rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.usenet-server-identity,
+.usenet-server-toggles,
+.usenet-server-actions,
+.usenet-server-toggle {
+    display: flex;
+    align-items: center;
+}
+
+.usenet-server-identity {
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    min-width: 0;
+    gap: 0.65rem;
+}
+
+.usenet-server-name {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.usenet-server-badge {
+    display: inline-flex;
+    min-width: 36px;
+    align-items: center;
+    justify-content: center;
+    padding: 0.12rem 0.42rem;
+    border: 1px solid rgba(99, 102, 241, 0.65);
+    border-radius: 6px;
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--accent-hover);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.usenet-server-toggles,
+.usenet-server-actions {
+    gap: 0.65rem;
+}
+
+.usenet-server-toggles {
+    margin-left: 0.6rem;
+}
+
+.usenet-server-toggle {
+    gap: 0.4rem;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.usenet-server-toggle .toggle {
+    flex: 0 0 auto;
+}
+
+.usenet-server-fields {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.8rem 1rem;
+    padding: 0.85rem;
+}
+
+.usenet-server-fields .form-group {
+    min-width: 0;
+    margin: 0;
+}
+
+.usenet-server-fields .form-label {
+    margin-bottom: 0.35rem;
+}
+
+.usenet-server-fields .form-hint {
+    margin-top: 0.3rem;
+}
+
+.usenet-server-actions .btn {
+    min-height: 36px;
+}
+
+@media (max-width: 1100px) {
+    .usenet-server-fields {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .usenet-server-card-header {
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .usenet-server-identity {
+        flex: 1 1 100%;
+    }
+
+    .usenet-server-toggles {
+        margin-left: 0;
+    }
+}
+
+@media (max-width: 640px) {
+    .usenet-server-fields {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .usenet-server-actions {
+        width: 100%;
+    }
+
+    .usenet-server-actions .btn-secondary {
+        flex: 1;
+        justify-content: center;
+    }
+}
+
 .field-subgroup {
     grid-column: 1 / -1;
     margin: 0.5rem 0 1rem;
@@ -43,6 +184,290 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem;
+}
+
+.live-source-card {
+    padding: 0;
+    overflow: visible;
+    background: var(--bg-secondary);
+}
+
+.live-source-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 72px;
+    padding: 0.8rem 0.9rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.live-source-card-identity,
+.live-source-card-meta,
+.live-source-card-actions {
+    display: flex;
+    align-items: center;
+}
+
+.live-source-card-identity {
+    min-width: 0;
+    flex: 1;
+    gap: 1rem;
+}
+
+.live-source-card-name {
+    min-width: 140px;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.live-source-card-meta {
+    min-width: 0;
+    gap: 0.7rem;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+}
+
+.live-source-card-meta > span + span {
+    padding-left: 0.7rem;
+    border-left: 1px solid var(--border);
+}
+
+.live-source-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+.live-source-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--text-muted);
+}
+
+.live-source-status.enabled .live-source-status-dot {
+    background: #22c55e;
+}
+
+.live-source-type-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 25px;
+    padding: 0.18rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.live-source-endpoint {
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.live-source-card-actions {
+    flex: 0 0 auto;
+    gap: 0.5rem;
+}
+
+.live-source-action-menu {
+    position: relative;
+}
+
+.live-source-action-menu > summary {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 32px;
+    padding: 0;
+    list-style: none;
+}
+
+.live-source-action-menu > summary::-webkit-details-marker,
+.live-source-group > summary::-webkit-details-marker {
+    display: none;
+}
+
+.live-source-action-menu > summary svg {
+    width: 16px;
+    height: 16px;
+}
+
+.live-source-action-menu-panel {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 0.35rem);
+    right: 0;
+    min-width: 150px;
+    padding: 0.35rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.live-source-action-menu-panel button {
+    width: 100%;
+    justify-content: flex-start;
+}
+
+.live-source-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.75rem;
+}
+
+.live-source-group {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-tertiary);
+    overflow: hidden;
+}
+
+.live-source-group > summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(180px, auto);
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 48px;
+    padding: 0.62rem 0.75rem;
+    list-style: none;
+    cursor: pointer;
+}
+
+.live-source-group > summary:focus-visible {
+    outline: 2px solid var(--accent-hover);
+    outline-offset: -2px;
+}
+
+.live-source-group-chevron {
+    display: grid;
+    place-items: center;
+    color: var(--text-secondary);
+    transition: transform 0.15s ease;
+}
+
+.live-source-group-chevron svg {
+    width: 15px;
+    height: 15px;
+}
+
+.live-source-group[open] .live-source-group-chevron {
+    transform: rotate(180deg);
+}
+
+.live-source-group-heading {
+    display: flex;
+    align-items: baseline;
+    min-width: 0;
+    gap: 0.65rem;
+}
+
+.live-source-group-title {
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    font-weight: 650;
+    white-space: nowrap;
+}
+
+.live-source-group-description,
+.live-source-group-summary {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: 0.74rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.live-source-group-summary {
+    text-align: right;
+}
+
+.live-source-group[open] .live-source-group-summary {
+    visibility: hidden;
+}
+
+.live-source-group-body {
+    padding: 0.2rem 0.75rem 0.75rem;
+    border-top: 1px solid var(--border);
+}
+
+.live-source-group-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem 0.9rem;
+    padding-top: 0.75rem;
+}
+
+.live-source-group.source .live-source-group-fields {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.live-source-group .form-group {
+    min-width: 0;
+}
+
+.live-source-group .form-group-toggle {
+    align-self: start;
+}
+
+@media (max-width: 1100px) {
+    .live-source-card-header,
+    .live-source-card-identity {
+        align-items: flex-start;
+    }
+    .live-source-card-header,
+    .live-source-card-identity,
+    .live-source-card-meta {
+        flex-wrap: wrap;
+    }
+    .live-source-card-actions {
+        width: 100%;
+        justify-content: flex-end;
+    }
+    .live-source-group.source .live-source-group-fields {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 700px) {
+    .live-source-card-identity,
+    .live-source-card-actions {
+        width: 100%;
+    }
+    .live-source-card-actions {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+    .live-source-card-name {
+        min-width: 100%;
+    }
+    .live-source-group > summary {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+    .live-source-group-heading {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.1rem;
+    }
+    .live-source-group-summary {
+        display: none;
+    }
+    .live-source-group-fields,
+    .live-source-group.source .live-source-group-fields {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* Shared drag-to-reorder row primitive, used by provider priority, home shelves,
@@ -427,12 +852,18 @@
 .settings-level-btn:hover { color: var(--text-primary); background: var(--bg-tertiary); }
 .settings-category-btn.active,
 .settings-level-btn.active { color: var(--text-primary); background: rgba(99, 102, 241, 0.15); border-color: var(--accent); }
+.settings-category-btn:focus-visible,
+.settings-level-btn:focus-visible,
+.settings-home-link:focus-visible {
+    outline: 2px solid var(--accent-hover);
+    outline-offset: 2px;
+}
 .settings-level-section {
     margin-top: 0.55rem;
     padding-top: 0.7rem;
     border-top: 1px solid var(--border);
 }
-.settings-level-switch { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.25rem; padding: 0.2rem; border-radius: 8px; background: var(--bg-tertiary); }
+.settings-level-switch { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.25rem; padding: 0.2rem; border-radius: 8px; background: var(--bg-tertiary); }
 .settings-level-btn:disabled {
     cursor: not-allowed;
     opacity: 0.42;
@@ -617,6 +1048,437 @@
     font-size: 0.75rem;
 }
 .settings-scope-tree-storage { display: none; }
+
+.settings-page-shell {
+    position: relative;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.playback-setting-group {
+    grid-column: 1 / -1;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.02);
+}
+.playback-setting-group > summary {
+    display: flex;
+    min-height: 48px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 0.85rem;
+    cursor: pointer;
+    list-style: none;
+}
+.playback-setting-group > summary::-webkit-details-marker { display: none; }
+.playback-setting-group > summary::after { content: 'Edit'; color: var(--accent-hover); font-size: 0.75rem; font-weight: 650; }
+.playback-setting-group[open] > summary::after { content: 'Close'; }
+.playback-setting-group > summary:focus-visible { outline: 2px solid var(--accent-hover); outline-offset: -2px; }
+.playback-setting-group-copy { min-width: 0; }
+.playback-setting-group-title { display: block; color: var(--text-primary); font-size: 0.875rem; font-weight: 650; }
+.playback-setting-group-description { display: block; overflow: hidden; margin-top: 0.12rem; color: var(--text-muted); font-size: 0.72rem; text-overflow: ellipsis; white-space: nowrap; }
+.playback-setting-group .field-subgroup-fields { padding: 0.85rem; border-top: 1px solid var(--border); }
+.playback-setting-group input[type="number"] { width: min(100%, 8rem); font-variant-numeric: tabular-nums; }
+.playback-setting-group-static > .playback-setting-group-copy { display: block; padding: 0.7rem 0.85rem; }
+
+.settings-page-header {
+    display: grid;
+    gap: 0.15rem;
+}
+
+.settings-page-kicker,
+.settings-category-breadcrumb {
+    color: var(--accent-hover);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.settings-page-header h1 {
+    margin: 0;
+    font-size: 1.65rem;
+}
+
+.settings-page-header > p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+
+.settings-command-bar {
+    display: grid;
+    grid-template-columns: minmax(240px, 1fr) auto minmax(210px, 0.7fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 0.75rem;
+}
+
+.settings-search-wrap {
+    position: relative;
+    min-width: 0;
+}
+
+.settings-search-wrap > svg {
+    position: absolute;
+    top: 50%;
+    left: 0.9rem;
+    width: 17px;
+    height: 17px;
+    color: var(--text-muted);
+    pointer-events: none;
+    transform: translateY(-50%);
+}
+
+.settings-search-wrap .form-input {
+    width: 100%;
+    min-height: 48px;
+    padding-left: 2.65rem;
+}
+
+.settings-command-bar .settings-level-switch {
+    display: grid;
+    width: 240px;
+    height: 48px;
+    padding: 0.2rem;
+}
+
+.settings-command-bar .settings-level-btn {
+    min-height: 0;
+    height: 100%;
+}
+
+.settings-command-bar .settings-context-trigger-desktop { min-height: 48px; }
+
+.settings-save-state {
+    display: inline-flex;
+    min-height: 48px;
+    align-items: center;
+    justify-self: end;
+    gap: 0.55rem;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.settings-save-state.unsaved {
+    border-color: rgba(245, 158, 11, 0.45);
+    background: rgba(245, 158, 11, 0.08);
+    color: #fbbf24;
+}
+
+.settings-scope-panel {
+    position: fixed;
+    z-index: 310;
+    display: none;
+    width: min(520px, calc(100vw - 2rem));
+    max-height: min(680px, calc(100vh - 2rem));
+    overflow-y: auto;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.42);
+}
+
+.settings-scope-panel.open { display: block; }
+
+.settings-scope-heading {
+    display: block;
+    margin-bottom: 0.4rem;
+    color: var(--text-muted);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.settings-scope-panel .settings-scope-bar {
+    display: none;
+}
+
+.settings-scope-panel .settings-scope-server-btn,
+.settings-scope-panel .settings-scope-select-wrap,
+.settings-scope-panel .settings-scope-select-wrap select {
+    min-height: 44px;
+}
+
+.settings-scope-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.settings-scope-actions .btn {
+    min-height: 40px;
+}
+
+.settings-scope-panel > .settings-scope-actions {
+    margin-top: 0.85rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid var(--border);
+}
+
+.settings-home[hidden],
+.settings-workspace[hidden],
+.settings-sticky-save[hidden],
+.settings-attention-banner[hidden] {
+    display: none !important;
+}
+
+.settings-home {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.settings-attention-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.8rem 1rem;
+    border: 1px solid rgba(245, 158, 11, 0.58);
+    border-radius: 9px;
+    background: rgba(245, 158, 11, 0.1);
+}
+
+.settings-attention-banner strong {
+    display: block;
+    color: var(--text-primary);
+    font-size: 0.8125rem;
+}
+
+.settings-attention-banner p {
+    margin: 0.2rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+.settings-home-heading {
+    margin-top: 0.75rem;
+}
+
+.settings-home-heading h2 {
+    margin: 0 0 0.35rem;
+    font-size: 1.5rem;
+    line-height: 1.2;
+}
+
+.settings-home-heading p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+
+.settings-category-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+}
+
+.settings-category-card {
+    position: relative;
+    display: grid;
+    min-height: 164px;
+    align-content: start;
+    gap: 0.7rem;
+    padding: 1.5rem 4rem 1.4rem 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.settings-category-card:hover {
+    border-color: var(--accent);
+    background: var(--bg-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px var(--shadow);
+}
+
+.settings-category-card:focus-visible {
+    outline: 2px solid var(--accent-hover);
+    outline-offset: 2px;
+}
+
+.settings-category-card-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    min-width: 0;
+}
+
+.settings-category-card-icon {
+    display: grid;
+    width: 44px;
+    height: 44px;
+    flex: 0 0 44px;
+    place-items: center;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.settings-category-card-icon svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.settings-category-card:hover .settings-category-card-icon,
+.settings-category-card:focus-visible .settings-category-card-icon {
+    border-color: var(--accent);
+    background: rgba(99, 102, 241, 0.15);
+    color: var(--accent-hover);
+}
+
+.settings-category-card-title {
+    min-width: 0;
+    font-size: 1.0625rem;
+    font-weight: 650;
+    line-height: 1.25;
+}
+
+.settings-category-card-description,
+.settings-category-card-meta {
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+}
+
+.settings-category-card-meta {
+    margin-top: auto;
+    color: var(--accent-hover);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.025em;
+    text-transform: uppercase;
+}
+
+.settings-category-card-arrow {
+    position: absolute;
+    top: 50%;
+    right: 1.4rem;
+    width: 18px;
+    height: 18px;
+    color: var(--text-muted);
+    transform: translateY(-50%);
+    transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.settings-category-card-arrow svg {
+    width: 100%;
+    height: 100%;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.settings-category-card:hover .settings-category-card-arrow,
+.settings-category-card:focus-visible .settings-category-card-arrow {
+    color: var(--accent-hover);
+    transform: translate(2px, -50%);
+}
+
+.settings-workspace {
+    display: block;
+}
+
+.settings-sidebar {
+    display: none;
+}
+
+.settings-home-link {
+    display: flex;
+    width: 100%;
+    min-height: 44px;
+    align-items: center;
+    padding: 0.55rem 0.65rem;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.settings-category-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: start;
+    margin-bottom: 1rem;
+}
+
+.settings-category-header h2 {
+    margin: 0.3rem 0 0.3rem;
+    font-size: 1.75rem;
+}
+
+.settings-category-header p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+}
+
+.settings-category-summary {
+    align-self: end;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.settings-sticky-save {
+    position: sticky;
+    bottom: 1rem;
+    z-index: 15;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid rgba(245, 158, 11, 0.5);
+    border-radius: 10px;
+    background: rgba(38, 28, 14, 0.97);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.settings-sticky-save strong {
+    color: #fbbf24;
+    font-size: 0.8125rem;
+}
+
+.settings-sticky-save p {
+    margin: 0.15rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.6875rem;
+}
+
+.settings-sticky-save-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.settings-sticky-save-actions .btn {
+    min-height: 44px;
+}
 .indexer-table-shell {
     overflow-x: auto;
     border-radius: var(--radius);
@@ -745,6 +1607,49 @@
 #settingsContainer .form-group { margin-bottom: 0.75rem; }
 #settingsContainer .form-hint { margin-top: 0.3rem; font-size: 0.74rem; line-height: 1.35; }
 #settingsContainer .field-subgroup { margin: 0.25rem 0 0.75rem; padding: 0.8rem; }
+.appearance-setting-group {
+    padding: 0;
+    overflow: hidden;
+    background: var(--bg-secondary);
+}
+.appearance-setting-group > summary {
+    display: flex;
+    min-height: 58px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1rem;
+    cursor: pointer;
+    list-style: none;
+}
+.appearance-setting-group > summary::-webkit-details-marker { display: none; }
+.appearance-setting-group > summary::after {
+    content: 'Show';
+    flex: 0 0 auto;
+    color: var(--accent-hover);
+    font-size: 0.75rem;
+    font-weight: 650;
+}
+.appearance-setting-group[open] > summary::after { content: 'Hide'; }
+.appearance-setting-group > summary:focus-visible { outline: 2px solid var(--accent-hover); outline-offset: -2px; }
+.appearance-setting-group-copy { min-width: 0; }
+.appearance-setting-group .field-subgroup-title {
+    margin: 0;
+    padding: 0;
+    color: var(--accent-hover);
+    font-size: 0.72rem;
+    font-weight: 750;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+}
+.appearance-setting-group .field-subgroup-description {
+    margin: 0.18rem 0 0;
+    padding: 0;
+    border: 0;
+}
+.appearance-setting-group .field-subgroup-fields { padding: 1rem; border-top: 1px solid var(--border); }
+.appearance-theme-presets { grid-column: 1 / -1; }
+.appearance-theme-presets > div { margin-bottom: 0 !important; }
 .advanced-setting-badge {
     display: inline-flex;
     margin-left: 0.45rem;
@@ -769,6 +1674,55 @@
     background: var(--bg-secondary);
 }
 .settings-related-card p { margin: 0.2rem 0 0; color: var(--text-muted); font-size: 0.75rem; }
+.settings-mobile-heading-row { display: block; }
+.settings-mobile-search-button,
+.settings-context-trigger,
+.settings-context-scrim,
+.settings-scope-sheet-close,
+.settings-scope-sheet-kicker,
+.settings-mobile-level-section { display: none; }
+.settings-scope-sheet-header { display: contents; }
+.settings-context-trigger-desktop {
+    display: flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    text-align: left;
+    cursor: pointer;
+}
+.settings-context-trigger-desktop svg { width: 16px; height: 16px; flex: 0 0 16px; color: var(--text-muted); }
+.settings-context-trigger-desktop .settings-context-label { display: block; color: var(--text-muted); font-size: 0.625rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.settings-context-trigger-desktop .settings-context-summary { display: block; overflow: hidden; max-width: 220px; margin-top: 0.1rem; text-overflow: ellipsis; white-space: nowrap; font-size: 0.75rem; font-weight: 650; }
+.settings-context-trigger-desktop:focus-visible { outline: 2px solid var(--accent-hover); outline-offset: 2px; }
+.settings-scope-tree-storage { display: flex; margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--border); }
+.settings-context-scrim.open { display: block; position: fixed; inset: 0; z-index: 309; border: 0; background: rgba(0, 0, 0, 0.35); }
+#settingsContainer .section { scroll-margin-top: 7rem; }
+#settingsContainer.settings-essentials-view .section {
+    border-color: var(--border);
+}
+
+.settings-workspace.settings-essentials-workspace {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.settings-workspace.settings-essentials-workspace .settings-sidebar {
+    display: none;
+}
+#settingsContainer.settings-essentials-view .section-header {
+    cursor: default;
+}
+#settingsContainer.settings-essentials-view .section-toggle {
+    display: none;
+}
+#settingsContainer.settings-essentials-view .section-content {
+    display: block;
+}
 @media (max-width: 900px) {
     .page-header-controls { flex-wrap: wrap; }
     .settings-workspace { grid-template-columns: 1fr; }
@@ -872,6 +1826,458 @@
     .indexer-url { max-width: 100%; }
     .indexer-actions { flex-wrap: wrap; }
 }
+
+@media (max-width: 900px) {
+    .settings-command-bar {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .settings-save-state {
+        grid-column: 1 / -1;
+        justify-self: stretch;
+    }
+
+    .settings-workspace {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-sidebar {
+        position: static;
+        max-height: none;
+        overflow: hidden;
+    }
+
+    .settings-category-nav {
+        flex-direction: row;
+        overflow-x: auto;
+        padding: 0.65rem 0 0.15rem;
+        scrollbar-width: thin;
+    }
+
+    .settings-category-btn {
+        width: auto;
+        min-height: 44px;
+        flex: 0 0 auto;
+        white-space: nowrap;
+    }
+}
+
+@media (min-width: 761px) and (max-width: 1024px),
+       (min-width: 761px) and (max-width: 1366px) and (any-pointer: coarse) {
+    .settings-context-scrim {
+        position: fixed;
+        inset: 0;
+        z-index: 309;
+        border: 0;
+        background: rgba(0, 0, 0, 0.62);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.18s ease, visibility 0.18s ease;
+    }
+
+    .settings-context-scrim.open {
+        display: block;
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .settings-scope-panel {
+        position: fixed;
+        top: auto !important;
+        right: 0;
+        bottom: 0;
+        left: 0 !important;
+        z-index: 310;
+        display: block;
+        width: auto;
+        max-height: min(82vh, 720px);
+        margin: 0;
+        padding: 0.9rem 0.9rem calc(0.9rem + env(safe-area-inset-bottom));
+        overflow-y: auto;
+        border: 1px solid var(--border);
+        border-bottom: 0;
+        border-radius: 18px 18px 0 0;
+        background: var(--bg-secondary);
+        box-shadow: 0 -18px 60px rgba(0, 0, 0, 0.45);
+        transform: translateY(105%);
+        visibility: hidden;
+        transition: transform 0.2s ease, visibility 0.2s ease;
+    }
+
+    .settings-scope-panel.open {
+        transform: translateY(0);
+        visibility: visible;
+    }
+
+    .settings-scope-sheet-header {
+        position: sticky;
+        top: -0.9rem;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin: -0.9rem -0.9rem 0.75rem;
+        padding: 1rem 0.9rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-secondary);
+    }
+
+    .settings-scope-sheet-kicker {
+        display: block;
+        margin-bottom: 0.15rem;
+        color: var(--text-muted);
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+    }
+
+    .settings-scope-heading {
+        display: block;
+        font-size: 0.875rem;
+    }
+
+    .settings-scope-sheet-close {
+        display: grid;
+        place-items: center;
+        width: 44px;
+        height: 44px;
+        flex: 0 0 44px;
+        padding: 0;
+        border: 1px solid var(--border);
+        border-radius: 50%;
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        font-size: 1.4rem;
+    }
+
+    .settings-scope-tree-storage {
+        display: flex;
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border);
+    }
+
+    .settings-scope-tree-storage[aria-hidden="true"] {
+        visibility: visible;
+    }
+
+    .settings-scope-row {
+        min-height: 44px;
+    }
+
+    .settings-mobile-level-section {
+        display: block;
+        margin-top: 0.9rem;
+        padding-top: 0.9rem;
+        border-top: 1px solid var(--border);
+    }
+
+    .settings-mobile-level-label {
+        display: block;
+        margin-bottom: 0.45rem;
+        color: var(--text-muted);
+        font-size: 0.68rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .settings-mobile-level-section .settings-level-btn {
+        min-height: 44px;
+    }
+
+    .settings-scope-actions {
+        display: none !important;
+    }
+}
+
+@media (max-width: 760px) {
+    .settings-page-shell {
+        padding-bottom: 5rem;
+    }
+
+    .settings-page-header {
+        position: sticky;
+        top: 0;
+        z-index: 24;
+        margin: -0.75rem -0.75rem 0;
+        padding: 0.7rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+        backdrop-filter: blur(14px);
+    }
+
+    .settings-page-header .settings-page-kicker,
+    .settings-page-header > p {
+        display: none;
+    }
+
+    .settings-mobile-heading-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+    }
+
+    .settings-page-header h1 {
+        margin: 0;
+        font-size: 1.25rem;
+    }
+
+    .settings-mobile-search-button {
+        display: grid;
+        place-items: center;
+        width: 44px;
+        height: 44px;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: var(--radius);
+        background: transparent;
+        color: var(--text-secondary);
+    }
+
+    .settings-mobile-search-button svg {
+        width: 20px;
+        height: 20px;
+    }
+
+    .settings-mobile-search-button:focus-visible,
+    .settings-context-trigger:focus-visible,
+    .settings-scope-sheet-close:focus-visible {
+        outline: 2px solid var(--accent-hover);
+        outline-offset: 2px;
+    }
+
+    .settings-command-bar {
+        display: none;
+        grid-template-columns: 1fr;
+        margin-top: 0.65rem;
+    }
+
+    .settings-page-shell.mobile-search-open .settings-command-bar {
+        display: grid;
+    }
+
+    .settings-command-bar .settings-level-switch,
+    .settings-command-bar .settings-save-state {
+        display: none;
+    }
+
+    .settings-context-trigger {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        width: 100%;
+        min-height: 48px;
+        margin: 0.75rem 0;
+        padding: 0.55rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        text-align: left;
+    }
+
+    .settings-context-trigger-desktop { display: none; }
+    .settings-context-trigger-mobile { display: flex; }
+
+    .settings-context-trigger svg {
+        width: 18px;
+        height: 18px;
+        flex: 0 0 18px;
+        color: var(--text-muted);
+    }
+
+    .settings-context-label {
+        display: block;
+        margin-bottom: 0.08rem;
+        color: var(--text-muted);
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .settings-context-summary {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 0.82rem;
+        font-weight: 650;
+    }
+
+    .settings-context-scrim {
+        position: fixed;
+        inset: 0;
+        z-index: 309;
+        border: 0;
+        background: rgba(0, 0, 0, 0.62);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.18s ease, visibility 0.18s ease;
+    }
+
+    .settings-context-scrim.open {
+        display: block;
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .settings-scope-panel {
+        position: fixed;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 310;
+        display: block;
+        max-height: min(82vh, 720px);
+        margin: 0;
+        padding: 0.9rem 0.9rem calc(0.9rem + env(safe-area-inset-bottom));
+        overflow-y: auto;
+        border: 1px solid var(--border);
+        border-bottom: 0;
+        border-radius: 18px 18px 0 0;
+        background: var(--bg-secondary);
+        box-shadow: 0 -18px 60px rgba(0, 0, 0, 0.45);
+        transform: translateY(105%);
+        visibility: hidden;
+        transition: transform 0.2s ease, visibility 0.2s ease;
+    }
+
+    .settings-scope-panel.open {
+        transform: translateY(0);
+        visibility: visible;
+    }
+
+    .settings-scope-sheet-header {
+        position: sticky;
+        top: -0.9rem;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin: -0.9rem -0.9rem 0.75rem;
+        padding: 1rem 0.9rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-secondary);
+    }
+
+    .settings-scope-sheet-kicker {
+        display: block;
+        margin-bottom: 0.15rem;
+        color: var(--text-muted);
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+    }
+
+    .settings-scope-heading {
+        display: block;
+        font-size: 0.875rem;
+    }
+
+    .settings-scope-sheet-close {
+        display: grid;
+        place-items: center;
+        width: 44px;
+        height: 44px;
+        flex: 0 0 44px;
+        padding: 0;
+        border: 1px solid var(--border);
+        border-radius: 50%;
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        font-size: 1.4rem;
+    }
+
+    .settings-scope-panel .settings-scope-bar {
+        display: none;
+    }
+
+    .settings-scope-tree-storage {
+        display: flex;
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border);
+    }
+
+    .settings-scope-tree-storage[aria-hidden="true"] {
+        visibility: visible;
+    }
+
+    .settings-scope-row {
+        min-height: 44px;
+    }
+
+    .settings-mobile-level-section {
+        display: block;
+        margin-top: 0.9rem;
+        padding-top: 0.9rem;
+        border-top: 1px solid var(--border);
+    }
+
+    .settings-mobile-level-label {
+        display: block;
+        margin-bottom: 0.45rem;
+        color: var(--text-muted);
+        font-size: 0.68rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .settings-mobile-level-section .settings-level-btn {
+        min-height: 44px;
+    }
+
+    .settings-scope-actions {
+        display: none !important;
+    }
+
+    .settings-category-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-category-card {
+        min-height: 132px;
+        gap: 0.6rem;
+        padding: 1rem 3.25rem 1rem 1rem;
+    }
+
+    .settings-category-card-icon {
+        width: 40px;
+        height: 40px;
+        flex-basis: 40px;
+    }
+
+    .settings-category-header {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-category-summary {
+        align-self: start;
+    }
+
+    .settings-sticky-save {
+        bottom: 0.5rem;
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .settings-sticky-save-actions .btn {
+        flex: 1;
+    }
+
+    #settingsContainer .section {
+        scroll-margin-top: 5.5rem;
+    }
+}
 </style>
 {{end}}
 
@@ -892,50 +2298,60 @@
     </div>
 </div>
 {{else}}
-<div class="page-header page-header-flex" style="display: flex; align-items: center; justify-content: space-between;">
-    <div>
+<div class="settings-page-shell">
+<header class="settings-page-header">
+    <div class="settings-page-kicker">Configure</div>
+    <div class="settings-mobile-heading-row">
         <h1>Settings</h1>
-        <p>{{if .IsAdmin}}Configure your Mediastorm server{{else}}Configure profile settings{{end}}</p>
-    </div>
-    <div class="page-header-controls" style="display: flex; gap: 0.5rem; align-items: center;">
-        <input type="search" id="settingsSearch" class="form-input" placeholder="Search settings..." autocomplete="off" autocapitalize="none" spellcheck="false" readonly aria-autocomplete="none" data-1p-ignore="true" data-lpignore="true" data-bwignore="true" data-protonpass-ignore="true" data-form-type="other" onpointerdown="activateSettingsSearch(this)" onkeydown="activateSettingsSearch(this)" onbeforeinput="activateSettingsSearch(this)" oninput="handleSettingsSearchInput(this)" style="min-width: 200px;">
-        <button id="identifyClientBtn" class="btn btn-secondary" style="display: none;" onclick="identifyClient()" title="Send ping to identify this device">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10"/>
-                <line x1="12" y1="8" x2="12" y2="12"/>
-                <line x1="12" y1="16" x2="12.01" y2="16"/>
-            </svg>
-            Identify
-        </button>
-        <button id="revertBtn" class="btn btn-secondary" style="display: none;" onclick="revertToGlobal()" title="Reset all settings to inherit from parent defaults">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                <path d="M3 3v5h5"/>
-            </svg>
-            Use Parent Defaults
-        </button>
-        <button id="propagateBtn" class="btn btn-secondary" style="display: none;" onclick="propagateSettings()" title="Review child scopes with custom settings">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M12 5v14"/>
-                <path d="M19 12l-7 7-7-7"/>
-            </svg>
-            <span id="propagateBtnLabel">Review Customizations</span>
-        </button>
-        <button class="btn btn-primary" onclick="saveAllSettings()">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
-                <polyline points="17 21 17 13 7 13 7 21"/>
-                <polyline points="7 3 7 8 15 8"/>
-            </svg>
-            Save
+        <button class="settings-mobile-search-button" type="button" aria-label="Search settings" aria-expanded="false" onclick="toggleSettingsMobileSearch(this)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
         </button>
     </div>
-</div>
+    <p>Find, understand, and safely customize MediaStorm.</p>
+    <div class="settings-command-bar">
+        <label class="settings-search-wrap" for="settingsSearch">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+            <input type="search" id="settingsSearch" class="form-input" placeholder="Search settings..." autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Search every setting" readonly aria-autocomplete="none" data-1p-ignore="true" data-lpignore="true" data-bwignore="true" data-protonpass-ignore="true" data-form-type="other" onpointerdown="activateSettingsSearch(this)" onkeydown="activateSettingsSearch(this)" onbeforeinput="activateSettingsSearch(this)" oninput="handleSettingsSearchInput(this)">
+        </label>
+        <div class="settings-level-switch" aria-label="Settings detail level">
+            <button id="settingsEssentialBtn" class="settings-level-btn" type="button" disabled aria-disabled="true">Essential</button>
+            <button id="settingsBasicBtn" class="settings-level-btn" type="button" onclick="setSettingsLevel('basic')">Basic</button>
+            <button id="settingsAdvancedBtn" class="settings-level-btn" type="button" onclick="setSettingsLevel('advanced')">Advanced</button>
+        </div>
+        <button class="settings-context-trigger settings-context-trigger-desktop" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="settingsScopePanel" onclick="openSettingsContextSheet()">
+            <span><span class="settings-context-label">Current scope</span><span class="settings-context-summary" data-settings-context-summary>Server defaults</span></span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+        </button>
+        <div id="settingsSaveState" class="settings-save-state" role="status" aria-live="polite">
+            <span aria-hidden="true">✓</span>
+            <span id="settingsSaveStateText">All changes saved</span>
+        </div>
+    </div>
+</header>
 
-<section class="settings-scope-panel" aria-label="Settings scope">
+<button id="settingsContextTrigger" class="settings-context-trigger settings-context-trigger-mobile" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="settingsScopePanel" onclick="openSettingsContextSheet()">
+    <span>
+        <span class="settings-context-label">Editing</span>
+        <span id="settingsContextSummary" class="settings-context-summary" data-settings-context-summary>Server defaults</span>
+    </span>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+</button>
+<button id="settingsContextScrim" class="settings-context-scrim" type="button" aria-label="Close settings context" onclick="closeSettingsContextSheet()"></button>
+
+<section id="settingsScopePanel" class="settings-scope-panel settings-scope-popover" aria-label="Settings scope">
+    <div class="settings-scope-sheet-header">
+        <div>
+            <span class="settings-scope-sheet-kicker">Editing context</span>
+            <span class="settings-scope-heading">Current scope · <span id="settingsScopeName">Server defaults</span></span>
+        </div>
+        <button class="settings-scope-sheet-close" type="button" aria-label="Close settings context" onclick="closeSettingsContextSheet()">×</button>
+    </div>
     <div class="settings-scope-bar">
-        <span class="settings-scope-label">Scope:</span>
         {{if .IsAdmin}}<button id="settingsServerScopeBtn" class="settings-scope-server-btn active" type="button" onclick="selectSettingsScope('server', '')">Server defaults</button>{{end}}
+        {{if .IsAdmin}}<label class="settings-scope-select-wrap" id="settingsHouseholdScopeWrap">
+            <span class="settings-scope-control-label">Household</span>
+            <select id="settingsHouseholdSelector" aria-label="Household access filter" onchange="handleSettingsHouseholdFilter(this.value)"><option value="">All households</option></select>
+        </label>{{end}}
         <label class="settings-scope-select-wrap" id="settingsPersonScopeWrap">
             <span class="settings-scope-control-label">Person</span>
             <select id="userSelector" aria-label="Person" onchange="selectSettingsScope(this.value ? 'person' : 'server', this.value)">
@@ -950,28 +2366,69 @@
             <select id="clientSelector" aria-label="Device" onchange="selectSettingsScope(this.value ? 'device' : 'person', selectedUserId, this.value)"><option value="">Choose a device</option></select>
         </label>
         <span class="settings-scope-spacer"></span>
-        <div class="settings-view-compact">
-            <span class="settings-scope-label">View:</span>
-            <div class="settings-level-switch" aria-label="Settings detail level">
-                <button id="settingsBasicBtn" class="settings-level-btn" type="button" disabled aria-disabled="true" title="Basic view is not ready yet">Basic</button>
-                <button id="settingsAdvancedBtn" class="settings-level-btn" type="button" onclick="setSettingsLevel('advanced')">Advanced</button>
-            </div>
+    </div>
+    <p id="settingsCascadeCopy" class="settings-cascade-copy">Settings cascade: Server defaults → Person overrides → Device overrides. Applies to all people and devices unless overridden.</p>
+    <div id="settingsScopeTree" class="settings-scope-tree settings-scope-tree-storage" aria-hidden="true"></div>
+    <div class="settings-scope-actions">
+        <button id="identifyClientBtn" class="btn btn-secondary" style="display: none;" onclick="identifyClient()" title="Send ping to identify this device">Identify device</button>
+        <button id="revertBtn" class="btn btn-secondary" style="display: none;" onclick="revertToGlobal()" title="Reset all settings to inherit from parent defaults">Use Parent Defaults</button>
+        <button id="propagateBtn" class="btn btn-secondary" style="display: none;" onclick="propagateSettings()" title="Review child scopes with custom settings"><span id="propagateBtnLabel">Review Customizations</span></button>
+    </div>
+    <div class="settings-mobile-level-section">
+        <span class="settings-mobile-level-label">Settings view</span>
+        <div class="settings-level-switch" aria-label="Mobile settings detail level">
+            <button id="settingsMobileEssentialBtn" class="settings-level-btn" type="button" disabled aria-disabled="true">Essential</button>
+            <button id="settingsMobileBasicBtn" class="settings-level-btn" type="button" onclick="setSettingsLevel('basic')">Basic</button>
+            <button id="settingsMobileAdvancedBtn" class="settings-level-btn" type="button" onclick="setSettingsLevel('advanced')">Advanced</button>
         </div>
     </div>
-    <p class="settings-cascade-copy">Settings cascade: Server defaults → Person overrides → Device overrides</p>
-    <div id="settingsScopeTree" class="settings-scope-tree settings-scope-tree-storage" aria-hidden="true"></div>
-    <div id="settingsCategoryNav" hidden aria-hidden="true"></div>
     <div id="settingsLevelHelp" hidden aria-hidden="true"></div>
 </section>
 
-<div class="settings-workspace">
-    <main class="settings-main">
+<section id="settingsHome" class="settings-home">
+    <div id="settingsAttentionBanner" class="settings-attention-banner" hidden>
+        <div>
+            <strong id="settingsAttentionTitle">Settings need attention</strong>
+            <p id="settingsAttentionCopy">Review the highlighted configuration issues.</p>
+        </div>
+        <button class="btn btn-secondary btn-sm" type="button" onclick="openFirstSettingsIssue()">Review issue →</button>
+    </div>
+    <div class="settings-home-heading">
+        <h2>Settings categories</h2>
+        <p>Choose a task area. Search also finds Advanced and technical settings.</p>
+    </div>
+    <div id="settingsCategoryCards" class="settings-category-grid"></div>
+</section>
+
+<div id="settingsCategoryWorkspace" class="settings-workspace" hidden>
+    <nav id="settingsCategoryNav" hidden aria-hidden="true"></nav>
+    <section class="settings-main" aria-labelledby="settingsCategoryTitle">
+        <header class="settings-category-header">
+            <div>
+                <div class="settings-category-breadcrumb">Settings</div>
+                <h2 id="settingsCategoryTitle">All settings</h2>
+                <p id="settingsCategoryDescription">Browse every available MediaStorm setting.</p>
+            </div>
+            <div id="settingsCategorySummary" class="settings-category-summary"></div>
+        </header>
         <div id="settingsContainer">
             <div style="display: flex; align-items: center; justify-content: center; padding: 2rem;">
                 <div class="spinner"></div>
             </div>
         </div>
-    </main>
+    </section>
+</div>
+
+<div id="settingsStickySave" class="settings-sticky-save" hidden>
+    <div>
+        <strong id="settingsStickySaveTitle">Unsaved changes</strong>
+        <p id="settingsStickySaveCopy">Review and save your changes.</p>
+    </div>
+    <div class="settings-sticky-save-actions">
+        <button class="btn btn-secondary" type="button" onclick="resetSettings()">Discard</button>
+        <button class="btn btn-primary" type="button" onclick="saveAllSettings()">Save changes</button>
+    </div>
+</div>
 </div>
 
 <!-- Test Result Modal -->
@@ -1209,22 +2666,30 @@
     // Sensitive settings may be revealed only until their first blur. Keep the
     // lock outside renderSettings so rerendering cannot make them viewable again.
     const lockedSensitiveFields = new Set();
-    const basicSettingsReady = false;
-    let settingsLevel = 'advanced';
-    localStorage.setItem('mediastorm-settings-level', settingsLevel);
+    const settingsLevels = new Set(['basic', 'advanced']);
+    const storedSettingsLevel = localStorage.getItem('mediastorm-settings-level');
+    let settingsLevel = settingsLevels.has(storedSettingsLevel) ? storedSettingsLevel : 'basic';
+    let settingsContextReturnFocus = null;
+    let settingsLastSectionViewport = null;
+    let selectedSettingsHouseholdId = '';
     let expandedIndexerEditIndex = -1;
+    const liveSourceGroupOpenState = new Map();
     const expandedProviderEditIndexes = {
         debridProviders: -1,
         torrentScrapers: -1,
+        usenet: -1,
+        usenetEngines: -1,
     };
     const providerTableSectionKeys = new Set(['indexers', 'debridProviders', 'torrentScrapers']);
+    providerTableSectionKeys.add('usenet');
+    providerTableSectionKeys.add('usenetEngines');
     const settingsSectionDescriptions = {
         indexers: 'Configure indexers and search providers',
         debridProviders: 'Real-Debrid, TorBox, AllDebrid, Premiumize, Torrin',
         torrentScrapers: 'Torrent indexers and streaming providers',
         'live.sources': 'IPTV and live television sources',
         'liveTV.sources': 'IPTV and live television sources',
-        usenet: 'Usenet server connections',
+        usenet: 'Manage and benchmark parallel provider slots',
         usenetEngines: 'SABnzbd, NZBGet configuration',
         streaming: 'Search behavior and source priority',
         filtering: 'Resolution, codec, and quality preferences',
@@ -1236,23 +2701,34 @@
         mdblist: 'MDBList integration and lists',
         subtitles: 'OpenSubtitles and subtitle preferences',
         homeShelves: 'Dashboard layout and widgets',
-        display: 'Theme, colors, and custom branding',
+        display: 'Interface, theme, accessibility, and custom branding',
         server: 'Base URL and port configuration',
         network: 'Local and remote access URLs'
     };
     const settingsOverviewGroups = [
-        { id: 'sources', label: 'Sources & Providers' },
-        { id: 'search', label: 'Search & Results' },
-        { id: 'playback', label: 'Playback' },
-        { id: 'metadata', label: 'Metadata & Services' },
-        { id: 'interface', label: 'Interface' },
+        { id: 'sources', label: 'Sources' },
+        { id: 'search', label: 'Search & Quality' },
+        { id: 'playback', label: 'Playback & Subtitles' },
+        { id: 'interface', label: 'Home' },
+        { id: 'appearance', label: 'Appearance & Branding' },
+        { id: 'metadata', label: 'Metadata' },
         { id: 'server', label: 'Server & Network' }
     ];
+    const settingsLandingGroups = [
+        { id: 'sources', label: 'Sources', description: 'Indexers, torrent scrapers, Usenet, debrid, and media sources.' },
+        { id: 'search', label: 'Search & Quality', description: 'Search behavior, filtering, quality, release terms, and ordering.' },
+        { id: 'playback', label: 'Playback & Subtitles', description: 'Playback, streams, transcoding, subtitles, and Live TV.' },
+        { id: 'interface', label: 'Home', description: 'Home screen shelves, discovery layout, and featured content.' },
+        { id: 'appearance', label: 'Appearance & Branding', description: 'Interface visibility, presentation, theme, accessibility, and branding images.' },
+        { id: 'metadata', label: 'Metadata', description: 'Movie and show information, languages, ratings, artwork, and metadata providers.' },
+        { id: 'server', label: 'Server & Network', description: 'Server, storage, WebDAV, networking, and maintenance.' }
+    ];
+    const settingsLandingArrowIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>';
     const settingsOverviewSectionOrder = new Map([
-        'indexers', 'debridProviders', 'torrentScrapers', 'live', 'usenet', 'usenetEngines',
+        'indexers', 'debridProviders', 'torrentScrapers', 'usenet', 'usenetEngines', 'live', 'liveTV',
         'streaming', 'filtering', 'animeFiltering', 'ranking',
-        'playback', 'transmux',
-        'metadata', 'mdblist', 'subtitles',
+        'playback', 'subtitles', 'transmux',
+        'metadata', 'mdblist',
         'homeShelves', 'display',
         'server', 'network'
     ].map((key, index) => [key, index]));
@@ -1315,32 +2791,158 @@
         'liveTV.sources.proxyUrl', 'liveTV.sources.playlistCacheTtlHours', 'liveTV.sources.probeSizeMb', 'liveTV.sources.analyzeDurationSec', 'liveTV.sources.lowLatency',
         'usenetEngines.apiPath', 'usenetEngines.priority', 'usenetEngines.config.webdavPathPrefix', 'usenetEngines.pollIntervalSeconds', 'usenetEngines.timeoutSeconds'
     ]);
+    // This presentation-only allowlist intentionally uses existing section and
+    // field paths. It can be reviewed independently without changing stored
+    // values, defaults, APIs, or inheritance behavior.
+    const watchEssentialSections = new Set([
+        'indexers', 'debridProviders', 'torrentScrapers', 'usenet', 'usenetEngines',
+        'streaming', 'filtering', 'playback', 'subtitles'
+    ]);
+    const watchEssentialFieldPaths = new Set([
+        'streaming.serviceMode',
+        'filtering.maxSizeMovieGb', 'filtering.maxSizeEpisodeGb', 'filtering.maxResolution', 'filtering.hdrDvPolicy',
+        'filtering.requiredTerms', 'filtering.filterOutTerms', 'filtering.preferredTerms', 'filtering.nonPreferredTerms',
+        'playback.preferredPlayer', 'playback.preferredAudioLanguage', 'playback.preferredSubtitleLanguage',
+        'playback.allowedTrackLanguages', 'playback.preferredSubtitleMode', 'playback.forceAacTranscoding',
+        'subtitles.openSubtitlesUsername', 'subtitles.openSubtitlesPassword', 'subtitles.subdlApiKey',
+        'subtitles.subsourceApiKey', 'subtitles.enableTranslatedSubs'
+    ]);
     const requestedSettingsSection = window.location.hash.replace(/^#/, '');
+    const requestedSettingsParams = new URLSearchParams(window.location.search);
+    const requestedSettingsCategory = requestedSettingsParams.get('category') || '';
+    if (settingsLandingGroups.some(group => group.id === requestedSettingsCategory)) {
+        activeSettingsGroup = requestedSettingsCategory;
+    }
     if (requestedSettingsSection && schema[requestedSettingsSection]?.group) {
-        activeSettingsGroup = schema[requestedSettingsSection].group;
+        activeSettingsGroup = settingsOverviewGroupForSection(requestedSettingsSection, schema[requestedSettingsSection]);
     }
     if (advancedSections.has(requestedSettingsSection)) {
         settingsLevel = 'advanced';
     }
 
     function setSettingsLevel(level) {
-        settingsLevel = (basicSettingsReady && level === 'basic') ? 'basic' : 'advanced';
+        settingsLevel = settingsLevels.has(level) ? level : 'basic';
         localStorage.setItem('mediastorm-settings-level', settingsLevel);
+        const url = new URL(window.location.href);
+        if (settingsLevel === 'essentials') {
+            activeSettingsGroup = '';
+            url.searchParams.delete('category');
+            url.searchParams.set('view', 'essentials');
+            url.hash = '';
+        } else if (activeSettingsGroup) {
+            url.searchParams.delete('view');
+        } else {
+            url.searchParams.set('view', 'dashboard');
+        }
+        history.pushState({}, '', url);
+        syncSettingsSidebarDestination(activeSettingsGroup || 'home');
         renderSettings();
+        closeSettingsContextSheet();
     }
 
     function setSettingsGroup(groupId) {
+        if (settingsLevel === 'essentials' && groupId) {
+            settingsLevel = 'basic';
+            localStorage.setItem('mediastorm-settings-level', settingsLevel);
+        }
         activeSettingsGroup = groupId;
+        searchTerm = '';
+        filteredSections = null;
+        filteredFields = null;
+        const searchInput = document.getElementById('settingsSearch');
+        if (searchInput) searchInput.value = '';
+        const url = new URL(window.location.href);
+        url.searchParams.delete('view');
+        if (groupId) url.searchParams.set('category', groupId);
+        else url.searchParams.delete('category');
+        url.hash = '';
+        history.pushState({}, '', url);
+        syncSettingsSidebarDestination(activeSettingsGroup || 'home');
         renderSettings();
+        requestAnimationFrame(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    }
+
+    function toggleSettingsMobileSearch(button) {
+        const shell = document.querySelector('.settings-page-shell');
+        if (!shell) return;
+        const shouldOpen = !shell.classList.contains('mobile-search-open');
+        shell.classList.toggle('mobile-search-open', shouldOpen);
+        button?.setAttribute('aria-expanded', String(shouldOpen));
+        if (shouldOpen) {
+            const input = document.getElementById('settingsSearch');
+            activateSettingsSearch(input);
+            requestAnimationFrame(() => input?.focus());
+        }
+    }
+
+    function settingsUsesSheetContext() {
+        return window.matchMedia('(max-width: 1024px)').matches ||
+            window.matchMedia('(max-width: 1366px) and (any-pointer: coarse)').matches;
+    }
+
+    function positionSettingsScopePanel(panel, trigger = settingsContextReturnFocus) {
+        if (!panel) return;
+        if (settingsUsesSheetContext()) {
+            panel.style.left = '';
+            panel.style.top = '';
+            return;
+        }
+        const triggerRect = trigger?.getBoundingClientRect?.();
+        const panelWidth = Math.min(520, window.innerWidth - 32);
+        const preferredLeft = triggerRect ? triggerRect.right - panelWidth : window.innerWidth - panelWidth - 16;
+        panel.style.left = Math.max(16, Math.min(preferredLeft, window.innerWidth - panelWidth - 16)) + 'px';
+        panel.style.top = Math.min((triggerRect?.bottom || 80) + 8, window.innerHeight - 240) + 'px';
+    }
+
+    function openSettingsContextSheet() {
+        const panel = document.getElementById('settingsScopePanel');
+        const scrim = document.getElementById('settingsContextScrim');
+        if (!panel) return;
+        if (scrim?.parentElement !== document.body) document.body.appendChild(scrim);
+        if (panel.parentElement !== document.body) document.body.appendChild(panel);
+        settingsContextReturnFocus = document.activeElement;
+        settingsScopeServerExpanded = true;
+        const households = settingsScopeHouseholds();
+        if (!isAdmin || households.length === 1) expandedSettingsHouseholds.add(households[0]?.id || '__household__');
+        if (selectedUserId) expandedSettingsPeople.add(selectedUserId);
+        renderSettingsScopeTree();
+        const isMobileContext = settingsUsesSheetContext();
+        positionSettingsScopePanel(panel);
+        panel.classList.add('open');
+        scrim?.classList.add('open');
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-modal', 'true');
+        document.getElementById('settingsScopeTree')?.setAttribute('aria-hidden', 'false');
+        document.querySelectorAll('.settings-context-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', 'true'));
+        document.body.style.overflow = 'hidden';
+        requestAnimationFrame(() => (isMobileContext ? panel.querySelector('.settings-scope-sheet-close') : panel.querySelector('.settings-scope-row button'))?.focus());
+    }
+
+    function closeSettingsContextSheet() {
+        const panel = document.getElementById('settingsScopePanel');
+        const scrim = document.getElementById('settingsContextScrim');
+        if (!panel?.classList.contains('open')) return;
+        panel.classList.remove('open');
+        scrim?.classList.remove('open');
+        panel.removeAttribute('role');
+        panel.removeAttribute('aria-modal');
+        document.getElementById('settingsScopeTree')?.setAttribute('aria-hidden', 'true');
+        document.querySelectorAll('.settings-context-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', 'false'));
+        document.body.style.overflow = '';
+        panel.style.left = '';
+        panel.style.top = '';
+        const returnFocus = settingsContextReturnFocus;
+        settingsContextReturnFocus = null;
+        requestAnimationFrame(() => returnFocus?.focus?.());
     }
 
     function renderSettingsWorkspaceNavigation() {
         renderSettingsScopeTree();
         updateSettingsScopeBarState();
         const nav = document.getElementById('settingsCategoryNav');
-        const availableGroups = groups.filter(group => Object.entries(schema).some(([key, def]) => {
-            if (def.group !== group.id || def.hidden) return false;
-            if (settingsLevel === 'basic' && advancedSections.has(key)) return false;
+        const availableGroups = settingsLandingGroups.filter(group => Object.entries(schema).some(([key, def]) => {
+            if (!def.group || settingsOverviewGroupForSection(key, def) !== group.id || def.hidden) return false;
+            if (!settingsSectionVisibleAtCurrentLevel(key)) return false;
             if (selectedClientId && !clientConfigSections.includes(key)) return false;
             if (selectedUserId && !selectedClientId && !perUserSections.includes(key)) return false;
             if (!selectedUserId && def.inheritFrom) return false;
@@ -1350,20 +2952,36 @@
             activeSettingsGroup = '';
         }
         if (nav) {
-            const allCustomizationCount = availableGroups.reduce((total, group) => total + settingsGroupCustomizationCount(group.id), 0);
-            const allButton = '<button type="button" class="settings-category-btn '+(!activeSettingsGroup ? 'active' : '')+'"'+(!activeSettingsGroup ? ' aria-current="page"' : '')+' onclick="setSettingsGroup(\'\')"><span class="settings-category-btn-copy"><span>All</span>'+renderCustomizationCount(allCustomizationCount)+'</span></button>';
-            nav.innerHTML = allButton + availableGroups.map(group => {
+            nav.innerHTML = availableGroups.map(group => {
                 const isActive = group.id === activeSettingsGroup;
-                const customizationCount = settingsGroupCustomizationCount(group.id);
+                const customizationCount = settingsOverviewCustomizationCount(group.id);
                 return '<button type="button" class="settings-category-btn '+(isActive ? 'active' : '')+'"'+(isActive ? ' aria-current="page"' : '')+' onclick="setSettingsGroup(\''+group.id+'\')"><span class="settings-category-btn-copy"><span>'+group.label+'</span>'+renderCustomizationCount(customizationCount)+'</span></button>';
             }).join('');
         }
-        document.getElementById('settingsBasicBtn')?.classList.toggle('active', settingsLevel === 'basic');
-        document.getElementById('settingsAdvancedBtn')?.classList.toggle('active', settingsLevel === 'advanced');
+        const essentialButton = document.getElementById('settingsEssentialBtn');
+        const basicButton = document.getElementById('settingsBasicBtn');
+        const advancedButton = document.getElementById('settingsAdvancedBtn');
+        const mobileEssentialButton = document.getElementById('settingsMobileEssentialBtn');
+        const mobileBasicButton = document.getElementById('settingsMobileBasicBtn');
+        const mobileAdvancedButton = document.getElementById('settingsMobileAdvancedBtn');
+        essentialButton?.classList.toggle('active', settingsLevel === 'essentials');
+        basicButton?.classList.toggle('active', settingsLevel === 'basic');
+        advancedButton?.classList.toggle('active', settingsLevel === 'advanced');
+        mobileEssentialButton?.classList.toggle('active', settingsLevel === 'essentials');
+        mobileBasicButton?.classList.toggle('active', settingsLevel === 'basic');
+        mobileAdvancedButton?.classList.toggle('active', settingsLevel === 'advanced');
+        essentialButton?.setAttribute('aria-pressed', String(settingsLevel === 'essentials'));
+        basicButton?.setAttribute('aria-pressed', String(settingsLevel === 'basic'));
+        advancedButton?.setAttribute('aria-pressed', String(settingsLevel === 'advanced'));
+        mobileEssentialButton?.setAttribute('aria-pressed', String(settingsLevel === 'essentials'));
+        mobileBasicButton?.setAttribute('aria-pressed', String(settingsLevel === 'basic'));
+        mobileAdvancedButton?.setAttribute('aria-pressed', String(settingsLevel === 'advanced'));
         const help = document.getElementById('settingsLevelHelp');
         if (help) help.textContent = settingsLevel === 'basic'
             ? 'Showing common settings. Switch to Advanced or search to find everything else.'
-            : 'Showing all settings.';
+            : (settingsLevel === 'essentials'
+                ? 'Showing the settings needed to find and watch content on one page.'
+                : 'Showing all settings.');
     }
 
     function updateSettingsScopeBarState() {
@@ -1372,6 +2990,7 @@
         const deviceWrap = document.getElementById('settingsDeviceScopeWrap');
         const userSelector = document.getElementById('userSelector');
         const clientSelector = document.getElementById('clientSelector');
+        renderSettingsHouseholdFilter();
         const isServer = !selectedUserId;
         const isPerson = !!selectedUserId && !selectedClientId;
         const isDevice = !!selectedClientId;
@@ -1383,14 +3002,28 @@
             clientSelector.disabled = !selectedUserId || clientsForUser.length === 0;
             if (clientSelector.value !== selectedClientId) clientSelector.value = selectedClientId;
         }
+        const scopeName = document.getElementById('settingsScopeName');
+        const cascadeCopy = document.getElementById('settingsCascadeCopy');
+        if (scopeName) scopeName.textContent = settingsScopeDisplayName();
+        document.querySelectorAll('[data-settings-context-summary]').forEach(summary => {
+            summary.textContent = settingsContextDisplayName();
+        });
+        if (cascadeCopy) {
+            cascadeCopy.textContent = isDevice
+                ? 'Overrides this device only · inherits from the selected person, then Server defaults.'
+                : (isPerson
+                    ? 'Applies to this person and their devices unless a device overrides it.'
+                    : 'Settings cascade: Server defaults → Person overrides → Device overrides. Applies to all people and devices unless overridden.');
+        }
     }
 
     function settingsOverviewGroupForSection(sectionKey, sectionDef) {
-        if (['indexers', 'debridProviders', 'torrentScrapers', 'live', 'usenet', 'usenetEngines'].includes(sectionKey)) return 'sources';
+        if (['indexers', 'debridProviders', 'torrentScrapers', 'live', 'liveTV', 'usenet', 'usenetEngines'].includes(sectionKey)) return 'sources';
         if (['streaming', 'filtering', 'animeFiltering', 'ranking'].includes(sectionKey)) return 'search';
-        if (['playback', 'transmux'].includes(sectionKey)) return 'playback';
-        if (['metadata', 'mdblist', 'subtitles'].includes(sectionKey)) return 'metadata';
-        if (['homeShelves', 'display'].includes(sectionKey)) return 'interface';
+        if (['playback', 'transmux', 'subtitles'].includes(sectionKey)) return 'playback';
+        if (['metadata', 'mdblist'].includes(sectionKey)) return 'metadata';
+        if (sectionKey === 'homeShelves') return 'interface';
+        if (sectionKey === 'display') return 'appearance';
         if (['server', 'network'].includes(sectionKey)) return 'server';
         return {
             providers: 'sources',
@@ -1399,6 +3032,203 @@
             services: 'metadata',
             server: 'server'
         }[sectionDef.group] || 'metadata';
+    }
+
+    function settingsAvailableSectionsForOverview(groupId) {
+        return Object.entries(schema).filter(([key, def]) => {
+            if (!def.group || def.hidden || settingsOverviewGroupForSection(key, def) !== groupId) return false;
+            if (!settingsSectionVisibleAtCurrentLevel(key)) return false;
+            if (selectedClientId && !clientConfigSections.includes(key)) return false;
+            if (selectedUserId && !selectedClientId && !perUserSections.includes(key)) return false;
+            if (!selectedUserId && def.inheritFrom) return false;
+            return true;
+        });
+    }
+
+    function settingsScopeDisplayName() {
+        if (selectedClientId) {
+            const client = clientsForUser.find(candidate => candidate.id === selectedClientId);
+            return 'Device · ' + (client?.nickname || client?.name || 'Selected device');
+        }
+        if (selectedUserId) {
+            const profile = profilesData.find(candidate => candidate.id === selectedUserId);
+            return 'Person · ' + (profile?.name || 'Selected person');
+        }
+        return 'Server defaults';
+    }
+
+    function renderSettingsHouseholdFilter() {
+        const householdSelector = document.getElementById('settingsHouseholdSelector');
+        const personSelector = document.getElementById('userSelector');
+        if (!householdSelector || !personSelector || !isAdmin) return;
+        const households = settingsScopeHouseholds();
+        const selectedProfile = profilesData.find(candidate => candidate.id === selectedUserId);
+        if (selectedProfile?.accountId) selectedSettingsHouseholdId = selectedProfile.accountId;
+        if (selectedSettingsHouseholdId && !households.some(household => household.id === selectedSettingsHouseholdId)) {
+            selectedSettingsHouseholdId = '';
+        }
+        householdSelector.innerHTML = '<option value="">All households</option>' + households.map(household => {
+            const id = household.id || '__household__';
+            const name = household.username || household.name || 'Household';
+            return '<option value="'+escapeHtml(id)+'">'+escapeHtml(/household$/i.test(name) ? name : name + '’s Household')+'</option>';
+        }).join('');
+        householdSelector.value = selectedSettingsHouseholdId;
+        const visibleProfiles = selectedSettingsHouseholdId
+            ? profilesData.filter(profile => profile.accountId === selectedSettingsHouseholdId)
+            : profilesData;
+        personSelector.innerHTML = '<option value="">Choose a person</option>' + visibleProfiles.map(profile =>
+            '<option value="'+escapeHtml(profile.id)+'">'+escapeHtml(profile.name || 'Unnamed person')+'</option>'
+        ).join('');
+        personSelector.value = visibleProfiles.some(profile => profile.id === selectedUserId) ? selectedUserId : '';
+    }
+
+    async function handleSettingsHouseholdFilter(householdId) {
+        selectedSettingsHouseholdId = householdId || '';
+        const selectedProfile = profilesData.find(candidate => candidate.id === selectedUserId);
+        if (selectedUserId && selectedSettingsHouseholdId && selectedProfile?.accountId !== selectedSettingsHouseholdId) {
+            await selectSettingsScope('server', '');
+        }
+        renderSettingsHouseholdFilter();
+    }
+
+    function settingsHouseholdDisplayName() {
+        if (!selectedUserId) return 'All households';
+        const profile = profilesData.find(candidate => candidate.id === selectedUserId);
+        const household = settingsScopeHouseholds().find(candidate => candidate.id === profile?.accountId);
+        const name = household?.username || household?.name || settingsScopeUsername || 'Household';
+        return /household$/i.test(name) ? name : name + '’s Household';
+    }
+
+    function settingsContextDisplayName() {
+        const parts = [settingsHouseholdDisplayName()];
+        if (selectedUserId) {
+            const profile = profilesData.find(candidate => candidate.id === selectedUserId);
+            parts.push(profile?.name || 'Selected person');
+        } else {
+            parts.push('Server defaults');
+        }
+        if (selectedClientId) {
+            const client = clientsForUser.find(candidate => candidate.id === selectedClientId);
+            parts.push(client?.nickname || client?.name || 'Selected device');
+        }
+        return parts.join(' · ');
+    }
+
+    function settingsSectionVisibleAtCurrentLevel(sectionKey) {
+        if (searchTerm) return true;
+        if (settingsLevel === 'essentials') return watchEssentialSections.has(sectionKey);
+        if (settingsLevel === 'basic') return !advancedSections.has(sectionKey);
+        return true;
+    }
+
+    function settingsFieldVisibleAtCurrentLevel(sectionKey, fieldKey, isAdvancedField) {
+        if (searchTerm) return true;
+        if (settingsLevel === 'essentials') return watchEssentialFieldPaths.has(sectionKey + '.' + fieldKey);
+        if (settingsLevel === 'basic') return !isAdvancedField;
+        return true;
+    }
+
+    function settingsCategoryMeta(groupId) {
+        const customizationCount = settingsOverviewCustomizationCount(groupId);
+        if (customizationCount > 0) return customizationCount + ' customized';
+        if (!selectedUserId && groupId === 'server') return 'Server only';
+        if (selectedUserId || selectedClientId) return 'Inherited unless customized';
+        const configured = settingsAvailableSectionsForOverview(groupId).reduce((total, [key, def]) => total + settingsSectionConfiguredCount(key, def), 0);
+        return configured > 0 ? configured + ' configured' : 'Using defaults';
+    }
+
+    function renderSettingsLanding() {
+        const cards = document.getElementById('settingsCategoryCards');
+        if (cards) {
+            cards.innerHTML = settingsLandingGroups
+                .filter(group => settingsAvailableSectionsForOverview(group.id).length > 0)
+                .map(group => '<button type="button" class="settings-category-card" onclick="setSettingsGroup(\''+group.id+'\')">' +
+                    '<span class="settings-category-card-heading"><span class="settings-category-card-icon">'+settingsLandingIcon(group.id)+'</span><span class="settings-category-card-title">'+escapeHtml(group.label)+'</span></span>' +
+                    '<span class="settings-category-card-description">'+escapeHtml(group.description)+'</span>' +
+                    '<span class="settings-category-card-meta">'+escapeHtml(settingsCategoryMeta(group.id))+'</span>' +
+                    '<span class="settings-category-card-arrow" aria-hidden="true">'+settingsLandingArrowIcon+'</span>' +
+                '</button>').join('');
+        }
+
+        const issueKeys = Object.keys(validationErrors);
+        const attention = document.getElementById('settingsAttentionBanner');
+        if (attention) attention.hidden = issueKeys.length === 0 || !!selectedUserId;
+        if (issueKeys.length > 0) {
+            const issueCount = issueKeys.reduce((total, key) => total + Math.max(1, getSectionErrorCount(key)), 0);
+            const firstLabel = schema[issueKeys[0]]?.label || issueKeys[0];
+            const title = document.getElementById('settingsAttentionTitle');
+            const copy = document.getElementById('settingsAttentionCopy');
+            if (title) title.textContent = issueCount + (issueCount === 1 ? ' setting needs attention' : ' settings need attention');
+            if (copy) copy.textContent = 'Review ' + firstLabel + (issueKeys.length > 1 ? ' and other highlighted sections.' : '.');
+        }
+    }
+
+    function renderSettingsCategoryHeader() {
+        const group = settingsLandingGroups.find(candidate => candidate.id === activeSettingsGroup);
+        const title = document.getElementById('settingsCategoryTitle');
+        const description = document.getElementById('settingsCategoryDescription');
+        const summary = document.getElementById('settingsCategorySummary');
+        const isEssentials = settingsLevel === 'essentials' && !searchTerm;
+        if (title) title.textContent = searchTerm ? 'Search results' : (isEssentials ? 'Essential settings' : (group?.label || 'All settings'));
+        if (description) description.textContent = searchTerm
+            ? 'Every matching setting is shown, including advanced and technical options.'
+            : (isEssentials
+                ? 'The settings most people need to connect sources, choose results, and start watching. All other controls remain available in Basic and Advanced.'
+                : (group?.description || 'Browse every available MediaStorm setting.'));
+        if (summary) {
+            const count = searchTerm && filteredSections
+                ? filteredSections.size
+                : (isEssentials
+                    ? Object.entries(schema).filter(([key, def]) => def.group && !def.hidden && watchEssentialSections.has(key)).length
+                    : (group ? settingsAvailableSectionsForOverview(group.id).length : 0));
+            summary.textContent = count + (count === 1 ? ' section' : ' sections') + ' · ' + settingsScopeDisplayName();
+        }
+    }
+
+    function openFirstSettingsIssue() {
+        const firstKey = Object.keys(validationErrors)[0];
+        if (!firstKey || !schema[firstKey]) return;
+        if (!settingsSectionVisibleAtCurrentLevel(firstKey)) {
+            settingsLevel = 'advanced';
+            localStorage.setItem('mediastorm-settings-level', settingsLevel);
+        }
+        activeSettingsGroup = settingsOverviewGroupForSection(firstKey, schema[firstKey]);
+        const url = new URL(window.location.href);
+        url.searchParams.set('category', activeSettingsGroup);
+        url.hash = firstKey;
+        history.pushState({}, '', url);
+        syncSettingsSidebarDestination(activeSettingsGroup);
+        renderSettings();
+        requestAnimationFrame(() => openSettingsSection(firstKey, { focus: true, scroll: true, historyMode: 'none' }));
+    }
+
+    function settingsHasUnsavedChanges() {
+        return Object.keys(schema).some(sectionHasChanges);
+    }
+
+    function updateSettingsSaveStatus() {
+        const hasChanges = settingsHasUnsavedChanges();
+        const state = document.getElementById('settingsSaveState');
+        const stateText = document.getElementById('settingsSaveStateText');
+        const sticky = document.getElementById('settingsStickySave');
+        const stickyTitle = document.getElementById('settingsStickySaveTitle');
+        const stickyCopy = document.getElementById('settingsStickySaveCopy');
+        state?.classList.toggle('unsaved', hasChanges);
+        if (stateText) stateText.textContent = hasChanges ? 'Unsaved changes' : 'All changes saved';
+        if (sticky) sticky.hidden = !hasChanges;
+        if (stickyTitle) stickyTitle.textContent = 'Unsaved changes · ' + settingsScopeDisplayName();
+        if (stickyCopy) stickyCopy.textContent = selectedClientId
+            ? 'Saving updates this device only.'
+            : (selectedUserId ? 'Saving updates this person and leaves device overrides unchanged.' : 'Saving updates the Server defaults. Existing overrides remain customized.');
+    }
+
+    function announceSettingsSaved() {
+        const stateText = document.getElementById('settingsSaveStateText');
+        if (!stateText) return;
+        stateText.textContent = 'Saved · ' + settingsScopeDisplayName();
+        window.setTimeout(() => {
+            if (!settingsHasUnsavedChanges()) stateText.textContent = 'All changes saved';
+        }, 3200);
     }
 
     function settingsSectionRowDescription(sectionKey, sectionDef) {
@@ -1558,6 +3388,13 @@
             .reduce((total, [sectionKey]) => total + settingsSectionCustomizationCount(sectionKey), 0);
     }
 
+    function settingsOverviewCustomizationCount(groupId) {
+        if (!selectedUserId && !selectedClientId) return 0;
+        return Object.entries(schema)
+            .filter(([sectionKey, def]) => def.group && !def.hidden && settingsOverviewGroupForSection(sectionKey, def) === groupId)
+            .reduce((total, [sectionKey]) => total + settingsSectionCustomizationCount(sectionKey), 0);
+    }
+
     function renderSettingsPersonScope(profile) {
         const profileClients = settingsScopeClients.filter(client => client.userId === profile.id);
         const activeClients = profileClients.filter(client => !isSettingsDeviceStale(client));
@@ -1583,8 +3420,19 @@
 
     function toggleSettingsHousehold(householdId) {
         if (expandedSettingsHouseholds.has(householdId)) expandedSettingsHouseholds.delete(householdId);
-        else expandedSettingsHouseholds.add(householdId);
+        else {
+            expandedSettingsHouseholds.clear();
+            expandedSettingsHouseholds.add(householdId);
+        }
         renderSettingsScopeTree();
+    }
+
+    function settingsLandingIcon(groupId) {
+        const sidebarIcon = document.querySelector('[data-settings-destination="'+groupId+'"] .sidebar-nav-icon');
+        if (!sidebarIcon) return '';
+        const icon = sidebarIcon.cloneNode(true);
+        icon.removeAttribute('class');
+        return icon.outerHTML;
     }
 
     function toggleSettingsServer(event) {
@@ -1613,6 +3461,7 @@
         settingsScopeServerExpanded = true;
         const householdId = profile.accountId || '__household__';
         expandedSettingsHouseholds.add(householdId);
+        expandedSettingsPeople.add(profileId);
     }
 
     async function selectSettingsScope(kind, profileId, clientId = '') {
@@ -1620,6 +3469,7 @@
             const selector = document.getElementById('userSelector');
             if (selector) selector.value = '';
             await handleUserChange('');
+            closeSettingsContextSheet();
             return;
         }
         const selector = document.getElementById('userSelector');
@@ -1630,6 +3480,7 @@
             if (clientSelector) clientSelector.value = clientId;
             await handleClientChange(clientId);
         }
+        closeSettingsContextSheet();
     }
 
     function stringifyDebugArg(arg) {
@@ -2088,6 +3939,13 @@
             return;
         }
         handleSettingsSearch(input.value);
+    }
+
+    function clearSettingsSearch() {
+        const input = document.getElementById('settingsSearch');
+        if (input) input.value = '';
+        handleSettingsSearch('');
+        requestAnimationFrame(() => input?.focus());
     }
 
     function handleSettingsSearch(term) {
@@ -3768,6 +5626,8 @@
         'unlock': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>',
         'edit': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>',
         'trash': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>',
+        'chevron-down': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>',
+        'more-horizontal': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg>',
         'plus': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
         'check': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>',
         'x': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>',
@@ -4526,6 +6386,7 @@
         section.querySelectorAll('.section-save-btn').forEach(button => {
             button.disabled = !hasChanges;
         });
+        updateSettingsSaveStatus();
     }
 
     function handleFieldInputChange(basePath, fieldKey, value) {
@@ -5793,6 +7654,7 @@
     // Close modal on Escape key
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape') {
+            closeSettingsContextSheet();
             closeTestModal();
         }
     });
@@ -6798,6 +8660,8 @@
                     showToast('Device settings saved successfully');
                     updateRevertButtonVisibility();
                     renderSettingsScopeTree();
+                    updateSettingsSaveStatus();
+                    announceSettingsSaved();
                     setTimeout(() => renderSettings(), 500);
                 } else {
                     const result = await response.json().catch(() => ({}));
@@ -6829,6 +8693,7 @@
                     setTimeout(() => renderSettings(), 500);
                     await updateClientSaveImpact();
                     renderSettings();
+                    announceSettingsSaved();
                 } else {
                     const result = await response.text();
                     showToast(result || 'Failed to save settings', 'error');
@@ -6853,6 +8718,7 @@
                     setTimeout(() => renderSettings(), 500);
                     await updateProfileSaveImpact(changedGroups);
                     renderSettings();
+                    announceSettingsSaved();
                 } else {
                     const result = await response.json();
                     showToast(result.error || 'Failed to save settings', 'error');
@@ -6956,7 +8822,7 @@
         return Object.entries(sectionDef.fields)
             .sort((a, b) => (a[1].order || 0) - (b[1].order || 0))
             .map(([fieldKey, fieldDef]) => {
-                if (settingsLevel === 'basic' && !searchTerm && advancedArrayFields.has(sectionKey + '.' + fieldKey)) return '';
+                if ((settingsLevel === 'basic' || settingsLevel === 'essentials') && !searchTerm && advancedArrayFields.has(sectionKey + '.' + fieldKey)) return '';
                 if (!providerTableFieldVisible(item, fieldDef)) return '';
                 const fieldValue = fieldKey.includes('.')
                     ? fieldKey.split('.').reduce((obj, key) => obj?.[key], item)
@@ -7000,7 +8866,11 @@
             const statusInput = renderInput('enabled', sectionDef.fields.enabled, item.enabled, basePath + '.' + index, sectionKey)
                 .replace('<label class="toggle">', '<label class="toggle" aria-label="Enable ' + escapeHtml(name).replace(/"/g, '&quot;') + '">');
             const isEditing = expandedProviderEditIndexes[sectionKey] === index;
-            const credentialMask = item.apiKey ? '••••••••' : 'Not set';
+            const credentialMask = options.credential ? options.credential(item) : (item.apiKey ? '••••••••' : 'Not set');
+            const detailValue = options.detail ? options.detail(item, index) : (index + 1);
+            const detailCell = options.detail
+                ? '<td data-label="' + options.detailLabel + '">' + escapeHtml(String(detailValue)) + '</td>'
+                : '<td data-label="Priority">' + (index + 1) + '</td>';
             const badges = renderProviderTableBadges(sectionKey, item);
             const badgesHtml = badges ? '<span class="provider-type-badges">' + badges + '</span>' : '';
             const editHint = sectionKey === 'torrentScrapers' && item.type === 'aiostreams' && item.enabled && (currentSettings.streaming?.indexerTimeoutSec || 5) <= 5
@@ -7011,8 +8881,8 @@
                     (secondary ? '<span class="indexer-url" title="' + escapeHtml(secondary).replace(/"/g, '&quot;') + '">' + escapeHtml(secondary) + '</span>' : '') +
                     badgesHtml + '</td>' +
                 '<td data-label="Status"><span class="indexer-status">' + statusInput + '<span class="indexer-status-text ' + (item.enabled ? 'enabled' : '') + '">' + (item.enabled ? 'On' : 'Off') + '</span></span></td>' +
-                '<td data-label="Priority">' + (index + 1) + '</td>' +
-                '<td data-label="API Key"><span class="indexer-api-mask">' + credentialMask + '</span></td>' +
+                detailCell +
+                '<td data-label="' + (options.credentialLabel || 'API Key') + '"><span class="indexer-api-mask">' + escapeHtml(String(credentialMask)) + '</span></td>' +
                 '<td data-label="Actions"><div class="indexer-actions">' +
                     '<button id="test-btn-' + sectionKey + '-' + index + '" class="indexer-action-btn" type="button" onclick="testProvider(\'' + sectionKey + '\', ' + index + ')">Test</button>' +
                     '<button class="indexer-action-btn" type="button" aria-expanded="' + isEditing + '" onclick="toggleProviderEditor(\'' + sectionKey + '\', ' + index + ', event)">' + (isEditing ? 'Close' : 'Edit') + '</button>' +
@@ -7025,7 +8895,7 @@
             return mainRow + editRow;
         }).join('');
         const table = items.length > 0
-            ? '<div class="indexer-table-shell provider-table-shell"><table class="indexer-table provider-table"><thead><tr><th scope="col">Name</th><th scope="col">Status</th><th scope="col">Priority</th><th scope="col">API Key</th><th scope="col">Actions</th></tr></thead><tbody>' + rows + '</tbody></table></div>'
+            ? '<div class="indexer-table-shell provider-table-shell"><table class="indexer-table provider-table"><thead><tr><th scope="col">Name</th><th scope="col">Status</th><th scope="col">' + (options.detailLabel || 'Priority') + '</th><th scope="col">' + (options.credentialLabel || 'API Key') + '</th><th scope="col">Actions</th></tr></thead><tbody>' + rows + '</tbody></table></div>'
             : '<div class="indexer-empty-state"><strong>' + options.emptyTitle + '</strong><p class="form-hint">' + options.emptyHint + '</p></div>';
         const hasChanges = sectionHasChanges(sectionKey);
         const saveLabel = !selectedUserId && !selectedClientId ? 'Save All Changes' : 'Save Changes';
@@ -7070,6 +8940,185 @@
             '<button type="button" class="section-save-btn" onclick="saveSection(\'indexers\', event)" ' + (hasChanges ? '' : 'disabled') + '>' + saveLabel + '</button></div>';
     }
 
+    function renderUsenetServerSection(sectionDef, items, basePath) {
+        const fieldOrder = ['name', 'host', 'port', 'username', 'password', 'connections'];
+        const renderUsenetField = (item, index, fieldKey) => {
+            const fieldDef = sectionDef.fields[fieldKey];
+            if (!fieldDef) return '';
+            const fieldValue = item[fieldKey];
+            const isRequired = fieldDef.required === true;
+            const isMissingRequired = isRequired && (fieldValue === undefined || fieldValue === null || String(fieldValue).trim() === '');
+            const requiredBadge = isMissingRequired ? '<span style="margin-left:0.4rem;color:var(--warning);font-size:0.68rem;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;">Required</span>' : '';
+            const requiredHint = isMissingRequired ? '<p class="form-hint" style="color:var(--warning);">Required before testing or saving this provider.</p>' : '';
+            const fieldInputId = (basePath+'.'+index+'_'+fieldKey).replace(/\./g, '_');
+            return '<div class="form-group'+(isMissingRequired ? ' required-missing' : '')+'">' +
+                '<label class="form-label" for="'+fieldInputId+'">'+escapeHtml(fieldDef.label)+requiredBadge+'</label>' +
+                renderInput(fieldKey, fieldDef, fieldValue, basePath+'.'+index, 'usenet') +
+                (fieldDef.description ? '<p class="form-hint">'+escapeHtml(fieldDef.description)+'</p>' : '') +
+                requiredHint + renderAdditionalFieldHint('usenet', fieldKey, item) + renderApiKeyFormatWarning(fieldKey, fieldValue) +
+            '</div>';
+        };
+        const renderHeaderToggle = (item, index, fieldKey) => {
+            const fieldDef = sectionDef.fields[fieldKey];
+            if (!fieldDef) return '';
+            const fieldInputId = (basePath+'.'+index+'_'+fieldKey).replace(/\./g, '_');
+            return '<div class="usenet-server-toggle">' +
+                renderInput(fieldKey, fieldDef, item[fieldKey], basePath+'.'+index, 'usenet') +
+                '<label for="'+fieldInputId+'">'+escapeHtml(fieldDef.label)+'</label>' +
+            '</div>';
+        };
+        const cardsHtml = items.map((item, index) => {
+            const displayName = item.name || item.host || 'New Usenet server';
+            const displayNameAttribute = escapeHtml(displayName).replace(/"/g, '&quot;');
+            return '<div class="usenet-server-card" data-usenet-index="'+index+'">' +
+                '<div class="usenet-server-card-header">' +
+                    '<div class="usenet-server-identity"><span class="usenet-server-name">'+escapeHtml(displayName)+'</span><span class="usenet-server-badge">USN</span><div class="usenet-server-toggles">'+renderHeaderToggle(item, index, 'enabled')+renderHeaderToggle(item, index, 'ssl')+'</div></div>' +
+                    '<div class="usenet-server-actions">' +
+                        '<button id="test-btn-usenet-'+index+'" class="btn btn-sm btn-secondary" type="button" onclick="testProvider(\'usenet\', '+index+')">'+getIcon('check')+' Test Connection</button>' +
+                        '<button class="btn btn-sm btn-danger" type="button" aria-label="Remove '+displayNameAttribute+'" title="Remove Usenet server" onclick="removeArrayItem(\'usenet\', '+index+')">'+getIcon('trash')+'</button>' +
+                    '</div>' +
+                '</div>' +
+                '<div class="usenet-server-fields">'+fieldOrder.map(fieldKey => renderUsenetField(item, index, fieldKey)).join('')+'</div>' +
+            '</div>';
+        }).join('');
+        const addButton = '<button class="add-item-btn usenet-add-server" type="button" onclick="addArrayItem(\'usenet\')">'+getIcon('plus')+' Add Usenet Server</button>';
+        return '<div class="usenet-server-list">'+cardsHtml+addButton+'</div>';
+    }
+
+    function isLiveSourceSection(sectionKey) {
+        return sectionKey === 'live.sources' || sectionKey === 'liveTV.sources';
+    }
+
+    function setLiveSourceGroupOpen(sectionKey, index, groupKey, isOpen) {
+        liveSourceGroupOpenState.set(sectionKey + ':' + index + ':' + groupKey, isOpen);
+    }
+
+    function liveSourceGroupIsOpen(sectionKey, index, groupKey) {
+        const stateKey = sectionKey + ':' + index + ':' + groupKey;
+        if (liveSourceGroupOpenState.has(stateKey)) return liveSourceGroupOpenState.get(stateKey);
+        return groupKey === 'source' || groupKey === 'connection';
+    }
+
+    function liveSourceOptionLabel(fieldDef, value, fallback) {
+        const option = (fieldDef?.options || []).find(candidate => {
+            const optionValue = typeof candidate === 'object' ? candidate.value : candidate;
+            return optionValue === value;
+        });
+        if (!option) return fallback || String(value || 'Not set');
+        return typeof option === 'object' ? option.label : option;
+    }
+
+    function liveSourceTypeLabel(sectionDef, item) {
+        return liveSourceOptionLabel(sectionDef.fields?.mode, item.mode, 'Type not set');
+    }
+
+    function liveSourceEndpointSummary(item) {
+        const rawEndpoint = item.mode === 'xtream'
+            ? item.xtreamHost
+            : item.mode === 'stremio'
+                ? item.manifestUrl
+                : item.playlistUrl;
+        if (!rawEndpoint) return 'Server not set';
+        try {
+            return new URL(rawEndpoint).host || 'Server configured';
+        } catch (_) {
+            const sanitized = String(rawEndpoint).replace(/^.*@/, '').replace(/^\w+:\/\//, '').split('/')[0];
+            return sanitized || 'Server configured';
+        }
+    }
+
+    function liveSourceGroupSummary(groupKey, sectionDef, item) {
+        if (groupKey === 'source') {
+            return liveSourceTypeLabel(sectionDef, item) + ' · ' + (item.enabled ? 'Enabled' : 'Disabled');
+        }
+        if (groupKey === 'connection') return liveSourceEndpointSummary(item);
+        if (groupKey === 'playback') {
+            const streams = Number(item.maxStreams || 0);
+            const streamLabel = streams === 0 ? 'Unlimited streams' : streams + ' max stream' + (streams === 1 ? '' : 's');
+            const format = liveSourceOptionLabel(sectionDef.fields?.streamFormat, item.streamFormat, 'Format not set');
+            const cacheTtl = item.playlistCacheTtlHours === undefined || item.playlistCacheTtlHours === null || item.playlistCacheTtlHours === ''
+                ? 'Default cache'
+                : item.playlistCacheTtlHours + 'h cache';
+            return streamLabel + ' · ' + format + ' · ' + cacheTtl + ' · Low latency ' + (item.lowLatency ? 'on' : 'off');
+        }
+        if (groupKey === 'channelFiltering') {
+            const categories = Array.isArray(item.filtering?.enabledCategories) ? item.filtering.enabledCategories : [];
+            const categoryLabel = categories.length === 0 ? 'All categories' : categories.length + ' categor' + (categories.length === 1 ? 'y' : 'ies');
+            const maxChannels = Number(item.filtering?.maxChannels || 0);
+            return categoryLabel + ' · ' + (maxChannels === 0 ? 'No channel limit' : maxChannels + ' channel limit');
+        }
+        if (groupKey === 'epg') {
+            if (!item.epg?.enabled) return 'Disabled';
+            const refresh = item.epg.refreshIntervalHours || 12;
+            const retention = item.epg.retentionDays || 7;
+            return 'Enabled · Refresh every ' + refresh + 'h · ' + retention + '-day retention';
+        }
+        return '';
+    }
+
+    function renderLiveSourceCard(sectionKey, sectionDef, item, index, fieldEntries, isTestable) {
+        const groupedEntries = [];
+        const groupsByKey = new Map();
+        for (const entry of fieldEntries) {
+            const groupKey = entry.group || 'source';
+            if (!groupsByKey.has(groupKey)) {
+                const group = {
+                    key: groupKey,
+                    label: entry.groupLabel || groupKey,
+                    description: entry.groupDescription || '',
+                    fields: [],
+                };
+                groupsByKey.set(groupKey, group);
+                groupedEntries.push(group);
+            }
+            groupsByKey.get(groupKey).fields.push(entry.html);
+        }
+
+        const groupsHtml = groupedEntries.map(group => {
+            const isOpen = liveSourceGroupIsOpen(sectionKey, index, group.key);
+            const safeGroupKey = escapeHtml(group.key).replace(/"/g, '&quot;');
+            return '<details class="live-source-group ' + safeGroupKey + '" ' + (isOpen ? 'open' : '') +
+                ' ontoggle="setLiveSourceGroupOpen(\'' + sectionKey + '\', ' + index + ', \'' + safeGroupKey + '\', this.open)">' +
+                    '<summary>' +
+                        '<span class="live-source-group-chevron" aria-hidden="true">' + getIcon('chevron-down') + '</span>' +
+                        '<span class="live-source-group-heading"><span class="live-source-group-title">' + escapeHtml(group.label) + '</span>' +
+                            (group.description ? '<span class="live-source-group-description">' + escapeHtml(group.description) + '</span>' : '') +
+                        '</span>' +
+                        '<span class="live-source-group-summary">' + escapeHtml(liveSourceGroupSummary(group.key, sectionDef, item)) + '</span>' +
+                    '</summary>' +
+                    '<div class="live-source-group-body"><div class="live-source-group-fields">' + group.fields.join('') + '</div></div>' +
+                '</details>';
+        }).join('');
+
+        const name = item.name || item.id || 'Live TV source ' + (index + 1);
+        const enabledLabel = item.enabled ? 'Enabled' : 'Disabled';
+        const endpoint = liveSourceEndpointSummary(item);
+        const testButton = isTestable
+            ? '<button id="test-btn-' + sectionKey + '-' + index + '" type="button" class="btn btn-sm btn-secondary" onclick="testProvider(\'' + sectionKey + '\', ' + index + ')">' + getIcon('check') + ' Test</button>'
+            : '';
+        const hiddenChannelsButton = '<button type="button" class="btn btn-sm btn-secondary" onclick="openHiddenChannelsManagerForSource(\'' + sectionKey + '\', ' + index + ', event)">' +
+            '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3l18 18"/><path d="M10.58 10.58A2 2 0 0 0 13.42 13.42"/><path d="M9.88 4.24A10.94 10.94 0 0 1 12 4c7 0 10 8 10 8a18.5 18.5 0 0 1-2.16 3.19"/><path d="M6.61 6.61C3.98 8.38 2 12 2 12s3 8 10 8a10.9 10.9 0 0 0 5.39-1.39"/></svg> Manage Hidden Channels</button>';
+        const deleteMenu = '<details class="live-source-action-menu">' +
+            '<summary class="btn btn-sm btn-secondary" aria-label="More actions for ' + escapeHtml(name).replace(/"/g, '&quot;') + '">' + getIcon('more-horizontal') + '</summary>' +
+            '<div class="live-source-action-menu-panel"><button type="button" class="btn btn-sm btn-danger" onclick="event.preventDefault(); removeArrayItem(\'' + sectionKey + '\', ' + index + ')">' + getIcon('trash') + ' Delete</button></div>' +
+        '</details>';
+
+        return '<div class="array-item live-source-card">' +
+            '<div class="live-source-card-header">' +
+                '<div class="live-source-card-identity">' +
+                    '<div class="live-source-card-name" title="' + escapeHtml(name).replace(/"/g, '&quot;') + '">' + escapeHtml(name) + '</div>' +
+                    '<div class="live-source-card-meta">' +
+                        '<span class="live-source-status ' + (item.enabled ? 'enabled' : '') + '"><span class="live-source-status-dot"></span>' + enabledLabel + '</span>' +
+                        '<span class="live-source-type-badge">' + escapeHtml(liveSourceTypeLabel(sectionDef, item)) + '</span>' +
+                        '<span class="live-source-endpoint" title="' + escapeHtml(endpoint).replace(/"/g, '&quot;') + '">Server: ' + escapeHtml(endpoint) + '</span>' +
+                    '</div>' +
+                '</div>' +
+                '<div class="live-source-card-actions">' + hiddenChannelsButton + testButton + deleteMenu + '</div>' +
+            '</div>' +
+            '<div class="live-source-groups">' + groupsHtml + '</div>' +
+        '</div>';
+    }
+
     function renderArraySection(sectionKey, sectionDef) {
         let items, basePath;
         const parentKey = sectionDef.parent;
@@ -7096,6 +9145,34 @@
         }
         const isTestable = testableSections.includes(sectionKey);
         if (sectionKey === 'indexers') return renderIndexerTableSection(sectionDef, items, basePath);
+        if (sectionKey === 'usenet') {
+            return renderProviderTableSection(sectionKey, sectionDef, items, basePath, {
+                itemFallback: 'Usenet server',
+                secondary: item => item.host ? item.host + ':' + (item.port || '') : 'Host not set',
+                detailLabel: 'Connection',
+                detail: item => (item.ssl ? 'SSL' : 'Plain') + ' · ' + (item.connections || 0) + ' connections',
+                credentialLabel: 'Login',
+                credential: item => item.username ? item.username : 'Not set',
+                intro: 'Manage Usenet servers in a compact list. Open a server only when you need to edit its connection details.',
+                emptyTitle: 'No Usenet servers configured',
+                emptyHint: 'Add a server to enable Usenet downloads.',
+                addLabel: 'Add Usenet Server',
+            });
+        }
+        if (sectionKey === 'usenetEngines') {
+            return renderProviderTableSection(sectionKey, sectionDef, items, basePath, {
+                itemFallback: 'Usenet app',
+                secondary: item => item.baseUrl || 'URL not set',
+                detailLabel: 'App',
+                detail: item => item.type || 'Not selected',
+                credentialLabel: 'Credentials',
+                credential: item => (item.apiKey || item.username || item.password) ? 'Configured' : 'Not set',
+                intro: 'Manage SABnzbd and NZBGet connections. Open an app only when you need to edit it.',
+                emptyTitle: 'No Usenet apps configured',
+                emptyHint: 'Add an app to send and manage Usenet downloads.',
+                addLabel: 'Add Usenet App',
+            });
+        }
         if (sectionKey === 'debridProviders') {
             return renderProviderTableSection(sectionKey, sectionDef, items, basePath, {
                 itemFallback: 'Debrid service',
@@ -7143,9 +9220,6 @@
                     typeBadgesHtml =
                         '<span style="' + badgeStyle + 'background:rgba(245,158,11,0.16);color:#f59e0b;border:1px solid rgba(245,158,11,0.35);">TOR</span>';
                 }
-            } else if (sectionKey === 'usenet') {
-                typeBadgesHtml =
-                    '<span style="display:inline-flex;align-items:center;justify-content:center;min-width:36px;padding:0.125rem 0.45rem;border-radius:999px;font-size:0.68rem;font-weight:700;letter-spacing:0.04em;background:rgba(59,130,246,0.16);color:#60a5fa;border:1px solid rgba(96,165,250,0.35);">USN</span>';
             } else if (sectionKey === 'usenetEngines') {
                 typeBadgesHtml =
                     '<span style="display:inline-flex;align-items:center;justify-content:center;min-width:36px;padding:0.125rem 0.45rem;border-radius:999px;font-size:0.68rem;font-weight:700;letter-spacing:0.04em;background:rgba(34,197,94,0.16);color:#22c55e;border:1px solid rgba(34,197,94,0.35);">ENG</span>';
@@ -7153,10 +9227,10 @@
             const fieldEntries = Object.entries(sectionDef.fields)
                 .sort((a, b) => (a[1].order || 0) - (b[1].order || 0))
                 .map(([fieldKey, fieldDef]) => {
-                if (settingsLevel === 'basic' && !searchTerm && advancedArrayFields.has(sectionKey + '.' + fieldKey)) {
+                if ((settingsLevel === 'basic' || settingsLevel === 'essentials') && !searchTerm && advancedArrayFields.has(sectionKey + '.' + fieldKey)) {
                     return null;
                 }
-                if (settingsLevel === 'basic' && sectionKey === 'usenetEngines' && ['apiPath', 'priority', 'config.webdavPathPrefix', 'pollIntervalSeconds', 'timeoutSeconds', 'allowedProfiles'].includes(fieldKey)) {
+                if ((settingsLevel === 'basic' || settingsLevel === 'essentials') && sectionKey === 'usenetEngines' && ['apiPath', 'priority', 'config.webdavPathPrefix', 'pollIntervalSeconds', 'timeoutSeconds', 'allowedProfiles'].includes(fieldKey)) {
                     return null;
                 }
                 const showWhen = fieldDef.showWhen;
@@ -7196,6 +9270,9 @@
                     html: '<div class="form-group'+(fieldDef.type === 'boolean' ? ' form-group-toggle' : '')+(isMissingRequired ? ' required-missing' : '')+'"><label class="form-label" for="'+fieldInputId+'">'+fieldDef.label+requiredBadge+'</label>'+renderInput(fieldKey, fieldDef, fieldValue, basePath+'.'+index, sectionKey)+(fieldDef.description ? '<p class="form-hint">'+fieldDef.description+'</p>' : '')+requiredHint+renderAdditionalFieldHint(sectionKey, fieldKey, item)+renderApiKeyFormatWarning(fieldKey, fieldValue)+'</div>',
                 };
             }).filter(Boolean);
+            if (isLiveSourceSection(sectionKey)) {
+                return renderLiveSourceCard(sectionKey, sectionDef, item, index, fieldEntries, isTestable);
+            }
             const fieldHtmlParts = [];
             let currentGroup = '';
             let groupedFields = [];
@@ -10957,6 +13034,62 @@
         });
     }
 
+    const playbackFieldGroups = [
+        { id: 'player', label: 'Player', description: 'Default player used when playback starts.', fields: ['preferredPlayer'] },
+        { id: 'languages', label: 'Languages & Tracks', description: 'Audio, subtitle, and player language choices.', fields: ['preferredAudioLanguage', 'preferredSubtitleLanguage', 'allowedTrackLanguages', 'preferredSubtitleMode'] },
+        { id: 'skipResume', label: 'Skip & Resume', description: 'Compact seek and rewind timing controls.', fields: ['seekForwardSeconds', 'seekBackwardSeconds', 'rewindOnResumeFromPause', 'rewindOnPlaybackStart'] },
+        { id: 'behavior', label: 'Playback Behavior', description: 'Compatibility, prequeue, migration, credits, and TV behavior.', fields: ['pauseWhenAppInactive', 'forceAacTranscoding', 'autoPlayTrailersTV', 'disablePrequeue', 'streamMigrationEnabled', 'creditsDetectionEnabled', 'creditsAutoSkip', 'matchFrameRate', 'liveClosedCaptionExtraction', 'maxResultsPerResolution'] },
+        { id: 'subtitleAppearance', label: 'Subtitle Appearance', description: 'Typography, color, outline, position, and background.', fields: ['subtitleSize', 'subtitleUseCropDetectPosition', 'subtitleColor', 'subtitleOpacity', 'subtitleFont', 'subtitleBold', 'subtitleOutlineEnabled', 'subtitleOutlineColor', 'subtitleOutlineWeight', 'subtitleBackgroundEnabled', 'subtitleBackgroundColor', 'subtitleBackgroundOpacity'] },
+        { id: 'preroll', label: 'Pre-roll', description: 'Optional artwork or video shown while playback is prepared.', fields: ['prerollMode', 'prerollAssetId', 'prerollMediaScope', 'prerollSkipIfPrequeueReady'] },
+        { id: 'playbackTools', label: 'Advanced Playback Tools', description: 'Seek thumbnails and server-side YouTube extraction.', fields: ['thumbnails.enabled', 'thumbnails.workers', 'youtubeProxyUrl', 'ytdlpCookies'] },
+    ];
+    const playbackFieldLayout = new Map(playbackFieldGroups.flatMap((group, groupIndex) => group.fields.map((field, fieldIndex) => [field, { ...group, groupIndex, fieldIndex }])));
+
+    const displayFieldGroups = [
+        {
+            id: 'interfaceContent',
+            label: 'Interface & Content',
+            description: 'Navigation, badges, content visibility, language, and information shown throughout the app.',
+            fields: ['badgeVisibility', 'navigationTabVisibility', 'watchStateIconStyle', 'hideWatched', 'alwaysShowProfileSelector', 'includeUnreleasedMoviesInLists', 'includeUnreleasedShowsInLists', 'includeUnreleasedMoviesInSearch', 'includeUnreleasedShowsInSearch', 'bypassFilteringForAioStreamsOnly', 'showParsedBadges', 'showStreamSourceInfo', 'appLanguage'],
+        },
+        {
+            id: 'motionTv',
+            label: 'Motion & TV Presentation',
+            description: 'Animation, hero artwork, TV layouts, simplified browsing, and spoiler presentation.',
+            fields: ['enableAnimations', 'enableHeroArtPanning', 'enableHeroArtRotation', 'hideContinueWatchingHeroMetadata', 'moveDetailsRatingsToMetadata', 'hideDetailsPoster', 'hideTvDrawerRail', 'simpleMode', 'simpleModeHomeShelves', 'disableTvHomeCardDimming', 'showSeriesBackdropForMissingEpisodeArt', 'blurUnwatchedEpisodeThumbnails', 'blurUnwatchedEpisodeThumbnailsIncludeCurrent', 'blurUnwatchedEpisodeOverviews', 'blurUnwatchedEpisodeOverviewsIncludeCurrent'],
+        },
+        {
+            id: 'theme',
+            label: 'Theme & Accessibility',
+            description: 'Text scale, color palette, buttons, contrast, and overlay treatment.',
+            fields: ['appearance.fontScale', 'appearance.accentColor', 'appearance.textColor', 'appearance.secondaryTextColor', 'appearance.backgroundColor', 'appearance.modalBackgroundColor', 'appearance.buttonStyle', 'appearance.buttonRadius', 'appearance.highContrast', 'appearance.reduceOverlays'],
+        },
+        {
+            id: 'branding',
+            label: 'Branding Images',
+            description: 'Upload and manage the images used across TV, mobile, loading, and web surfaces.',
+            fields: ['branding.wizard', 'branding.homeTvImageUrl', 'branding.homeTvImageUpload', 'branding.homeMobileLogoUrl', 'branding.homeMobileLogoUpload', 'branding.settingsTvImageUrl', 'branding.settingsTvImageUpload', 'branding.webIconUrl', 'branding.webIconUpload', 'branding.loadingLogoUrl', 'branding.loadingLogoUpload'],
+        },
+    ];
+    const displayFieldLayout = new Map(displayFieldGroups.flatMap((group, groupIndex) => group.fields.map((field, fieldIndex) => [field, { ...group, groupIndex, fieldIndex }])));
+
+    function handleSettingsSubsectionActivation(summary) {
+        const details = summary?.closest('details[data-settings-accordion]');
+        if (!details) return;
+        requestAnimationFrame(() => {
+            if (!details.open) return;
+            const accordion = details.dataset.settingsAccordion;
+            document.querySelectorAll('details[data-settings-accordion]').forEach(other => {
+                if (other !== details && other.dataset.settingsAccordion === accordion) other.open = false;
+            });
+            summary.focus({ preventScroll: true });
+            details.scrollIntoView({
+                behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+                block: 'start',
+            });
+        });
+    }
+
     function renderObjectSection(sectionKey, sectionDef) {
         // Use getValue for proper three-tier cascade (global → profile → client)
         // Get section data for showWhen conditions
@@ -10966,12 +13099,22 @@
         const sectionFieldFilter = filteredFields ? filteredFields.get(sectionKey) : null;
 
         const fieldEntries = Object.entries(sectionDef.fields)
-            .sort((a, b) => (a[1].order || 0) - (b[1].order || 0))
+            .sort((a, b) => {
+                if (sectionKey === 'playback' || sectionKey === 'display') {
+                    const fieldLayout = sectionKey === 'playback' ? playbackFieldLayout : displayFieldLayout;
+                    const aLayout = fieldLayout.get(a[0]);
+                    const bLayout = fieldLayout.get(b[0]);
+                    const aRank = aLayout ? aLayout.groupIndex * 100 + aLayout.fieldIndex : 9999 + (a[1].order || 0);
+                    const bRank = bLayout ? bLayout.groupIndex * 100 + bLayout.fieldIndex : 9999 + (b[1].order || 0);
+                    return aRank - bRank;
+                }
+                return (a[1].order || 0) - (b[1].order || 0);
+            })
             .map(([fieldKey, fieldDef]) => {
                 // Skip hidden fields
                 if (fieldDef.hidden) return '';
                 const isAdvancedField = fieldDef.advanced || advancedFieldPaths.has(sectionKey + '.' + fieldKey);
-                if (settingsLevel === 'basic' && !searchTerm && isAdvancedField) return '';
+                if (!settingsFieldVisibleAtCurrentLevel(sectionKey, fieldKey, isAdvancedField)) return '';
                 // Skip global-only fields (like file uploads) when viewing profile/client settings
                 if (fieldDef.globalOnly && (selectedUserId || selectedClientId)) return '';
                 // When editing device settings, only show fields that support client overrides.
@@ -11021,10 +13164,13 @@
                 const requiredForBadge = fieldDef.requiredFor
                     ? '<span class="settings-section-badge" style="margin-left:0.4rem;">Required for ' + escapeHtml(fieldDef.requiredFor) + '</span>'
                     : '';
+                const sectionLayout = sectionKey === 'playback'
+                    ? playbackFieldLayout.get(fieldKey)
+                    : (sectionKey === 'display' ? displayFieldLayout.get(fieldKey) : null);
                 return {
-                    group: fieldDef.group || '',
-                    groupLabel: fieldDef.groupLabel || '',
-                    groupDescription: fieldDef.groupDescription || '',
+                    group: sectionLayout?.id || fieldDef.group || '',
+                    groupLabel: sectionLayout?.label || fieldDef.groupLabel || '',
+                    groupDescription: sectionLayout?.description || fieldDef.groupDescription || '',
                     html: '<div class="form-group'+(fieldDef.type === 'boolean' ? ' form-group-toggle' : '')+invalidClass+inheritanceClass+'"><label class="form-label" for="'+fieldInputId+'"><span class="setting-field-title">'+fieldDef.label+(isAdvancedField ? '<span class="advanced-setting-badge">Advanced</span>' : '')+requiredForBadge+renderUserEditableSettingToggle(fieldDef)+'</span>'+inheritanceBadge+'</label>'+renderInput(fieldKey, fieldDef, fieldValue, sectionKey, sectionKey)+(fieldDef.description ? '<p class="form-hint">'+fieldDef.description+'</p>' : '')+renderAdditionalFieldHint(sectionKey, fieldKey)+renderApiKeyFormatWarning(fieldKey, fieldValue)+errorHtml+'</div>',
                 };
             })
@@ -11037,14 +13183,42 @@
         let currentGroupDescription = '';
         const flushGroup = () => {
             if (groupedFields.length === 0) return;
-            if (currentGroup) {
-                fieldHtmlParts.push(
-                    '<div class="field-subgroup">' +
-                        '<h3 class="field-subgroup-title">' + currentGroupLabel + '</h3>' +
-                        (currentGroupDescription ? '<p class="field-subgroup-description">' + currentGroupDescription + '</p>' : '') +
-                        '<div class="field-subgroup-fields">' + groupedFields.join('') + '</div>' +
-                    '</div>'
-                );
+                if (currentGroup && sectionKey === 'playback' && settingsLevel === 'essentials') {
+                    fieldHtmlParts.push(
+                        '<div class="playback-setting-group playback-setting-group-static"><span class="playback-setting-group-copy"><span class="playback-setting-group-title">' + currentGroupLabel + '</span>' +
+                        (currentGroupDescription ? '<span class="playback-setting-group-description">' + currentGroupDescription + '</span>' : '') + '</span>' +
+                        '<div class="field-subgroup-fields">' + groupedFields.join('') + '</div></div>'
+                    );
+                } else if (currentGroup && sectionKey === 'playback') {
+                    const groupOpen = currentGroup === 'player' || Boolean(searchTerm);
+                    fieldHtmlParts.push(
+                        '<details class="playback-setting-group" data-settings-accordion="playback"' + (groupOpen ? ' open' : '') + '>' +
+                            '<summary onclick="handleSettingsSubsectionActivation(this)"><span class="playback-setting-group-copy"><span class="playback-setting-group-title">' + currentGroupLabel + '</span>' +
+                            (currentGroupDescription ? '<span class="playback-setting-group-description">' + currentGroupDescription + '</span>' : '') + '</span></summary>' +
+                            '<div class="field-subgroup-fields">' + groupedFields.join('') + '</div>' +
+                        '</details>'
+                    );
+                } else if (currentGroup) {
+                    const appearancePresetHtml = sectionKey === 'display' && currentGroup === 'theme'
+                        ? '<div class="appearance-theme-presets">' + renderThemeQuickSelect() + '</div>'
+                        : '';
+                    if (sectionKey === 'display') {
+                        fieldHtmlParts.push(
+                            '<details class="field-subgroup appearance-setting-group"' + (searchTerm ? ' open' : '') + '>' +
+                                '<summary><span class="appearance-setting-group-copy"><span class="field-subgroup-title">' + currentGroupLabel + '</span>' +
+                                (currentGroupDescription ? '<p class="field-subgroup-description">' + currentGroupDescription + '</p>' : '') + '</span></summary>' +
+                                '<div class="field-subgroup-fields">' + appearancePresetHtml + groupedFields.join('') + '</div>' +
+                            '</details>'
+                        );
+                    } else {
+                        fieldHtmlParts.push(
+                            '<div class="field-subgroup">' +
+                                '<h3 class="field-subgroup-title">' + currentGroupLabel + '</h3>' +
+                                (currentGroupDescription ? '<p class="field-subgroup-description">' + currentGroupDescription + '</p>' : '') +
+                                '<div class="field-subgroup-fields">' + groupedFields.join('') + '</div>' +
+                            '</div>'
+                        );
+                    }
             } else {
                 fieldHtmlParts.push(...groupedFields);
             }
@@ -11068,9 +13242,6 @@
         if (sectionKey === 'streaming') {
             customHtml = renderProviderPriorityUI();
         }
-        if (sectionKey === 'display') {
-            customHtml = renderThemeQuickSelect();
-        }
 
         // Add test button for testable object sections
         let testHtml = '';
@@ -11080,7 +13251,7 @@
                 '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg> Test Connection</button>'+
                 '<span id="test-result-'+sectionKey+'" class="test-result"></span></div>';
         }
-        return (sectionKey === 'display' ? customHtml + fieldsHtml : fieldsHtml + customHtml) + testHtml;
+        return fieldsHtml + customHtml + testHtml;
     }
 
     function sectionShowWhenMatches(sectionDef) {
@@ -11209,8 +13380,8 @@
             resultSpan.className = 'test-result error';
         }
     }
-    function renderSection(sectionKey, sectionDef) {
-        const isOpen = window.location.hash === '#'+sectionKey;
+    function renderSection(sectionKey, sectionDef, forceOpen = false) {
+        const isOpen = forceOpen || window.location.hash === '#'+sectionKey;
         const errorCount = getSectionErrorCount(sectionKey);
         const customizationCount = settingsSectionCustomizationCount(sectionKey);
         const sectionMessages = validationErrors[sectionKey]?.messages || [];
@@ -11273,6 +13444,7 @@
         for (const [nestedKey, nestedDef] of Object.entries(schema)) {
             // Only render as nested if parent matches AND section doesn't have its own group
             if (nestedDef.parent === sectionKey && !nestedDef.group) {
+                if (settingsLevel === 'essentials' && !searchTerm && !watchEssentialSections.has(nestedKey)) continue;
                 if (selectedUserId && !perUserSections.includes(nestedKey)) continue;
                 if (!sectionShowWhenMatches(nestedDef)) continue;
                 nestedHtml += renderNestedSectionPanel(nestedKey, nestedDef);
@@ -11281,12 +13453,15 @@
         const advancedBadge = advancedSections.has(sectionKey) ? '<span class="advanced-setting-badge">Advanced</span>' : '';
         const rowDescription = settingsSectionRowDescription(sectionKey, sectionDef);
         const configuredBadge = renderSettingsSectionBadge(sectionKey, sectionDef);
+        const headerInteractionAttrs = forceOpen
+            ? 'role="heading" aria-level="3"'
+            : 'role="button" tabindex="0" aria-expanded="'+(isOpen ? 'true' : 'false')+'" aria-controls="section-content-'+sectionKey+'" onclick="toggleSettingsSection(this)" onkeydown="handleSettingsSectionKeydown(event, this)"';
         return '<div class="section '+(isOpen ? 'open' : '')+(hasChanges ? ' has-changes' : '')+disabledClass+'" id="section-'+sectionKey+'">' +
-            '<div class="section-header" onclick="toggleSettingsSection(this)" onkeydown="handleSettingsSectionKeydown(event, this)">' +
+            '<div class="section-header" '+headerInteractionAttrs+'>' +
                 '<div class="section-title">'+getIcon(sectionDef.icon)+'<span class="settings-section-copy"><span class="settings-section-label">'+sectionDef.label+advancedBadge+renderCustomizationCount(customizationCount, 'section-customization-count')+warningBadge+'</span><span class="settings-section-description">'+escapeHtml(rowDescription)+'</span></span></div>' +
                 '<div class="section-header-actions">'+configuredBadge+saveBtn+'<svg class="section-toggle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg></div>' +
             '</div>' +
-            '<div class="section-content">'+comingSoonHtml+messagesHtml+descriptionHtml+contentHtml+nestedHtml+'</div>' +
+            '<div class="section-content" id="section-content-'+sectionKey+'">'+comingSoonHtml+messagesHtml+descriptionHtml+contentHtml+nestedHtml+'</div>' +
         '</div>';
     }
 
@@ -12039,6 +14214,25 @@
         // Run validation before rendering
         validationErrors = validateSettings();
 
+        const settingsHome = document.getElementById('settingsHome');
+        const settingsWorkspace = document.getElementById('settingsCategoryWorkspace');
+        const sectionHash = window.location.hash.replace(/^#/, '');
+        const isEssentials = settingsLevel === 'essentials' && !searchTerm;
+        const showHome = !isEssentials && !activeSettingsGroup && !searchTerm && !schema[sectionHash];
+        if (settingsHome) settingsHome.hidden = !showHome;
+        if (settingsWorkspace) {
+            settingsWorkspace.hidden = showHome;
+            settingsWorkspace.classList.toggle('settings-essentials-workspace', isEssentials);
+        }
+        container.classList.toggle('settings-essentials-view', isEssentials);
+        if (showHome) {
+            container.innerHTML = '';
+            renderSettingsLanding();
+            updateSettingsSaveStatus();
+            return;
+        }
+        renderSettingsCategoryHeader();
+
         // Save currently open sections before re-rendering
         const openSection = container.querySelector('.section.open')?.id.replace('section-', '') || '';
 
@@ -12056,9 +14250,13 @@
         }
 
         // Add validation warning banner if there are issues
-        const totalErrors = Object.keys(validationErrors).length;
+        const visibleErrorKeys = Object.keys(validationErrors).filter(key => {
+            if (!activeSettingsGroup || searchTerm || !schema[key]) return true;
+            return settingsOverviewGroupForSection(key, schema[key]) === activeSettingsGroup;
+        });
+        const totalErrors = visibleErrorKeys.length;
         if (totalErrors > 0 && !selectedUserId) {
-            const errorSections = Object.keys(validationErrors).map(key => {
+            const errorSections = visibleErrorKeys.map(key => {
                 const sectionDef = schema[key];
                 return sectionDef?.label || key;
             }).join(', ');
@@ -12073,11 +14271,12 @@
         let totalMatchingSections = 0;
 
         for (const group of settingsOverviewGroups) {
+            if (activeSettingsGroup && !searchTerm && group.id !== activeSettingsGroup) continue;
             const groupSections = Object.entries(schema).filter(([key, def]) => {
                 if (!def.group || settingsOverviewGroupForSection(key, def) !== group.id) return false;
                 // Skip hidden sections
                 if (def.hidden) return false;
-                if (settingsLevel === 'basic' && !searchTerm && advancedSections.has(key)) return false;
+                if (!settingsSectionVisibleAtCurrentLevel(key)) return false;
                 // If search is active, only show matching sections
                 if (filteredSections !== null && !filteredSections.has(key)) return false;
                 // If a client is selected, only show client-configurable sections
@@ -12096,54 +14295,96 @@
             if (groupSections.length === 0) continue;
 
             totalMatchingSections += groupSections.length;
-            const relatedHtml = group.id === 'metadata' && isAdmin && !selectedUserId && !selectedClientId
-                ? '<div class="settings-related-card"><div><strong>Connected services</strong><p>Connect Trakt, Simkl, MDBList, Plex, or Jellyfin and assign them to profiles.</p></div><a class="btn btn-secondary btn-sm" href="'+basePath+'/integrations">Manage Services</a></div>'
-                : '';
-            html += '<div class="settings-group"><h2 class="group-title">'+group.label+'</h2><div class="group-sections">'+relatedHtml+groupSections.map(([key, def]) => renderSection(key, def)).join('')+'</div></div>';
+            html += '<div class="settings-group"><h2 class="group-title">'+group.label+'</h2><div class="group-sections">'+groupSections.map(([key, def]) => renderSection(key, def, isEssentials || (activeSettingsGroup === 'appearance' && key === 'display'))).join('')+'</div></div>';
         }
 
         // Show "no results" message if search found nothing
         if (searchTerm && totalMatchingSections === 0) {
-            html += '<div style="text-align: center; padding: 3rem; color: var(--text-muted);"><svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5" style="margin-bottom: 1rem; opacity: 0.5;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg><p style="margin: 0;">No settings found for "<strong>' + searchTerm + '</strong>"</p><p style="margin: 0.5rem 0 0; font-size: 0.875rem;">Try a different search term</p></div>';
+            html += '<div role="status" style="text-align: center; padding: 3rem; color: var(--text-muted);"><svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5" style="margin-bottom: 1rem; opacity: 0.5;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg><p style="margin: 0;">No settings found for "<strong>' + escapeHtml(searchTerm) + '</strong>"</p><p style="margin: 0.5rem 0 1rem; font-size: 0.875rem;">Search includes every settings level.</p><button class="btn btn-secondary btn-sm" type="button" onclick="clearSettingsSearch()">Clear search</button></div>';
         }
 
         container.innerHTML = html;
 
         // Restore previously open sections (or auto-expand if searching)
-        if (searchTerm && filteredSections && filteredSections.size > 0) {
+        if (isEssentials) {
+            container.querySelectorAll('.section').forEach(section => {
+                section.classList.add('open');
+                section.querySelector(':scope > .section-header')?.setAttribute('aria-expanded', 'true');
+            });
+        } else if (searchTerm && filteredSections && filteredSections.size > 0) {
             // Keep progressive disclosure intact while searching: open the first match only.
             const firstMatch = filteredSections.values().next().value;
             const section = document.getElementById('section-'+firstMatch);
-            if (section) section.classList.add('open');
+            if (section) {
+                section.classList.add('open');
+                section.querySelector(':scope > .section-header')?.setAttribute('aria-expanded', 'true');
+            }
         } else if (openSection) {
             const section = document.getElementById('section-'+openSection);
-            if (section) section.classList.add('open');
+            if (section) {
+                section.classList.add('open');
+                section.querySelector(':scope > .section-header')?.setAttribute('aria-expanded', 'true');
+            }
         }
 
-        if (window.location.hash) {
+        if (window.location.hash && !isEssentials) {
             const section = document.getElementById('section-'+window.location.hash.substring(1));
             if (section) {
-                container.querySelectorAll('.section.open').forEach(open => open.classList.remove('open'));
-                section.classList.add('open');
-                section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                requestAnimationFrame(() => openSettingsSection(section.id.replace('section-', ''), { focus: false, scroll: true, historyMode: 'none' }));
             }
         }
 
         // Initialize drag-drop for provider priority and shelves
         initDragDrop();
         initFileUploadStatuses();
+        updateSettingsSaveStatus();
+    }
+
+    function openSettingsSection(sectionKey, options = {}) {
+        const { focus = true, scroll = true, historyMode = 'push' } = options;
+        const container = document.getElementById('settingsContainer');
+        const section = document.getElementById('section-' + sectionKey);
+        if (!container || !section) return false;
+        if (settingsLevel !== 'essentials') {
+            container.querySelectorAll('.section.open').forEach(openSection => {
+                if (openSection === section) return;
+                openSection.classList.remove('open');
+                openSection.querySelector(':scope > .section-header')?.setAttribute('aria-expanded', 'false');
+            });
+        }
+        section.classList.add('open');
+        const header = section.querySelector(':scope > .section-header');
+        header?.setAttribute('aria-expanded', 'true');
+        if (historyMode !== 'none') {
+            const url = new URL(window.location.href);
+            url.hash = sectionKey;
+            history[historyMode === 'replace' ? 'replaceState' : 'pushState']({}, '', url);
+        }
+        if (scroll) section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (focus) requestAnimationFrame(() => header?.focus({ preventScroll: true }));
+        return true;
     }
 
     function toggleSettingsSection(header) {
         const section = header.closest('.section');
-        if (!section) return;
+        if (!section || settingsLevel === 'essentials') return;
+        const sectionKey = section.id.replace('section-', '');
         const shouldOpen = !section.classList.contains('open');
-        document.querySelectorAll('#settingsContainer .section.open').forEach(openSection => {
-            openSection.classList.remove('open');
-            openSection.querySelector(':scope > .section-header')?.setAttribute('aria-expanded', 'false');
-        });
-        section.classList.toggle('open', shouldOpen);
-        header.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+        if (shouldOpen) {
+            settingsLastSectionViewport = window.scrollY;
+            openSettingsSection(sectionKey, { focus: true, scroll: true, historyMode: 'push' });
+            return;
+        }
+        section.classList.remove('open');
+        header.setAttribute('aria-expanded', 'false');
+        const url = new URL(window.location.href);
+        url.hash = '';
+        history.pushState({}, '', url);
+        if (Number.isFinite(settingsLastSectionViewport)) {
+            const restoreTop = settingsLastSectionViewport;
+            settingsLastSectionViewport = null;
+            window.scrollTo({ top: restoreTop, behavior: 'smooth' });
+        }
     }
 
     function handleSettingsSectionKeydown(event, header) {
@@ -12192,6 +14433,8 @@
                     updateClientDropdownIndicators();
                     updateRevertButtonVisibility();
                     renderSettingsScopeTree();
+                    updateSettingsSaveStatus();
+                    announceSettingsSaved();
                 } else {
                     const result = await response.json().catch(() => ({}));
                     showToast(result.error || 'Failed to save client settings', 'error');
@@ -12217,6 +14460,7 @@
                     renderSettings(); // Re-render to update inherited field styling
                     await updateClientSaveImpact();
                     renderSettings();
+                    announceSettingsSaved();
                 } else {
                     const result = await response.text();
                     showToast(result || 'Failed to save user settings', 'error');
@@ -12238,6 +14482,7 @@
                     if (committedPendingTextArrays) renderSettings();
                     await updateProfileSaveImpact(changedGroups);
                     renderSettings();
+                    announceSettingsSaved();
                 } else {
                     const result = await response.json();
                     showToast(result.error || 'Failed to save settings', 'error');
@@ -12307,14 +14552,58 @@
             }
         }
         renderSettings();
+        syncSettingsSidebarDestination(activeSettingsGroup || 'home');
     });
     window.addEventListener('hashchange', () => {
         const hash = window.location.hash.substring(1);
-        if (hash) {
-            document.querySelectorAll('.section').forEach(s => s.classList.remove('open'));
-            const section = document.getElementById('section-'+hash);
-            if (section) { section.classList.add('open'); section.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+        if (hash && schema[hash]) {
+            if (settingsLevel === 'essentials' && !watchEssentialSections.has(hash)) {
+                settingsLevel = 'advanced';
+                localStorage.setItem('mediastorm-settings-level', settingsLevel);
+            }
+            activeSettingsGroup = settingsOverviewGroupForSection(hash, schema[hash]);
+            syncSettingsSidebarDestination(activeSettingsGroup);
+            renderSettings();
+            requestAnimationFrame(() => openSettingsSection(hash, { focus: true, scroll: true, historyMode: 'none' }));
         }
+    });
+    window.addEventListener('popstate', () => {
+        const params = new URLSearchParams(window.location.search);
+        const category = params.get('category') || '';
+        const storedLevel = settingsLevels.has(localStorage.getItem('mediastorm-settings-level')) ? localStorage.getItem('mediastorm-settings-level') : 'basic';
+        settingsLevel = storedLevel;
+        activeSettingsGroup = settingsLandingGroups.some(group => group.id === category) ? category : '';
+        syncSettingsSidebarDestination(activeSettingsGroup || 'home');
+        renderSettings();
+    });
+    document.addEventListener('keydown', event => {
+        const panel = document.getElementById('settingsScopePanel');
+        if (event.key === 'Escape') {
+            closeSettingsContextSheet();
+            return;
+        }
+        if (event.key !== 'Tab' || !panel?.classList.contains('open')) return;
+        const focusable = Array.from(panel.querySelectorAll('button:not([disabled]), select:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'))
+            .filter(element => element.getClientRects().length > 0);
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    });
+    window.addEventListener('resize', () => {
+        const panel = document.getElementById('settingsScopePanel');
+        if (panel?.classList.contains('open')) positionSettingsScopePanel(panel);
+    });
+    window.addEventListener('beforeunload', event => {
+        if (!settingsHasUnsavedChanges()) return;
+        event.preventDefault();
+        event.returnValue = '';
     });
 </script>
 {{end}}

--- a/backend/handlers/admin_templates/share_links.html
+++ b/backend/handlers/admin_templates/share_links.html
@@ -42,9 +42,12 @@
     .sl-sub { font-size: 0.78rem; color: var(--text-secondary); }
 </style>
 
-<div class="page-header">
-    <h1>Share Links</h1>
-    <p>One-time and multi-use playback links you've created. Deactivate to disable a link without deleting it, or delete it entirely.</p>
+<div class="page-header" data-page-group="Maintenance &amp; records">
+    <div class="page-header-copy">
+        <div class="page-kicker">Maintenance &amp; records</div>
+        <h1>Share links</h1>
+        <p>Review temporary playback links, deactivate access, or permanently delete a link.</p>
+    </div>
 </div>
 
 <div class="settings-group">

--- a/backend/handlers/admin_templates/status.html
+++ b/backend/handlers/admin_templates/status.html
@@ -252,8 +252,24 @@
     margin-bottom: 0 !important;
 }
 
+.dashboard-header-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1.5rem;
+    align-items: end;
+}
+
 .dashboard-page-header {
     margin: 0;
+}
+
+.dashboard-page-kicker {
+    margin: 0 0 0.35rem;
+    color: var(--accent-light);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 .dashboard-page-header h1 {
@@ -265,7 +281,7 @@
 
 .dashboard-toolbar {
     display: flex;
-    min-height: 36px;
+    min-height: 44px;
     align-items: center;
     justify-content: flex-end;
     gap: 0.5rem;
@@ -282,6 +298,7 @@
 }
 
 .dashboard-toolbar .settings-level-btn {
+    min-height: 44px;
     border: 1px solid transparent;
     border-radius: var(--radius);
     background: transparent;
@@ -304,7 +321,7 @@
 
 .dashboard-summary-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
     gap: 1rem;
 }
 
@@ -330,6 +347,26 @@
     font-size: 1.375rem;
     font-weight: 700;
     line-height: 1.25;
+}
+
+.dashboard-status-value {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+}
+
+.dashboard-status-dot {
+    width: 0.625rem;
+    height: 0.625rem;
+    flex: 0 0 auto;
+    border-radius: 999px;
+    background: #22c55e;
+    box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
+}
+
+.dashboard-status-dot.warning {
+    background: #f59e0b;
+    box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.12);
 }
 
 .dashboard-summary-meta {
@@ -789,9 +826,93 @@ body.numbers-station-open {
     border-radius: 8px;
 }
 
+.dashboard-primary-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+    gap: 1.25rem;
+    align-items: stretch;
+}
+
+.dashboard-primary-grid.dashboard-primary-grid-single {
+    grid-template-columns: 1fr;
+}
+
+.dashboard-primary-grid > .card {
+    display: flex;
+    min-width: 0;
+    min-height: 100%;
+    flex-direction: column;
+}
+
+.dashboard-primary-grid > .card > .card-body {
+    flex: 1;
+}
+
+.provider-health-list {
+    display: grid;
+}
+
+.provider-health-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: center;
+    min-height: 58px;
+    padding: 0.65rem 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.provider-health-row:last-child {
+    border-bottom: 0;
+}
+
+.provider-health-name {
+    color: var(--text-primary);
+    font-size: 0.8125rem;
+    font-weight: 600;
+}
+
+.provider-health-meta {
+    margin-top: 0.15rem;
+    color: var(--text-muted);
+    font-size: 0.6875rem;
+}
+
+.dashboard-advanced-disclosure {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+}
+
+.dashboard-advanced-disclosure[hidden] {
+    display: none;
+}
+
+.dashboard-advanced-disclosure strong {
+    display: block;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+}
+
+.dashboard-advanced-disclosure p {
+    margin: 0.2rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.dashboard-advanced-disclosure .btn {
+    flex: 0 0 auto;
+    min-height: 44px;
+}
+
 .dashboard-insights {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1.25rem;
 }
 
@@ -835,6 +956,12 @@ body.numbers-station-open {
         justify-content: flex-start;
     }
 
+    .dashboard-header-row {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+        align-items: stretch;
+    }
+
     .dashboard-toolbar {
         align-items: stretch;
         flex-direction: column;
@@ -851,13 +978,25 @@ body.numbers-station-open {
     .dashboard-summary-grid {
         grid-template-columns: 1fr;
     }
+
+    .dashboard-primary-grid,
+    .dashboard-insights {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .dashboard-advanced-disclosure {
+        align-items: stretch;
+        flex-direction: column;
+    }
 }
 </style>
 {{end}}
 
 {{define "content"}}
 <div class="dashboard-v4">
+<div class="dashboard-header-row">
 <div class="page-header dashboard-page-header">
+    <div class="dashboard-page-kicker">Overview</div>
     <h1>
         <span>Dashboard</span>
         <button id="numbersStationSignal" class="numbers-station-signal" type="button" aria-label="Unidentified carrier" title="77.77" onclick="openNumbersStation()">
@@ -866,10 +1005,6 @@ body.numbers-station-open {
         </button>
     </h1>
     <p>System overview and quick actions</p>
-</div>
-
-<div id="numbersStationAchievement" class="numbers-station-achievement" hidden>
-    <button class="numbers-station-achievement-badge" type="button" onclick="openNumbersStation()" aria-label="Storm-Marked — open Numbers Station">Storm-Marked</button>
 </div>
 
 <div class="dashboard-toolbar" aria-label="Dashboard controls">
@@ -885,38 +1020,11 @@ body.numbers-station-open {
         Refresh
     </button>
 </div>
+</div>
 
-<section id="donationBanner" class="donation-banner" aria-label="Support mediastorm">
-    <div class="donation-banner-copy">
-        <h2 class="donation-banner-title">
-            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-            </svg>
-            Support the project
-        </h2>
-        <p>mediastorm is free to use. Donations help keep development moving.</p>
-    </div>
-    <div class="donation-links" aria-label="Donation links">
-        <a class="donation-link github" href="https://github.com/sponsors/godver3" target="_blank" rel="noopener noreferrer">
-            <span class="donation-link-label">Sponsor</span>
-            <span class="donation-link-value">GitHub</span>
-        </a>
-        <a class="donation-link patreon" href="https://patreon.com/godver3" target="_blank" rel="noopener noreferrer">
-            <span class="donation-link-label">Support</span>
-            <span class="donation-link-value">Patreon</span>
-        </a>
-        <a class="donation-link kofi" href="https://ko-fi.com/godver3" target="_blank" rel="noopener noreferrer">
-            <span class="donation-link-label">Support</span>
-            <span class="donation-link-value">Ko-fi</span>
-        </a>
-    </div>
-    <button class="donation-banner-close" type="button" aria-label="Hide donation links permanently" title="Hide donation links" onclick="hideDonationBanner()">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <line x1="18" y1="6" x2="6" y2="18"/>
-            <line x1="6" y1="6" x2="18" y2="18"/>
-        </svg>
-    </button>
-</section>
+<div id="numbersStationAchievement" class="numbers-station-achievement" hidden>
+    <button class="numbers-station-achievement-badge" type="button" onclick="openNumbersStation()" aria-label="Storm-Marked — open Numbers Station">Storm-Marked</button>
+</div>
 
 <section id="dashboardUpdateBanner" class="dashboard-update-banner" aria-label="Backend update available" hidden>
     <div>
@@ -951,6 +1059,14 @@ body.numbers-station-open {
 
 <div class="dashboard-summary-grid" aria-label="Dashboard summary">
     <section class="dashboard-summary-card">
+        <div class="dashboard-summary-label">System Status</div>
+        <div class="dashboard-summary-value dashboard-status-value">
+            <span id="dashboardSystemStatusDot" class="dashboard-status-dot" aria-hidden="true"></span>
+            <span id="dashboardSystemStatus" aria-live="polite">Checking…</span>
+        </div>
+        <div class="dashboard-summary-meta" id="dashboardSystemStatusMeta">Contacting the backend</div>
+    </section>
+    <section class="dashboard-summary-card">
         <div class="dashboard-summary-label">Active Streams</div>
         <div class="dashboard-summary-value" id="activeStreamCount">0</div>
         <div class="dashboard-summary-meta" id="streamSubtext">Loading stream activity…</div>
@@ -960,8 +1076,23 @@ body.numbers-station-open {
         <div class="dashboard-uptime">
             <span id="backendUptime" aria-live="polite">Loading…</span>
         </div>
-        <div class="dashboard-summary-meta">Live server runtime</div>
+        <div class="dashboard-summary-meta" id="backendStartedAt">Live server runtime</div>
     </section>
+    {{if .IsAdmin}}
+    <section id="providerReadinessCard" class="dashboard-summary-card"
+        data-usenet-enabled="{{countEnabledProviders .Settings.Usenet}}"
+        data-usenet-total="{{len .Settings.Usenet}}"
+        data-debrid-enabled="{{countEnabledDebrid .Settings.Streaming.DebridProviders}}"
+        data-debrid-total="{{len .Settings.Streaming.DebridProviders}}"
+        data-indexer-enabled="{{countEnabledIndexers .Settings.Indexers}}"
+        data-indexer-total="{{len .Settings.Indexers}}"
+        data-scraper-enabled="{{countEnabledScrapers .Settings.TorrentScrapers}}"
+        data-scraper-total="{{len .Settings.TorrentScrapers}}">
+        <div class="dashboard-summary-label">Provider Readiness</div>
+        <div class="dashboard-summary-value" id="providerReadinessValue">—</div>
+        <div class="dashboard-summary-meta" id="providerReadinessMeta">Configured source groups</div>
+    </section>
+    {{end}}
 </div>
 
 <dialog id="numbersStationDialog" class="numbers-station-dialog" aria-label="Numbers Station receiver">
@@ -972,8 +1103,9 @@ body.numbers-station-open {
     </div>
 </dialog>
 
+<div class="dashboard-primary-grid {{if not .IsAdmin}}dashboard-primary-grid-single{{end}}">
 <!-- Active Streams -->
-<div class="card" style="margin-bottom: 1.5rem;">
+<div class="card">
     <div class="card-header">
         <h2>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1007,6 +1139,69 @@ body.numbers-station-open {
             </div>
         </div>
     </div>
+</div>
+
+{{if .IsAdmin}}
+<section class="card" aria-labelledby="providerHealthHeading">
+    <div class="card-header">
+        <h2 id="providerHealthHeading">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/>
+            </svg>
+            Provider Health
+        </h2>
+        <a href="{{.BasePath}}/settings" class="btn btn-sm btn-secondary">Manage</a>
+    </div>
+    <div class="card-body">
+        <div class="provider-health-list">
+            <div class="provider-health-row">
+                <div>
+                    <div class="provider-health-name">Usenet</div>
+                    <div class="provider-health-meta">{{countEnabledProviders .Settings.Usenet}} enabled of {{len .Settings.Usenet}}</div>
+                </div>
+                {{if gt (countEnabledProviders .Settings.Usenet) 0}}
+                <span class="status-badge online"><span class="status-dot"></span> Ready</span>
+                {{else}}
+                <span class="status-badge offline"><span class="status-dot"></span> Not set</span>
+                {{end}}
+            </div>
+            <div class="provider-health-row">
+                <div>
+                    <div class="provider-health-name">Debrid</div>
+                    <div class="provider-health-meta">{{countEnabledDebrid .Settings.Streaming.DebridProviders}} enabled of {{len .Settings.Streaming.DebridProviders}}</div>
+                </div>
+                {{if gt (countEnabledDebrid .Settings.Streaming.DebridProviders) 0}}
+                <span class="status-badge online"><span class="status-dot"></span> Ready</span>
+                {{else}}
+                <span class="status-badge offline"><span class="status-dot"></span> Not set</span>
+                {{end}}
+            </div>
+            <div class="provider-health-row">
+                <div>
+                    <div class="provider-health-name">Indexers</div>
+                    <div class="provider-health-meta">{{countEnabledIndexers .Settings.Indexers}} enabled of {{len .Settings.Indexers}}</div>
+                </div>
+                {{if gt (countEnabledIndexers .Settings.Indexers) 0}}
+                <span class="status-badge online"><span class="status-dot"></span> Ready</span>
+                {{else}}
+                <span class="status-badge offline"><span class="status-dot"></span> Not set</span>
+                {{end}}
+            </div>
+            <div class="provider-health-row">
+                <div>
+                    <div class="provider-health-name">Torrent Scrapers</div>
+                    <div class="provider-health-meta">{{countEnabledScrapers .Settings.TorrentScrapers}} enabled of {{len .Settings.TorrentScrapers}}</div>
+                </div>
+                {{if gt (countEnabledScrapers .Settings.TorrentScrapers) 0}}
+                <span class="status-badge online"><span class="status-dot"></span> Ready</span>
+                {{else}}
+                <span class="status-badge offline"><span class="status-dot"></span> Not set</span>
+                {{end}}
+            </div>
+        </div>
+    </div>
+</section>
+{{end}}
 </div>
 
 <!-- User Stats -->
@@ -1084,6 +1279,14 @@ body.numbers-station-open {
         </div>
     </div>
 </div>
+
+<section id="dashboardAdvancedDisclosure" class="dashboard-advanced-disclosure" aria-label="Advanced dashboard details">
+    <div>
+        <strong>Need deeper system detail?</strong>
+        <p>Show connection usage, provider diagnostics, endpoint checks, and configuration summaries.</p>
+    </div>
+    <button class="btn btn-secondary" type="button" onclick="setDashboardDetail('advanced')">Show advanced details</button>
+</section>
 
 <!-- Usenet Activity -->
 <div class="card dashboard-advanced-detail" style="margin-bottom: 1.5rem;">
@@ -1570,6 +1773,38 @@ body.numbers-station-open {
     </div>
 </div>
 {{end}}
+
+<section id="donationBanner" class="donation-banner" aria-label="Support mediastorm">
+    <div class="donation-banner-copy">
+        <h2 class="donation-banner-title">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+            </svg>
+            Support the project
+        </h2>
+        <p>mediastorm is free to use. Donations help keep development moving.</p>
+    </div>
+    <div class="donation-links" aria-label="Donation links">
+        <a class="donation-link github" href="https://github.com/sponsors/godver3" target="_blank" rel="noopener noreferrer">
+            <span class="donation-link-label">Sponsor</span>
+            <span class="donation-link-value">GitHub</span>
+        </a>
+        <a class="donation-link patreon" href="https://patreon.com/godver3" target="_blank" rel="noopener noreferrer">
+            <span class="donation-link-label">Support</span>
+            <span class="donation-link-value">Patreon</span>
+        </a>
+        <a class="donation-link kofi" href="https://ko-fi.com/godver3" target="_blank" rel="noopener noreferrer">
+            <span class="donation-link-label">Support</span>
+            <span class="donation-link-value">Ko-fi</span>
+        </a>
+    </div>
+    <button class="donation-banner-close" type="button" aria-label="Hide donation links permanently" title="Hide donation links" onclick="hideDonationBanner()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+    </button>
+</section>
 </div>
 {{end}}
 
@@ -2379,8 +2614,38 @@ body.numbers-station-open {
         document.querySelectorAll('.dashboard-advanced-detail').forEach(element => {
             element.style.display = dashboardDetail === 'advanced' ? '' : 'none';
         });
-        document.getElementById('dashboardBasicBtn')?.classList.toggle('active', dashboardDetail === 'basic');
-        document.getElementById('dashboardAdvancedBtn')?.classList.toggle('active', dashboardDetail === 'advanced');
+        const basicButton = document.getElementById('dashboardBasicBtn');
+        const advancedButton = document.getElementById('dashboardAdvancedBtn');
+        basicButton?.classList.toggle('active', dashboardDetail === 'basic');
+        advancedButton?.classList.toggle('active', dashboardDetail === 'advanced');
+        basicButton?.setAttribute('aria-pressed', String(dashboardDetail === 'basic'));
+        advancedButton?.setAttribute('aria-pressed', String(dashboardDetail === 'advanced'));
+        const disclosure = document.getElementById('dashboardAdvancedDisclosure');
+        if (disclosure) disclosure.hidden = dashboardDetail === 'advanced';
+    }
+
+    function initializeProviderReadiness() {
+        const card = document.getElementById('providerReadinessCard');
+        if (!card) return;
+        const groups = ['usenet', 'debrid', 'indexer', 'scraper'];
+        const totals = groups.reduce((result, group) => {
+            result.enabled += Number(card.dataset[`${group}Enabled`]) || 0;
+            result.total += Number(card.dataset[`${group}Total`]) || 0;
+            return result;
+        }, { enabled: 0, total: 0 });
+        const value = document.getElementById('providerReadinessValue');
+        const meta = document.getElementById('providerReadinessMeta');
+        if (value) value.textContent = totals.total > 0 ? `${totals.enabled} / ${totals.total}` : 'Not configured';
+        if (meta) meta.textContent = totals.total > 0 ? 'Enabled provider and source entries' : 'Add providers in Settings';
+    }
+
+    function setDashboardSystemStatus(healthy) {
+        const label = document.getElementById('dashboardSystemStatus');
+        const meta = document.getElementById('dashboardSystemStatusMeta');
+        const dot = document.getElementById('dashboardSystemStatusDot');
+        if (label) label.textContent = healthy ? 'Operational' : 'Needs attention';
+        if (meta) meta.textContent = healthy ? 'Backend is responding normally' : 'Backend status is unavailable';
+        dot?.classList.toggle('warning', !healthy);
     }
     const isAdmin = {{json .IsAdmin}};
     const donationBannerStorageKey = 'mediastormDonationBannerHidden';
@@ -2549,7 +2814,9 @@ body.numbers-station-open {
         const uptimeEl = document.getElementById('backendUptime');
         if (!uptimeEl || !backendStartedAtMs) return;
         const elapsedSeconds = Math.max(0, (Date.now() - backendStartedAtMs) / 1000);
-        uptimeEl.innerHTML = `Backend up for <span class="dashboard-uptime-count">${formatBackendUptime(elapsedSeconds)}</span> (since ${formatBackendStartedAt(backendStartedAtMs)})`;
+        uptimeEl.innerHTML = `<span class="dashboard-uptime-count">${formatBackendUptime(elapsedSeconds)}</span>`;
+        const startedAtEl = document.getElementById('backendStartedAt');
+        if (startedAtEl) startedAtEl.textContent = `Since ${formatBackendStartedAt(backendStartedAtMs)}`;
     }
 
     function startBackendUptimeTimer() {
@@ -2564,17 +2831,23 @@ body.numbers-station-open {
             const response = await fetch(basePath + '/api/status', { credentials: 'same-origin' });
             if (!response.ok) throw new Error(`Status ${response.status}`);
             const status = await response.json();
+            setDashboardSystemStatus(true);
             const startedAt = new Date(status.started_at).getTime();
             if (!Number.isNaN(startedAt)) {
                 backendStartedAtMs = startedAt;
                 renderBackendUptime();
                 startBackendUptimeTimer();
             } else {
-                uptimeEl.innerHTML = `Backend up for <span class="dashboard-uptime-count">${formatBackendUptime(status.uptime_seconds)}</span> (since unknown)`;
+                uptimeEl.innerHTML = `<span class="dashboard-uptime-count">${formatBackendUptime(status.uptime_seconds)}</span>`;
+                const startedAtEl = document.getElementById('backendStartedAt');
+                if (startedAtEl) startedAtEl.textContent = 'Start time unavailable';
             }
         } catch (error) {
             console.warn('Failed to load backend uptime:', error);
             uptimeEl.textContent = 'Backend uptime unavailable';
+            const startedAtEl = document.getElementById('backendStartedAt');
+            if (startedAtEl) startedAtEl.textContent = 'Unable to read server runtime';
+            setDashboardSystemStatus(false);
         }
     }
 
@@ -3989,6 +4262,7 @@ body.numbers-station-open {
 
     document.addEventListener('DOMContentLoaded', () => {
         setDashboardDetail(dashboardDetail);
+        initializeProviderReadiness();
         setStreamView(currentStreamView);
         connectSSE();
         startInterpolation();

--- a/backend/handlers/admin_templates/tools.html
+++ b/backend/handlers/admin_templates/tools.html
@@ -3,23 +3,249 @@
 {{define "title"}}{{if hasSuffix .CurrentPath "/tasks"}}Automations{{else if hasSuffix .CurrentPath "/integrations"}}Connected Services{{else}}Maintenance{{end}} - {{if .IsAdmin}}mediastorm Admin{{else}}mediastorm account{{end}}{{end}}
 
 {{define "content"}}
-<div class="page-header">
-    {{if hasSuffix .CurrentPath "/tasks"}}
-    <h1>Automations</h1>
-    <p>Schedule recurring syncs{{if .IsAdmin}}, library scans, backups, and background preparation{{end}}.</p>
-    {{else if hasSuffix .CurrentPath "/integrations"}}
-    <h1>Connected Services</h1>
-    <p>Connect external media services and choose which profiles use them.</p>
-    {{else}}
-    <h1>Maintenance</h1>
-    <p>Manage integrations, internal data, diagnostics, and server maintenance.</p>
-    {{end}}
+<div class="page-header" data-page-group="{{if or (hasSuffix .CurrentPath "/tasks") (hasSuffix .CurrentPath "/integrations")}}Configuration &amp; operations{{else}}Maintenance &amp; records{{end}}">
+    <div class="page-header-copy">
+        <div class="page-kicker">{{if or (hasSuffix .CurrentPath "/tasks") (hasSuffix .CurrentPath "/integrations")}}Configuration &amp; operations{{else}}Maintenance &amp; records{{end}}</div>
+        {{if hasSuffix .CurrentPath "/tasks"}}
+        <h1>Automations</h1>
+        <p>Schedule recurring syncs{{if .IsAdmin}}, library scans, backups, and background preparation{{end}}.</p>
+        {{else if hasSuffix .CurrentPath "/integrations"}}
+        <h1>Integrations</h1>
+        <p>Connect external media services and choose which profiles use them.</p>
+        {{else}}
+        <h1>Maintenance</h1>
+        <p>Review records, diagnose issues, and keep MediaStorm running cleanly.</p>
+        {{end}}
+    </div>
 </div>
 
 {{if hasSuffix .CurrentPath "/tasks"}}
 <div id="tasksPageHost"></div>
 {{else if hasSuffix .CurrentPath "/integrations"}}
 <div id="integrationsPageHost"></div>
+{{else}}
+<div class="maintenance-dashboard">
+    <div class="maintenance-status-strip" aria-label="Maintenance status">
+        <div class="maintenance-status-item maintenance-status-healthy">
+            <span class="maintenance-status-dot" aria-hidden="true"></span>
+            <span>Maintenance ready</span>
+        </div>
+        <div class="maintenance-status-item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M21 12a9 9 0 1 1-2.64-6.36"/>
+                <polyline points="21 3 21 9 15 9"/>
+            </svg>
+            <span id="maintenanceUpdateStatus">Checking releases...</span>
+        </div>
+        {{if .IsAdmin}}
+        <div class="maintenance-status-item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48 2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48 2.83-2.83"/>
+            </svg>
+            <span id="maintenanceWorkersStatus">Checking workers...</span>
+        </div>
+        {{end}}
+        {{if .IsAdmin}}
+        <a class="maintenance-status-action" href="{{.BasePath}}/backup">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M12 16V4M7 9l5-5 5 5"/>
+                <path d="M5 13v7h14v-7"/>
+            </svg>
+            Backup
+        </a>
+        {{end}}
+    </div>
+
+    <section class="maintenance-dashboard-section" aria-labelledby="maintenanceRecordsTitle">
+        <h2 id="maintenanceRecordsTitle">Review records</h2>
+        <div class="maintenance-link-grid">
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/tools/hidden-items">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M3 3l18 18M10.5 10.7a2 2 0 0 0 2.8 2.8M9.5 5.3A10.8 10.8 0 0 1 12 5c5 0 9 7 9 7a15 15 0 0 1-2.1 2.7M6.2 6.2C4.2 7.6 3 12 3 12s4 7 9 7c1.2 0 2.4-.4 3.4-1"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy">
+                    <strong>Hidden Items</strong>
+                    <span>Review titles hidden from profiles and shelves.</span>
+                </span>
+                <span class="maintenance-row-meta">Manage</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            {{if .IsAdmin}}
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/tools/resolved-nzbs">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M6 3h9l4 4v14H6Z"/><path d="M15 3v5h5M9 13h6M9 17h6"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy">
+                    <strong>Resolved NZBs</strong>
+                    <span>Inspect reusable Usenet resolution records.</span>
+                </span>
+                <span class="maintenance-row-meta">Review</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/tools/bad-streams">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <circle cx="12" cy="12" r="9"/><path d="m6 6 12 12"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy">
+                    <strong>Bad Streams</strong>
+                    <span>Review streams skipped during future playback.</span>
+                </span>
+                <span class="maintenance-row-meta">Inspect</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            {{end}}
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/tools/share-links">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M14 4h6v6M20 4l-9 9"/><path d="M18 13v7H4V6h7"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy">
+                    <strong>Share Links</strong>
+                    <span>Manage active playback links and expirations.</span>
+                </span>
+                <span class="maintenance-row-meta">Manage</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+        </div>
+    </section>
+
+    {{if .IsAdmin}}
+    <section class="maintenance-dashboard-section" aria-labelledby="maintenanceDiagnoseTitle">
+        <h2 id="maintenanceDiagnoseTitle">Diagnose &amp; inspect</h2>
+        <div class="maintenance-link-grid">
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/logs">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M6 3h9l4 4v14H6Z"/><path d="M15 3v5h5M9 13h6M9 17h6"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy"><strong>Logs</strong><span>Browse backend events and application output.</span></span>
+                <span class="maintenance-row-meta">Open</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/performance">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M3 12h4l2-6 4 12 2-6h6"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy"><strong>Performance</strong><span>Monitor resource use and service health.</span></span>
+                <span class="maintenance-row-meta">Open</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/connections">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <circle cx="6" cy="12" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="18" cy="18" r="2"/><path d="m8 11 8-4M8 13l8 4"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy"><strong>Connections</strong><span>Inspect active services and client connections.</span></span>
+                <span class="maintenance-row-meta">Open</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+            <a class="maintenance-dashboard-row" href="{{.BasePath}}/prequeue">
+                <span class="maintenance-row-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>
+                    </svg>
+                </span>
+                <span class="maintenance-row-copy"><strong>Prequeue</strong><span>View active prewarmed streams and resolution state.</span></span>
+                <span class="maintenance-row-meta">Open</span>
+                <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+            </a>
+        </div>
+    </section>
+    {{end}}
+
+    <section class="maintenance-dashboard-section" aria-labelledby="maintenanceSystemTitle">
+        <h2 id="maintenanceSystemTitle">Maintain system</h2>
+        <div class="maintenance-system-layout">
+            <div class="maintenance-system-list">
+                {{if .IsAdmin}}
+                <a class="maintenance-dashboard-row" href="{{.BasePath}}/backup">
+                    <span class="maintenance-row-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path d="M12 16V4M7 9l5-5 5 5"/><path d="M5 13v7h14v-7"/>
+                        </svg>
+                    </span>
+                    <span class="maintenance-row-copy"><strong>Backup</strong><span>Create, restore, and manage server backups.</span></span>
+                    <span class="maintenance-row-meta">Open</span>
+                    <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+                </a>
+                {{end}}
+                <div class="maintenance-dashboard-row maintenance-dashboard-row-static">
+                    <span class="maintenance-row-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5M3 12c0 1.7 4 3 9 3s9-1.3 9-3"/>
+                        </svg>
+                    </span>
+                    <span class="maintenance-row-copy"><strong>Metadata Cache</strong><span>Clear cached metadata and poster artwork.</span></span>
+                    <button class="btn btn-secondary maintenance-row-action" type="button" id="clear-cache-dashboard-btn" onclick="clearMetadataCache()">Clear cache</button>
+                </div>
+                <div class="maintenance-dashboard-row maintenance-dashboard-row-static">
+                    <span class="maintenance-row-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <path d="M21 12a9 9 0 1 1-2.64-6.36"/><polyline points="21 3 21 9 15 9"/>
+                        </svg>
+                    </span>
+                    <span class="maintenance-row-copy"><strong>System Updates</strong><span>Check the running backend against the latest release.</span></span>
+                    <button class="btn btn-secondary maintenance-row-action" type="button" id="maintenanceCheckSystemUpdatesBtn" onclick="loadUpdateStatus(true)">Check now</button>
+                </div>
+                {{if .IsAdmin}}
+                <button class="maintenance-dashboard-row maintenance-dashboard-row-danger" type="button" onclick="openMaintenanceTool('databaseDataSection')">
+                    <span class="maintenance-row-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5M3 12c0 1.7 4 3 9 3s9-1.3 9-3"/>
+                        </svg>
+                    </span>
+                    <span class="maintenance-row-copy"><strong>Database Data</strong><span>Permanently remove profile records by category.</span></span>
+                    <span class="maintenance-row-meta">Review</span>
+                    <span class="maintenance-row-chevron" aria-hidden="true">›</span>
+                </button>
+                <div class="maintenance-dashboard-row maintenance-dashboard-row-static maintenance-dashboard-row-danger">
+                    <span class="maintenance-row-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+                        </svg>
+                    </span>
+                    <span class="maintenance-row-copy"><strong>Restart Backend</strong><span>Gracefully restart the backend process.</span></span>
+                    <button class="btn btn-secondary maintenance-row-action maintenance-row-action-danger" type="button" id="restart-backend-dashboard-btn" onclick="restartBackend()">Restart</button>
+                </div>
+                {{end}}
+            </div>
+
+            <aside class="maintenance-quick-tools" aria-labelledby="maintenanceQuickToolsTitle">
+                <h3 id="maintenanceQuickToolsTitle">On-page tools</h3>
+                <p>Select a tool to open its existing controls below.</p>
+                {{if .IsAdmin}}
+                <button type="button" onclick="openMaintenanceTool('profileMessageSection')">Profile messages <span aria-hidden="true">›</span></button>
+                <button type="button" onclick="openMaintenanceTool('prequeueManagementSection')">Prequeue cache <span aria-hidden="true">›</span></button>
+                <button type="button" onclick="openMaintenanceTool('backgroundWorkersSection')">Background workers <span aria-hidden="true">›</span></button>
+                {{end}}
+                <button type="button" onclick="openMaintenanceTool('troubleshootingSection')">Troubleshooting uploads <span aria-hidden="true">›</span></button>
+            </aside>
+        </div>
+    </section>
+</div>
+
+<details class="maintenance-tool-details" id="maintenanceToolDetails">
+    <summary>
+        <span>
+            <strong>Advanced controls</strong>
+            <small>Open actions and live tools that need additional input.</small>
+        </span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <polyline points="6 9 12 15 18 9"/>
+        </svg>
+    </summary>
+    <div class="maintenance-tool-details-body">
 {{end}}
 
 <!-- SYSTEM CATEGORY -->
@@ -73,39 +299,6 @@
     </div>
     {{end}}
 
-    <div class="section" id="systemUpdatesSection">
-        <div class="section-header" onclick="toggleSection(this)">
-            <div class="section-title">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M21 12a9 9 0 1 1-2.64-6.36"/>
-                    <polyline points="21 3 21 9 15 9"/>
-                </svg>
-                System Updates
-            </div>
-            <span id="systemUpdatesBadge" class="status-badge"></span>
-            <svg class="section-toggle" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="6 9 12 15 18 9"/>
-            </svg>
-        </div>
-        <div class="section-content">
-            <p class="text-muted" style="margin-bottom: 1rem;">
-                Check whether the running backend is behind the latest published release. Updates are applied outside the app through Docker or your deployment tooling.
-            </p>
-            <div id="systemUpdatesStatus" style="display:grid;gap:0.75rem;margin-bottom:1rem;">
-                <div class="text-muted">Checking for updates...</div>
-            </div>
-            <div class="btn-group">
-                <button class="btn btn-primary" onclick="loadUpdateStatus(true)" id="checkSystemUpdatesBtn">
-                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 0.5rem;">
-                        <path d="M21 12a9 9 0 1 1-2.64-6.36"/>
-                        <polyline points="21 3 21 9 15 9"/>
-                    </svg>
-                    Check for Updates
-                </button>
-            </div>
-        </div>
-    </div>
-
     {{if .IsAdmin}}
     <div class="section" id="profileMessageSection">
         <div class="section-header" onclick="toggleSection(this)">
@@ -157,7 +350,7 @@
 <div class="settings-group" id="integrationsGroup">
     <div class="group-title">Integrations</div>
 
-    <!-- Scrobbling Accounts Section -->
+    <!-- Watch Activity & Sync Section -->
     <div class="section" id="traktAccountSection">
         <div class="section-header" onclick="toggleSection(this)">
             <div class="section-title">
@@ -165,7 +358,7 @@
                     <circle cx="12" cy="12" r="10"/>
                     <path d="M8 12l2 2 4-4"/>
                 </svg>
-                Scrobbling Accounts
+                Watch Activity &amp; Sync
             </div>
             <span id="traktStatusBadge" class="status-badge"></span>
             <svg class="section-toggle" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
@@ -174,8 +367,8 @@
         </div>
         <div class="section-content">
             <p class="text-muted" style="margin-bottom: 1rem;">
-                Register Trakt, Simkl, MDBList, and self-hosted Scrob accounts here. Scrob accounts are selected directly by history sync automations.
-                Scrobbling pushes watched items to the linked service. To pull watch history, create a sync automation.
+                Connect Trakt, Simkl, MDBList, and self-hosted Scrob accounts for watch activity and history sync.
+                Watched items can be sent to a linked service; use a sync automation when you want to pull history into MediaStorm.
             </p>
 
             <!-- Trakt Accounts -->
@@ -339,7 +532,7 @@
         </div>
     </div>
 
-    <!-- Profile Scrobbling Section -->
+    <!-- Profile service linking section -->
     <div class="section" id="profileTraktLinkingSection">
         <div class="section-header" onclick="toggleSection(this)">
             <div class="section-title">
@@ -348,7 +541,7 @@
                     <circle cx="8.5" cy="7" r="4"/>
                     <line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/>
                 </svg>
-                Profile Scrobbling
+                Profile Service Links
             </div>
             <svg class="section-toggle" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="6 9 12 15 18 9"/>
@@ -1534,37 +1727,9 @@
 <div class="settings-group">
     <div class="group-title">Maintenance</div>
 
-    <!-- Clear Cache Section -->
-    <div class="section" id="clearCacheSection">
-        <div class="section-header" onclick="toggleSection(this)">
-            <div class="section-title">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="3 6 5 6 21 6"/>
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                </svg>
-                Clear Metadata Cache
-            </div>
-            <svg class="section-toggle" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="6 9 12 15 18 9"/>
-            </svg>
-        </div>
-        <div class="section-content">
-            <p class="text-muted" style="margin-bottom: 1rem;">
-                Remove all cached metadata and posters. Fresh data will be fetched from TVDB/TMDB on next request.
-            </p>
-            <button class="btn btn-secondary" id="clear-cache-btn" onclick="clearMetadataCache()">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="3 6 5 6 21 6"/>
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                </svg>
-                Clear Cache
-            </button>
-        </div>
-    </div>
-
     {{if .IsAdmin}}
     <!-- Database Data Section (master admin only) -->
-    <div class="section" id="databaseDataSection">
+    <div class="section is-destructive" id="databaseDataSection">
         <div class="section-header" onclick="toggleSection(this)">
             <div class="section-title">
                 <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
@@ -1649,37 +1814,14 @@
         </div>
     </div>
 
-    <div class="section" id="restartBackendSection">
-        <div class="section-header" onclick="toggleSection(this)">
-            <div class="section-title">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="23 4 23 10 17 10"/>
-                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-                </svg>
-                Restart Backend
-            </div>
-            <svg class="section-toggle" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="6 9 12 15 18 9"/>
-            </svg>
-        </div>
-        <div class="section-content">
-            <p class="text-muted" style="margin-bottom: 1rem;">
-                Gracefully restart the backend process. Active streams and background tasks
-                are drained first. This only restarts automatically when the server is run
-                with a restart policy (the bundled Docker setup uses
-                <code>restart: unless-stopped</code>) — otherwise the backend will stop and
-                must be started manually.
-            </p>
-            <button class="btn btn-secondary" id="restart-backend-btn" onclick="restartBackend()" style="color: var(--danger);">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="23 4 23 10 17 10"/>
-                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
-                </svg>
-                Restart Backend
-            </button>
-        </div>
-    </div>
 </div>
+
+{{if hasSuffix .CurrentPath "/tasks"}}
+{{else if hasSuffix .CurrentPath "/integrations"}}
+{{else}}
+    </div>
+</details>
+{{end}}
 
 <style>
     {{if hasSuffix .CurrentPath "/tasks"}}
@@ -1696,6 +1838,10 @@
     {{else}}
     #scheduledTasksSection { display: none; }
     #integrationsGroup { display: none; }
+    #hiddenItemsSection,
+    #badStreamsSection,
+    #resolvedNZBsSection,
+    #shareLinksSection { display: none; }
     {{end}}
     .task-toolbar {
         display: grid;
@@ -1798,6 +1944,348 @@
     }
     a:hover {
         color: #d1d5db;
+    }
+    .maintenance-dashboard {
+        margin-bottom: 1.5rem;
+    }
+    .maintenance-status-strip {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+        margin-bottom: 1.5rem;
+        border-block: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+    }
+    .maintenance-status-item,
+    .maintenance-status-action {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        min-height: 50px;
+        gap: 0.55rem;
+        padding: 0.7rem 1rem;
+        color: var(--text-secondary);
+        font-size: 0.8125rem;
+        text-decoration: none;
+    }
+    .maintenance-status-item + .maintenance-status-item,
+    .maintenance-status-action {
+        border-left: 1px solid var(--border);
+    }
+    .maintenance-status-item svg,
+    .maintenance-status-action svg {
+        width: 17px;
+        height: 17px;
+        flex: 0 0 auto;
+        color: var(--text-muted);
+    }
+    .maintenance-status-item span:last-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .maintenance-status-healthy {
+        color: var(--text-primary);
+    }
+    .maintenance-status-dot {
+        width: 8px;
+        height: 8px;
+        flex: 0 0 auto;
+        border-radius: 50%;
+        background: var(--success);
+    }
+    .maintenance-status-action,
+    .maintenance-status-action:visited {
+        justify-content: center;
+        color: var(--accent);
+        font-weight: 500;
+        white-space: nowrap;
+    }
+    .maintenance-status-action:hover {
+        color: var(--text-primary);
+        background: var(--bg-hover);
+    }
+    .maintenance-dashboard-section {
+        margin-bottom: 1.65rem;
+    }
+    .maintenance-dashboard-section h2 {
+        margin: 0 0 0.55rem;
+        padding: 0 0.25rem 0.55rem;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-primary);
+        font-size: 1rem;
+        font-weight: 600;
+    }
+    .maintenance-link-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.35rem 0.75rem;
+    }
+    .maintenance-dashboard-row {
+        display: grid;
+        grid-template-columns: 22px minmax(0, 1fr) auto 14px;
+        align-items: center;
+        min-width: 0;
+        min-height: 64px;
+        gap: 0.75rem;
+        width: 100%;
+        padding: 0.7rem 0.9rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+        color: var(--text-primary);
+        font: inherit;
+        text-align: left;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s;
+    }
+    .maintenance-dashboard-row:visited {
+        color: var(--text-primary);
+    }
+    .maintenance-dashboard-row:hover {
+        border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
+        background: var(--bg-hover);
+        color: var(--text-primary);
+    }
+    .maintenance-dashboard-row:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+    }
+    .maintenance-row-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--text-secondary);
+    }
+    .maintenance-row-icon svg {
+        width: 20px;
+        height: 20px;
+    }
+    .maintenance-row-copy {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        gap: 0.18rem;
+    }
+    .maintenance-row-copy strong {
+        overflow: hidden;
+        color: var(--text-primary);
+        font-size: 0.9rem;
+        font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .maintenance-row-copy span {
+        overflow: hidden;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .maintenance-row-meta {
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+        white-space: nowrap;
+    }
+    .maintenance-row-chevron {
+        color: var(--text-muted);
+        font-size: 1.25rem;
+        line-height: 1;
+        transition: transform 0.15s, color 0.15s;
+    }
+    .maintenance-dashboard-row:hover .maintenance-row-chevron {
+        color: var(--accent);
+        transform: translateX(2px);
+    }
+    .maintenance-dashboard-row-static {
+        grid-template-columns: 22px minmax(0, 1fr) auto;
+        cursor: default;
+    }
+    .maintenance-dashboard-row-static:hover {
+        border-color: var(--border);
+        background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+    }
+    .maintenance-row-action {
+        min-width: 88px;
+        justify-content: center;
+        margin: 0;
+        white-space: nowrap;
+    }
+    .maintenance-row-action-danger {
+        border-color: var(--danger);
+        color: var(--danger);
+    }
+    .maintenance-system-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1.5fr) minmax(235px, 0.65fr);
+        gap: 1rem;
+    }
+    .maintenance-system-list {
+        display: grid;
+        gap: 0.35rem;
+    }
+    .maintenance-system-list .maintenance-dashboard-row {
+        min-height: 56px;
+        padding-block: 0.5rem;
+    }
+    .maintenance-dashboard-row-danger .maintenance-row-icon,
+    .maintenance-dashboard-row-danger .maintenance-row-meta {
+        color: var(--danger);
+    }
+    .maintenance-quick-tools {
+        min-width: 0;
+        padding: 0.85rem 0 0.85rem 1rem;
+        border-left: 1px solid var(--border);
+    }
+    .maintenance-quick-tools h3 {
+        margin: 0 0 0.25rem;
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        font-weight: 600;
+    }
+    .maintenance-quick-tools p {
+        margin: 0 0 0.75rem;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+    }
+    .maintenance-quick-tools button {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        min-height: 42px;
+        padding: 0.55rem 0.25rem;
+        border: 0;
+        border-bottom: 1px solid var(--border);
+        background: transparent;
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.8125rem;
+        text-align: left;
+        cursor: pointer;
+    }
+    .maintenance-quick-tools button:hover {
+        color: var(--text-primary);
+    }
+    .maintenance-quick-tools button span {
+        color: var(--text-muted);
+        font-size: 1.1rem;
+    }
+    .maintenance-tool-details {
+        margin-bottom: 2rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--bg-secondary);
+        overflow: hidden;
+    }
+    .maintenance-tool-details > summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-height: 58px;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        color: var(--text-primary);
+        cursor: pointer;
+        list-style: none;
+    }
+    .maintenance-tool-details > summary::-webkit-details-marker {
+        display: none;
+    }
+    .maintenance-tool-details > summary:hover {
+        background: var(--bg-hover);
+    }
+    .maintenance-tool-details > summary span {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        gap: 0.15rem;
+    }
+    .maintenance-tool-details > summary strong {
+        font-size: 0.875rem;
+        font-weight: 600;
+    }
+    .maintenance-tool-details > summary small {
+        overflow: hidden;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .maintenance-tool-details > summary svg {
+        width: 18px;
+        height: 18px;
+        flex: 0 0 auto;
+        color: var(--text-muted);
+        transition: transform 0.2s;
+    }
+    .maintenance-tool-details[open] > summary {
+        border-bottom: 1px solid var(--border);
+    }
+    .maintenance-tool-details[open] > summary svg {
+        transform: rotate(180deg);
+    }
+    .maintenance-tool-details-body {
+        padding: 1rem;
+    }
+    .maintenance-tool-details-body > .settings-group:last-child {
+        margin-bottom: 0;
+    }
+    @media (max-width: 980px) {
+        .maintenance-status-strip {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .maintenance-status-item:nth-child(3),
+        .maintenance-status-action {
+            border-top: 1px solid var(--border);
+        }
+        .maintenance-status-item:nth-child(3) {
+            border-left: 0;
+        }
+        .maintenance-system-layout {
+            grid-template-columns: 1fr;
+        }
+        .maintenance-quick-tools {
+            padding: 0.85rem 0 0;
+            border-top: 1px solid var(--border);
+            border-left: 0;
+        }
+    }
+    @media (max-width: 700px) {
+        .maintenance-link-grid {
+            grid-template-columns: 1fr;
+        }
+        .maintenance-status-strip {
+            grid-template-columns: 1fr;
+        }
+        .maintenance-status-item + .maintenance-status-item,
+        .maintenance-status-item:nth-child(3),
+        .maintenance-status-action {
+            border-top: 1px solid var(--border);
+            border-left: 0;
+        }
+        .maintenance-status-action {
+            justify-content: flex-start;
+        }
+    }
+    @media (max-width: 480px) {
+        .maintenance-dashboard-row {
+            grid-template-columns: 22px minmax(0, 1fr) 14px;
+            min-height: 62px;
+        }
+        .maintenance-dashboard-row-static {
+            grid-template-columns: 22px minmax(0, 1fr);
+        }
+        .maintenance-dashboard-row-static .maintenance-row-action {
+            grid-column: 2;
+            width: 100%;
+        }
+        .maintenance-row-meta {
+            display: none;
+        }
+        .maintenance-tool-details > summary small {
+            white-space: normal;
+        }
     }
     .settings-group {
         margin-bottom: 2rem;
@@ -2299,12 +2787,20 @@
     // ========== Section Toggle ==========
     function toggleSection(header) {
         const section = header.parentElement;
-        section.classList.toggle('open');
+        const shouldOpen = !section.classList.contains('open');
+
+        if (shouldOpen) {
+            document.querySelectorAll('.settings-group .section.open').forEach(openSection => {
+                if (openSection !== section) openSection.classList.remove('open');
+            });
+        }
+
+        section.classList.toggle('open', shouldOpen);
     }
 
     // ========== Clear Cache ==========
     async function clearMetadataCache() {
-        const btn = document.getElementById('clear-cache-btn');
+        const btn = document.getElementById('clear-cache-dashboard-btn');
         if (!btn) return;
 
         if (!confirm('Clear all cached metadata and posters? This will force fresh data to be fetched from TVDB/TMDB.')) {
@@ -2446,7 +2942,7 @@
     }
 
     async function restartBackend() {
-        const btn = document.getElementById('restart-backend-btn');
+        const btn = document.getElementById('restart-backend-dashboard-btn');
         if (!btn) return;
 
         if (!confirm('Restart the backend now? Active streams will be interrupted. The backend will be unavailable for a few seconds while it restarts.')) {
@@ -2588,6 +3084,22 @@
     const isIntegrationsPage = {{if hasSuffix .CurrentPath "/integrations"}}true{{else}}false{{end}};
     const isAdmin = {{json .IsAdmin}};
     const requestedTaskProfileId = new URLSearchParams(window.location.search).get('profileId') || '';
+
+    function openMaintenanceTool(sectionId) {
+        const details = document.getElementById('maintenanceToolDetails');
+        const section = document.getElementById(sectionId);
+        if (!details || !section) return;
+
+        details.open = true;
+        if (!section.classList.contains('open')) {
+            const header = section.querySelector('.section-header');
+            if (header) toggleSection(header);
+        }
+
+        requestAnimationFrame(() => {
+            section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+    }
 
     // ========== Initialize ==========
     document.addEventListener('DOMContentLoaded', async function() {
@@ -4733,13 +5245,8 @@
     }
 
     async function loadUpdateStatus(force) {
-        const statusEl = document.getElementById('systemUpdatesStatus');
-        const badge = document.getElementById('systemUpdatesBadge');
-        const btn = document.getElementById('checkSystemUpdatesBtn');
+        const btn = document.getElementById('maintenanceCheckSystemUpdatesBtn');
         if (btn) btn.disabled = true;
-        if (force && statusEl) {
-            statusEl.innerHTML = '<div class="text-muted">Checking for updates...</div>';
-        }
         try {
             const url = basePath + '/api/updates/status' + (force ? '?force=true' : '');
             const response = await fetch(url, { credentials: 'same-origin' });
@@ -4751,13 +5258,8 @@
             }
         } catch (err) {
             console.error('Failed to load update status:', err);
-            if (badge) {
-                badge.textContent = 'Unavailable';
-                badge.className = 'status-badge warning';
-            }
-            if (statusEl) {
-                statusEl.innerHTML = `<div style="color: var(--error);">Failed to check for updates: ${escapeHtml(err.message)}</div>`;
-            }
+            const dashboardStatus = document.getElementById('maintenanceUpdateStatus');
+            if (dashboardStatus) dashboardStatus.textContent = 'Release status unavailable';
             if (force) showToast('Failed to check for updates: ' + err.message, 'error');
         } finally {
             if (btn) btn.disabled = false;
@@ -4766,47 +5268,19 @@
 
     function renderUpdateStatus(status) {
         const backend = status?.backend || {};
-        const statusEl = document.getElementById('systemUpdatesStatus');
-        const badge = document.getElementById('systemUpdatesBadge');
-        if (!statusEl || !badge) return;
+        const dashboardStatus = document.getElementById('maintenanceUpdateStatus');
 
-        const current = backend.currentVersion
-            ? `${backend.currentVersion}${backend.currentBuildId ? ` (${backend.currentBuildId})` : ''}`
-            : 'Unknown';
         const latest = backend.latestVersion
             ? `${backend.latestVersion}${backend.latestBuildId ? ` (${backend.latestBuildId})` : ''}`
             : 'Unknown';
-        const checkedAt = status?.checkedAt ? new Date(status.checkedAt).toLocaleString() : 'Unknown';
 
         if (backend.error) {
-            badge.textContent = 'Unavailable';
-            badge.className = 'status-badge warning';
+            if (dashboardStatus) dashboardStatus.textContent = 'Release status unavailable';
         } else if (backend.updateAvailable) {
-            badge.textContent = 'Update Available';
-            badge.className = 'status-badge warning';
+            if (dashboardStatus) dashboardStatus.textContent = `${latest} available`;
         } else {
-            badge.textContent = 'Up to Date';
-            badge.className = 'status-badge connected';
+            if (dashboardStatus) dashboardStatus.textContent = 'Backend up to date';
         }
-
-        statusEl.innerHTML = `
-            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:0.75rem;">
-                <div style="padding:0.75rem;background:var(--bg-surface);border:1px solid var(--border);border-radius:8px;">
-                    <div class="text-muted" style="font-size:0.8rem;margin-bottom:0.25rem;">Current Backend</div>
-                    <div style="font-weight:600;">${escapeHtml(current)}</div>
-                </div>
-                <div style="padding:0.75rem;background:var(--bg-surface);border:1px solid var(--border);border-radius:8px;">
-                    <div class="text-muted" style="font-size:0.8rem;margin-bottom:0.25rem;">Latest Release</div>
-                    <div style="font-weight:600;">${escapeHtml(latest)}</div>
-                </div>
-                <div style="padding:0.75rem;background:var(--bg-surface);border:1px solid var(--border);border-radius:8px;">
-                    <div class="text-muted" style="font-size:0.8rem;margin-bottom:0.25rem;">Last Checked</div>
-                    <div style="font-weight:600;">${escapeHtml(checkedAt)}</div>
-                </div>
-            </div>
-            ${backend.updateAvailable ? `<p class="text-muted" style="margin-top:0.75rem;">A newer backend release is available. Update through Docker or your deployment tooling.</p>` : ''}
-            ${backend.error ? `<p style="color:var(--error);margin-top:0.75rem;">${escapeHtml(backend.error)}</p>` : ''}
-        `;
     }
 
     function updateClientCountBadge() {
@@ -6780,6 +7254,8 @@
         } catch (err) {
             const el = document.getElementById('workersList');
             if (el) el.innerHTML = '<p class="text-muted">Could not load worker status.</p>';
+            const dashboardStatus = document.getElementById('maintenanceWorkersStatus');
+            if (dashboardStatus) dashboardStatus.textContent = 'Worker status unavailable';
         }
         clearTimeout(workersPollTimer);
         workersPollTimer = setTimeout(loadWorkers, 15000);
@@ -6799,11 +7275,13 @@
         if (!el) return;
 
         let workerCount = 0;
+        let activeWorkerCount = 0;
         let html = '';
 
         // Metadata Cache Manager
         if (cm) {
             workerCount++;
+            if (cm.running) activeWorkerCount++;
             const { statusClass, label: statusLabel } = workerStatusBadge(cm.status, cm.running);
             const lastRefresh = cm.lastRefreshAt && cm.lastRefreshAt !== '0001-01-01T00:00:00Z'
                 ? formatRelativeTime(cm.lastRefreshAt) : 'Never';
@@ -6861,6 +7339,7 @@
         // API Top Ten Worker
         if (tt) {
             workerCount++;
+            if (tt.running) activeWorkerCount++;
             const { statusClass, label: statusLabel } = workerStatusBadge(tt.status, tt.running);
             const lastRefresh = tt.lastRefreshAt && tt.lastRefreshAt !== '0001-01-01T00:00:00Z'
                 ? formatRelativeTime(tt.lastRefreshAt) : 'Never';
@@ -6919,6 +7398,7 @@
         // Calendar Worker
         if (cal) {
             workerCount++;
+            if (cal.running) activeWorkerCount++;
             const { statusClass, label: statusLabel } = workerStatusBadge(cal.state, cal.running);
             const lastRefresh = cal.lastRefreshAt && cal.lastRefreshAt !== '0001-01-01T00:00:00Z'
                 ? formatRelativeTime(cal.lastRefreshAt) : 'Never';
@@ -6974,6 +7454,13 @@
 
         const badge = document.getElementById('workersCountBadge');
         if (badge) badge.textContent = workerCount;
+
+        const dashboardStatus = document.getElementById('maintenanceWorkersStatus');
+        if (dashboardStatus) {
+            dashboardStatus.textContent = workerCount > 0
+                ? `${activeWorkerCount} of ${workerCount} workers active`
+                : 'No workers available';
+        }
 
         el.innerHTML = html || '<p class="text-muted">No workers available.</p>';
     }

--- a/backend/handlers/admin_ui.go
+++ b/backend/handlers/admin_ui.go
@@ -379,7 +379,7 @@ var SettingsSchema = map[string]interface{}{
 	},
 	"usenet": map[string]interface{}{
 		"label":    "Usenet Servers",
-		"icon":     "download",
+		"icon":     "database",
 		"group":    "providers",
 		"order":    2,
 		"is_array": true,


### PR DESCRIPTION
## Summary

- reorganize the shared admin navigation, dashboard, and settings workspace for faster scanning and clearer task grouping
- refine Usenet and Live TV status cards while preserving existing backend contracts and settings behavior
- turn Maintenance into a navigation dashboard with direct cache, update, and restart actions; keep advanced sections mutually exclusive and show Essentials as a disabled placeholder

## Scope

This is a cohesive admin workspace UI update covering the shared shell and the related admin pages. It intentionally leaves API contracts, configuration keys, persistence, authentication, permissions, playback behavior, Docker configuration, workflows, documentation, and test files unchanged.

## Verification

- `go build ./...` - passed
- `go vet ./...` - passed
- `go test ./handlers -run TestAdminMaintenanceLinksAllSubpages -count=1` - passed
- maintenance render check for non-admin Backup links - passed using an out-of-tree overlay
- browser checks - Maintenance actions render once, advanced sections remain mutually exclusive, and Essentials is visible but disabled
- `git diff --check upstream/master...HEAD` - passed
- staged-content privacy scan - no personal paths, email addresses, private-network hosts, private keys, or credential literals found
- `go test ./...` - completed with four handler assertion failures: three assert the previous admin layout (disabled Basic control, 22 navigation SVGs, and Search Diagnostics on Connections), while `TestWebPlaybackTemplateSynchronizesExternalWatchPartyGuests` also fails unchanged on upstream `master`; no test files are changed in this PR