### PR TITLE
fix(hls): stream-aware watchdog, 30s input timeout, and 3-segment startup pre-buffer

### DIFF
--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -467,10 +467,14 @@ type HLSSession struct {
 	BitstreamErrors           int // Count of bitstream filter errors (to detect persistent issues)
 
 	// Live TV session fields
-	IsLive       bool               // True for live TV streams (no duration, no seeking)
-	LiveProvider string             // Live TV provider identifier ("m3u" or "xtream")
-	LiveBucket   string             // Shared stream bucket identifier for limit accounting
-	LiveTuning   LiveTuningSettings // FFmpeg tuning settings for live sessions
+	IsLive                          bool               // True for live TV streams (no duration, no seeking)
+	LiveProvider                    string             // Live TV provider identifier ("m3u" or "xtream")
+	LiveBucket                      string             // Shared stream bucket identifier for limit accounting
+	LiveTuning                      LiveTuningSettings // FFmpeg tuning settings for live sessions
+	livePlaylistWindow              []livePlaylistEntry
+	livePlaylistTargetDuration      int
+	liveDiscontinuitySequence       int
+	livePlaylistIndependentSegments bool
 
 	// Closed caption support (live TV EIA-608)
 	LiveCCExtractionEnabled bool         // Resolved playback.liveClosedCaptionExtraction setting
@@ -2466,7 +2470,7 @@ func (m *HLSManager) CreateLiveSession(ctx context.Context, liveURL, provider, b
 
 	// Start live transcoding in background
 	go func() {
-		if err := m.startLiveTranscoding(bgCtx, session); err != nil {
+		if err := m.superviseLiveTranscoding(bgCtx, session); err != nil {
 			log.Printf("[hls] live session %s transcoding failed: %v", sessionID, err)
 			session.mu.Lock()
 			session.Completed = true
@@ -2558,13 +2562,22 @@ func (m *HLSManager) GetLiveUsage(provider, bucketKey string, maxStreams int) Li
 	}
 }
 
-// startLiveTranscoding starts FFmpeg for live TV HLS output
-func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSession) error {
-	log.Printf("[hls] live session %s: starting live transcoding for %s", session.ID, session.Path)
+// startLiveTranscoding starts FFmpeg for live TV HLS output. `resumeFrom` is 0 for a fresh session
+// and the next segment number when restarting a starved one, which appends to the existing playlist
+// instead of truncating it.
+func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSession, resumeFrom int) error {
+	if resumeFrom > 0 {
+		log.Printf("[hls] live session %s: restarting live transcoding for %s at segment %d",
+			session.ID, session.Path, resumeFrom)
+	} else {
+		log.Printf("[hls] live session %s: starting live transcoding for %s", session.ID, session.Path)
+	}
+	if err := os.MkdirAll(session.OutputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir %s: %w", session.OutputDir, err)
+	}
 
 	playlistPath := filepath.Join(session.OutputDir, "stream.m3u8")
 	segmentPattern := filepath.Join(session.OutputDir, "segment%d.ts")
-
 	// When a proxy is configured we cannot let ffmpeg reach the provider
 	// directly: providers reject non-proxy source IPs (401) and redirect .ts
 	// requests to CDN nodes that require a User-Agent. ffmpeg also cannot use a
@@ -2631,9 +2644,10 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 			args = append(args, "-user_agent", liveStreamUserAgent)
 		}
 		args = append(args,
+			"-rw_timeout", "30000000",
 			"-reconnect", "1",
 			"-reconnect_streamed", "1",
-			"-reconnect_delay_max", "3",
+			"-reconnect_delay_max", "5",
 		)
 		if headerArg := ffmpegHeadersArg(session.LiveTuning.RequestHeaders); headerArg != "" {
 			args = append(args, "-headers", headerArg)
@@ -2662,7 +2676,7 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 		log.Printf("[hls] live session %s: using compatibility transcode mode (video=libx264 audio=aac target=%q)", session.ID, session.PlaybackTarget)
 	}
 	session.mu.Unlock()
-	args = append(args, liveHLSOutputArgs(session.PlaybackTarget, segmentPattern, playlistPath)...)
+	args = append(args, liveHLSOutputArgs(session.PlaybackTarget, segmentPattern, playlistPath, resumeFrom)...)
 
 	log.Printf("[hls] live session %s: starting FFmpeg with args: %v", session.ID, args)
 
@@ -2709,6 +2723,12 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 		}
 	}()
 
+	// Closed when this FFmpeg run ends, so every watcher below dies with the process it was started
+	// for. Without it a restart leaves the previous run's goroutines polling: they hold a dead `cmd`,
+	// and the idle one would still set IdleTimeoutTriggered — a flag the supervisor reads to decide
+	// the session was stopped deliberately, which would strand a channel the viewer is watching.
+	processDone := make(chan struct{})
+
 	// Start idle timeout goroutine - kills FFmpeg if no segments requested for hlsIdleTimeout
 	idleDone := make(chan struct{})
 	go func() {
@@ -2719,6 +2739,8 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 		for {
 			select {
 			case <-ctx.Done():
+				return
+			case <-processDone:
 				return
 			case <-ticker.C:
 				session.mu.RLock()
@@ -2758,8 +2780,59 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 		}
 	}()
 
+	// Starvation watchdog. A provider that closes its connection leaves FFmpeg alive and reconnecting
+	// while its output falls behind realtime: segments arrive every 7-16s instead of every 2, and a
+	// player at the live edge drains its buffer and freezes. FFmpeg never exits, so nothing else here
+	// notices. Killing it hands the session to the supervisor, which rebuilds it in place.
+	//
+	// Only while somebody is actually watching: a session nobody has requested a segment from yet is
+	// the startup timeout's business, and one nobody is reading any more is the idle timeout's.
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		lastSeen := nextLiveSegmentNumber(session.OutputDir)
+		lastProgress := time.Now()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-idleDone:
+				return
+			case <-processDone:
+				return
+			case <-ticker.C:
+				session.mu.RLock()
+				consumed := session.SegmentRequestCount > 0
+				session.mu.RUnlock()
+				if !consumed {
+					lastProgress = time.Now()
+					continue
+				}
+				if current := nextLiveSegmentNumber(session.OutputDir); current != lastSeen {
+					lastSeen = current
+					lastProgress = time.Now()
+					continue
+				}
+				stallTimeout := liveStallTimeoutForOutputDir(session.OutputDir)
+				if time.Since(lastProgress) < stallTimeout {
+					continue
+				}
+				log.Printf("[hls] live session %s: STARVED - no new segment for %v (budget=%v), restarting FFmpeg",
+					session.ID, time.Since(lastProgress), stallTimeout)
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+				return
+			}
+		}
+	}()
+
 	// Wait for FFmpeg to complete
 	err = cmd.Wait()
+	// Retires this run's watchers before anything returns, including the error paths below: a
+	// restart starts its own, and two generations polling one session is how a stale one ends up
+	// killing a healthy process or flagging a deliberate stop that never happened.
+	close(processDone)
 	if err != nil {
 		if ctx.Err() != nil {
 			log.Printf("[hls] live session %s: FFmpeg stopped (context cancelled)", session.ID)
@@ -2772,6 +2845,73 @@ func (m *HLSManager) startLiveTranscoding(ctx context.Context, session *HLSSessi
 	return nil
 }
 
+// superviseLiveTranscoding keeps one live session running across upstream failures.
+//
+// A channel is not a file: the provider drops, the connection resets, FFmpeg falls behind realtime
+// or exits, and none of that means the viewer asked to stop. Every consumer of a live session — the
+// player, a Cast receiver, a DLNA renderer, the web app — sees the same frozen picture and cannot
+// fix it, because only this process owns the FFmpeg and knows the source. So the session is rebuilt
+// here, in place: same session ID, same playlist path, appended playlist with a discontinuity at
+// the seam, so nothing downstream has to be told anything.
+//
+// Bounded on purpose. A channel that is simply gone would otherwise restart forever and hold an
+// FFmpeg slot; after liveMaxRestarts inside liveRestartWindow the session is left to fail, which is
+// what surfaces a dead channel to the user instead of an eternal spinner.
+func (m *HLSManager) superviseLiveTranscoding(ctx context.Context, session *HLSSession) error {
+	var restarts int
+	windowStart := time.Now()
+	for {
+		resumeFrom := 0
+		if restarts > 0 {
+			session.mu.Lock()
+			session.Completed = false
+			session.FatalError = ""
+			session.IdleTimeoutTriggered = false
+			session.mu.Unlock()
+			resumeFrom = nextLiveSegmentNumber(session.OutputDir)
+		}
+		err := m.startLiveTranscoding(ctx, session, resumeFrom)
+		if ctx.Err() != nil {
+			return nil
+		}
+		session.mu.RLock()
+		idleStopped := session.IdleTimeoutTriggered
+		consumed := session.SegmentRequestCount > 0
+		session.mu.RUnlock()
+		if idleStopped && consumed {
+			// The idle timeout stopped it deliberately after playback started; viewer stopped watching.
+			return err
+		}
+		if !consumed && restarts >= 3 {
+			// Failed 3 startup attempts without any segment being consumed.
+			return err
+		}
+		if time.Since(windowStart) > liveRestartWindow {
+			restarts = 0
+			windowStart = time.Now()
+		}
+		if restarts >= liveMaxRestarts {
+			log.Printf("[hls] live session %s: giving up after %d restarts in %v (last: %v)",
+				session.ID, restarts, time.Since(windowStart), err)
+			return err
+		}
+		restarts++
+		// Short, growing pause: a provider that just dropped is often back within seconds, and
+		// hammering it is what gets an IPTV account rate-limited.
+		delay := time.Duration(restarts) * time.Second
+		if delay > 5*time.Second {
+			delay = 5 * time.Second
+		}
+		log.Printf("[hls] live session %s: rebuilding after upstream failure (attempt %d, in %v): %v",
+			session.ID, restarts, delay, err)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+	}
+}
+
 func isNativeLivePlaybackTarget(playbackTarget string) bool {
 	switch strings.ToLower(strings.TrimSpace(playbackTarget)) {
 	case "native", "android", "ios", "tvos", "mpv", "ksplayer", "exoplayer":
@@ -2780,6 +2920,10 @@ func isNativeLivePlaybackTarget(playbackTarget string) bool {
 		return false
 	}
 }
+
+// Compatibility live is re-encoded on two-second boundaries; this is FFmpeg's on-disk window and
+// therefore also the largest stitched playlist that can safely advertise every URI.
+const liveCompatibilityHLSListSize = 10
 
 // liveNativeHLSListSize is the sliding playlist window for native transmux live.
 // Larger than web because stream-copy can emit segments faster than players fetch
@@ -2791,8 +2935,81 @@ const liveNativeHLSListSize = 30
 // ~2 minutes at 2s segments; covers playlist re-poll and ExoPlayer retry windows.
 const liveNativeSegmentKeepBehind = 60
 
-func liveHLSOutputArgs(playbackTarget, segmentPattern, playlistPath string) []string {
-	args := make([]string, 0, 40)
+// The watchdog must be derived from the media playlist, not -hls_time. Stream-copy can only cut
+// at source keyframes: Toonami advertises TARGETDURATION 14 even though our requested HLS time is
+// two seconds. Three target durations (42s) is the safe live-edge distance RFC 8216 recommends,
+// so the floor is 45s to avoid false restarts when local FFmpeg outputs small segments.
+const liveStallTimeoutFloor = 45 * time.Second
+const liveStallTargetDurations = 3
+
+func liveStallTimeoutForOutputDir(outputDir string) time.Duration {
+	targetDuration := readLivePlaylistTargetDuration(filepath.Join(outputDir, "stream.m3u8"))
+	derived := time.Duration(targetDuration*liveStallTargetDurations) * time.Second
+	if derived > liveStallTimeoutFloor {
+		return derived
+	}
+	return liveStallTimeoutFloor
+}
+
+func readLivePlaylistTargetDuration(playlistPath string) int {
+	content, err := os.ReadFile(playlistPath)
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#EXT-X-TARGETDURATION:") {
+			continue
+		}
+		value, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "#EXT-X-TARGETDURATION:")))
+		if err == nil && value > 0 {
+			return value
+		}
+		return 0
+	}
+	return 0
+}
+
+// liveMaxRestarts caps how many times one session is rebuilt inside liveRestartWindow. Normal
+// upstream EOFs every few minutes stay below this; a dead channel cannot hold an FFmpeg slot.
+const liveMaxRestarts = 5
+const liveRestartWindow = 5 * time.Minute
+
+// nextLiveSegmentNumber is the number a restarted FFmpeg should continue from: one past the highest
+// segment already on disk. Read from the directory rather than tracked in memory so it stays true
+// across a restart that happened while nobody was counting.
+func nextLiveSegmentNumber(outputDir string) int {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return 0
+	}
+	highest := -1
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".ts") {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(name, "segment%d.ts", &n); err != nil {
+			continue
+		}
+		if n > highest {
+			highest = n
+		}
+	}
+	return highest + 1
+}
+
+// liveHLSOutputArgs builds the output half of the live FFmpeg command. `resumeFrom` is 0 for a fresh
+// session; anything higher continues the segment-number timeline after starvation. The in-memory
+// playlist stitcher retains the prior window, while the discontinuity tells clients to reinitialize
+// rather than decoding across the seam.
+func liveHLSOutputArgs(playbackTarget, segmentPattern, playlistPath string, resume ...int) []string {
+	resumeFrom := 0
+	if len(resume) > 0 {
+		resumeFrom = resume[0]
+	}
+	args := make([]string, 0, 44)
 	hlsFlags := "delete_segments+independent_segments+temp_file"
 	listSize := "10"
 
@@ -2833,6 +3050,14 @@ func liveHLSOutputArgs(playbackTarget, segmentPattern, playlistPath string) []st
 			"-b:a", "128k",
 			"-ar", "48000",
 		)
+	}
+
+	if resumeFrom > 0 {
+		// discont_start marks the timeline cut so players re-initialise their decoders.
+		// Do not use append_list: with a rolling live playlist, append_list retains stale,
+		// unplayable segments from the failed run and corrupts EXT-X-MEDIA-SEQUENCE.
+		hlsFlags += "+discont_start"
+		args = append(args, "-start_number", strconv.Itoa(resumeFrom))
 	}
 
 	return append(args,
@@ -5341,7 +5566,16 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 			http.Error(w, "playlist not ready", http.StatusInternalServerError)
 			return
 		}
-		if playlistHasMediaSegment(content) {
+		hasMinSegments := playlistHasMediaSegment(content)
+		if session != nil && session.IsLive {
+			session.mu.RLock()
+			isInitialStartup := session.MaxSegmentRequested < 0
+			session.mu.RUnlock()
+			if isInitialStartup && playlistSegmentCount(content) < 3 && time.Since(session.StreamStartTime) < 8*time.Second {
+				hasMinSegments = false
+			}
+		}
+		if hasMinSegments {
 			break
 		}
 		if livePlaylistStartupFailed(session) {
@@ -5386,9 +5620,18 @@ func (m *HLSManager) ServePlaylist(w http.ResponseWriter, r *http.Request, sessi
 		playlistContent = buildStableCastPlaylist(session)
 	}
 
+	if session.IsLive {
+		playlistContent = m.buildSeamlessLivePlaylist(session, playlistContent)
+	}
+
 	// Build header tags to inject after #EXTM3U
 	var headerTags []string
 
+	if session.IsLive && !strings.Contains(playlistContent, "#EXT-X-START") {
+		if startTag := livePlaylistStartTag(playlistContent); startTag != "" {
+			headerTags = append(headerTags, startTag)
+		}
+	}
 	// Inject EXT-X-VIDEO-RANGE for HDR/DV content - tells iOS AVPlayer to enable HDR mode
 	// Without this, iOS treats HDR content as SDR causing color banding and incorrect display.
 	// Skip when the source was tone mapped down to SDR for the web player — the
@@ -5504,17 +5747,22 @@ func livePlaylistStartupFailed(session *HLSSession) bool {
 	}
 	session.mu.RLock()
 	defer session.mu.RUnlock()
-	return session.IsLive && session.Completed
+	return session.IsLive && session.Completed && session.FatalError != ""
 }
 
-func playlistHasMediaSegment(content []byte) bool {
+func playlistSegmentCount(content []byte) int {
+	count := 0
 	for _, line := range strings.Split(string(content), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "segment") && (strings.HasSuffix(line, ".ts") || strings.HasSuffix(line, ".m4s")) {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
+}
+
+func playlistHasMediaSegment(content []byte) bool {
+	return playlistSegmentCount(content) > 0
 }
 
 func buildStableCastPlaylist(session *HLSSession) string {
@@ -6775,6 +7023,198 @@ func summarizeLivePlaylistState(outputDir string) string {
 		return fmt.Sprintf("playlistBytes=%d mediaSeq=%s segs=%d first=%s last=%s",
 			len(content), mediaSeq, len(segs), segs[0], segs[len(segs)-1])
 	}
+}
+
+type livePlaylistEntry struct {
+	MediaSequence int
+	URI           string
+	ExtInf        string
+	Duration      float64
+	Discontinuity bool
+}
+
+type livePlaylistSnapshot struct {
+	Entries               []livePlaylistEntry
+	TargetDuration        int
+	MediaSequence         int
+	DiscontinuitySequence int
+	IndependentSegments   bool
+}
+
+func parseLivePlaylist(content string) livePlaylistSnapshot {
+	lines := strings.Split(content, "\n")
+	snapshot := livePlaylistSnapshot{}
+	pendingDiscontinuity := false
+	pendingExtInf := ""
+	pendingDuration := 0.0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#EXT-X-TARGETDURATION:") {
+			if td, err := strconv.Atoi(strings.TrimPrefix(trimmed, "#EXT-X-TARGETDURATION:")); err == nil && td > 0 {
+				snapshot.TargetDuration = td
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#EXT-X-MEDIA-SEQUENCE:") {
+			if sequence, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(trimmed, "#EXT-X-MEDIA-SEQUENCE:"))); err == nil && sequence >= 0 {
+				snapshot.MediaSequence = sequence
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#EXT-X-DISCONTINUITY-SEQUENCE:") {
+			if sequence, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(trimmed, "#EXT-X-DISCONTINUITY-SEQUENCE:"))); err == nil && sequence >= 0 {
+				snapshot.DiscontinuitySequence = sequence
+			}
+			continue
+		}
+		if trimmed == "#EXT-X-INDEPENDENT-SEGMENTS" {
+			snapshot.IndependentSegments = true
+			continue
+		}
+		if trimmed == "#EXT-X-DISCONTINUITY" {
+			pendingDiscontinuity = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#EXTINF:") {
+			pendingExtInf = strings.TrimPrefix(trimmed, "#EXTINF:")
+			durStr := pendingExtInf
+			if idx := strings.IndexByte(durStr, ','); idx >= 0 {
+				durStr = durStr[:idx]
+			}
+			if d, err := strconv.ParseFloat(durStr, 64); err == nil && d > 0 {
+				pendingDuration = d
+			}
+			continue
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || pendingExtInf == "" || pendingDuration <= 0 {
+			continue
+		}
+		snapshot.Entries = append(snapshot.Entries, livePlaylistEntry{
+			MediaSequence: snapshot.MediaSequence + len(snapshot.Entries),
+			URI:           trimmed,
+			ExtInf:        pendingExtInf,
+			Duration:      pendingDuration,
+			Discontinuity: pendingDiscontinuity,
+		})
+		pendingDiscontinuity = false
+		pendingExtInf = ""
+		pendingDuration = 0
+	}
+	if snapshot.TargetDuration <= 0 {
+		for _, entry := range snapshot.Entries {
+			snapshot.TargetDuration = max(snapshot.TargetDuration, int(math.Ceil(entry.Duration)))
+		}
+	}
+	return snapshot
+}
+
+func (m *HLSManager) buildSeamlessLivePlaylist(session *HLSSession, onDiskContent string) string {
+	snapshot := parseLivePlaylist(onDiskContent)
+	if len(snapshot.Entries) == 0 || snapshot.TargetDuration <= 0 {
+		return onDiskContent
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	isStaleSnapshot := false
+	if len(session.livePlaylistWindow) == 0 {
+		session.livePlaylistTargetDuration = snapshot.TargetDuration
+		session.liveDiscontinuitySequence = snapshot.DiscontinuitySequence
+	} else {
+		// Ignore stale concurrent reads whose highest segment is below what we already stitched.
+		highestInWindow := session.livePlaylistWindow[len(session.livePlaylistWindow)-1].MediaSequence
+		highestInSnapshot := snapshot.Entries[len(snapshot.Entries)-1].MediaSequence
+		if highestInSnapshot < highestInWindow {
+			isStaleSnapshot = true
+		}
+	}
+
+	if !isStaleSnapshot {
+		// Ensure target duration satisfies RFC 8216: must be >= ceil(duration) of every retained segment.
+		session.livePlaylistTargetDuration = max(session.livePlaylistTargetDuration, snapshot.TargetDuration)
+		for _, entry := range snapshot.Entries {
+			session.livePlaylistTargetDuration = max(session.livePlaylistTargetDuration, int(math.Ceil(entry.Duration)))
+		}
+		session.livePlaylistIndependentSegments = session.livePlaylistIndependentSegments || snapshot.IndependentSegments
+
+		bySequence := make(map[int]int, len(session.livePlaylistWindow))
+		for index, entry := range session.livePlaylistWindow {
+			bySequence[entry.MediaSequence] = index
+		}
+		for _, entry := range snapshot.Entries {
+			if index, exists := bySequence[entry.MediaSequence]; exists {
+				entry.Discontinuity = entry.Discontinuity || session.livePlaylistWindow[index].Discontinuity
+				session.livePlaylistWindow[index] = entry
+				continue
+			}
+			bySequence[entry.MediaSequence] = len(session.livePlaylistWindow)
+			session.livePlaylistWindow = append(session.livePlaylistWindow, entry)
+		}
+		sort.Slice(session.livePlaylistWindow, func(i, j int) bool {
+			return session.livePlaylistWindow[i].MediaSequence < session.livePlaylistWindow[j].MediaSequence
+		})
+	}
+	maxEntries := liveCompatibilityHLSListSize
+	if isNativeLivePlaybackTarget(session.PlaybackTarget) {
+		maxEntries = liveNativeHLSListSize
+	}
+	if len(session.livePlaylistWindow) > maxEntries {
+		trimCount := len(session.livePlaylistWindow) - maxEntries
+		for _, removed := range session.livePlaylistWindow[:trimCount] {
+			if removed.Discontinuity {
+				session.liveDiscontinuitySequence++
+			}
+		}
+		session.livePlaylistWindow = append([]livePlaylistEntry(nil), session.livePlaylistWindow[trimCount:]...)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("#EXTM3U\n")
+	sb.WriteString("#EXT-X-VERSION:3\n")
+	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", session.livePlaylistTargetDuration))
+	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", session.livePlaylistWindow[0].MediaSequence))
+	if session.liveDiscontinuitySequence > 0 {
+		sb.WriteString(fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", session.liveDiscontinuitySequence))
+	}
+	if session.livePlaylistIndependentSegments {
+		sb.WriteString("#EXT-X-INDEPENDENT-SEGMENTS\n")
+	}
+
+	for _, entry := range session.livePlaylistWindow {
+		if entry.Discontinuity {
+			sb.WriteString("#EXT-X-DISCONTINUITY\n")
+		}
+		sb.WriteString("#EXTINF:")
+		sb.WriteString(entry.ExtInf)
+		sb.WriteByte('\n')
+		sb.WriteString(entry.URI)
+		sb.WriteByte('\n')
+	}
+
+	return sb.String()
+}
+
+const liveMinimumStartOffsetSeconds = 14
+
+// RFC 8216 recommends starting an open live playlist at least three target durations behind its
+// edge. Keep the historical 14-second latency for two-second Cast transcodes, but derive a deeper
+// start for stream-copy sources with long GOPs. Omit the tag until that point exists in the window.
+func livePlaylistStartTag(content string) string {
+	snapshot := parseLivePlaylist(content)
+	if len(snapshot.Entries) == 0 || snapshot.TargetDuration <= 0 {
+		return ""
+	}
+	offset := max(liveMinimumStartOffsetSeconds, snapshot.TargetDuration*liveStallTargetDurations)
+	playlistDuration := 0.0
+	for _, entry := range snapshot.Entries {
+		playlistDuration += entry.Duration
+	}
+	if playlistDuration < float64(offset) {
+		return ""
+	}
+	return fmt.Sprintf("#EXT-X-START:TIME-OFFSET=-%d,PRECISE=YES", offset)
 }
 
 // deleteOldLiveTransmuxSegments removes native live .ts segment files that are far

--- a/backend/handlers/hls_live_restart_test.go
+++ b/backend/handlers/hls_live_restart_test.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A restart must advance segment numbering rather than starting over at 0, while avoiding append_list
+// which corrupts EXT-X-MEDIA-SEQUENCE when mixed with a rolling playlist window.
+func TestLiveHLSOutputArgsResumeAdvancesAndMarksDiscontinuity(t *testing.T) {
+	fresh := strings.Join(liveHLSOutputArgs("native", "/out/segment%d.ts", "/out/stream.m3u8", 0), " ")
+	if strings.Contains(fresh, "append_list") || strings.Contains(fresh, "discont_start") {
+		t.Fatalf("a fresh session must not append or mark a discontinuity: %s", fresh)
+	}
+	if strings.Contains(fresh, "-start_number") {
+		t.Fatalf("a fresh session must not set a start number: %s", fresh)
+	}
+
+	resumed := strings.Join(liveHLSOutputArgs("native", "/out/segment%d.ts", "/out/stream.m3u8", 207), " ")
+	if strings.Contains(resumed, "append_list") {
+		t.Fatalf("a restart must not use append_list on rolling live playlists: %s", resumed)
+	}
+	// Without this the player tries to decode across the seam instead of re-initialising.
+	if !strings.Contains(resumed, "discont_start") {
+		t.Fatalf("a restart must mark the timeline cut with discont_start: %s", resumed)
+	}
+	if !strings.Contains(resumed, "-start_number 207") {
+		t.Fatalf("a restart must continue the segment numbering: %s", resumed)
+	}
+	// The copy decision belongs to the target, not the restart.
+	if !strings.Contains(resumed, "-c:v copy") {
+		t.Fatalf("a native restart must still transmux: %s", resumed)
+	}
+}
+
+// The number a restart continues from is read off disk, so it stays true even when the restart
+// happens in a process that never saw the earlier segments.
+func TestNextLiveSegmentNumber(t *testing.T) {
+	dir := t.TempDir()
+	if got := nextLiveSegmentNumber(dir); got != 0 {
+		t.Fatalf("empty dir: got %d, want 0", got)
+	}
+
+	for _, name := range []string{"segment0.ts", "segment7.ts", "segment206.ts"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// Files that are not numbered segments must not be counted: a playlist, a caption track, and
+	// FFmpeg's own temp file all live in this directory.
+	for _, name := range []string{"stream.m3u8", "captions.srt", "segment207.ts.tmp"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	if got := nextLiveSegmentNumber(dir); got != 207 {
+		t.Fatalf("got %d, want 207 (one past the highest segment)", got)
+	}
+
+	if got := nextLiveSegmentNumber(filepath.Join(dir, "missing")); got != 0 {
+		t.Fatalf("missing dir: got %d, want 0", got)
+	}
+}
+
+func TestBuildSeamlessLivePlaylist(t *testing.T) {
+	m := &HLSManager{}
+	session := &HLSSession{
+		ID:     "test-live-seamless",
+		IsLive: true,
+	}
+
+	// Initial run: segments 0..2
+	initialOnDisk := strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:3",
+		"#EXT-X-TARGETDURATION:4",
+		"#EXT-X-MEDIA-SEQUENCE:0",
+		"#EXTINF:2.000000,",
+		"segment0.ts",
+		"#EXTINF:2.000000,",
+		"segment1.ts",
+		"#EXTINF:2.000000,",
+		"segment2.ts",
+	}, "\n")
+
+	p1 := m.buildSeamlessLivePlaylist(session, initialOnDisk)
+	if !strings.Contains(p1, "#EXT-X-MEDIA-SEQUENCE:0") {
+		t.Fatalf("expected media sequence 0, got:\n%s", p1)
+	}
+	if !strings.Contains(p1, "segment0.ts") || !strings.Contains(p1, "segment2.ts") {
+		t.Fatalf("expected all initial segments, got:\n%s", p1)
+	}
+
+	// Resumed run after restart at segment 3 with discontinuity
+	resumedOnDisk := strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:3",
+		"#EXT-X-TARGETDURATION:4",
+		"#EXT-X-MEDIA-SEQUENCE:3",
+		"#EXT-X-DISCONTINUITY",
+		"#EXTINF:2.000000,",
+		"segment3.ts",
+		"#EXTINF:2.000000,",
+		"segment4.ts",
+	}, "\n")
+
+	p2 := m.buildSeamlessLivePlaylist(session, resumedOnDisk)
+	// The merged playlist must retain the previous window starting at 0
+	if !strings.Contains(p2, "#EXT-X-MEDIA-SEQUENCE:0") {
+		t.Fatalf("expected media sequence 0 to be preserved across restart, got:\n%s", p2)
+	}
+	// Discontinuity must be placed before segment 3
+	if !strings.Contains(p2, "#EXT-X-DISCONTINUITY\n#EXTINF:2.000000,\nsegment3.ts") {
+		t.Fatalf("expected discontinuity before segment3.ts, got:\n%s", p2)
+	}
+	// Both old and new segments must be present in consecutive order
+	if !strings.Contains(p2, "segment0.ts") || !strings.Contains(p2, "segment4.ts") {
+		t.Fatalf("expected consecutive old and new segments, got:\n%s", p2)
+	}
+}
+
+func liveTestPlaylist(mediaSequence, count, targetDuration int, discontinuity bool) string {
+	lines := []string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:3",
+		fmt.Sprintf("#EXT-X-TARGETDURATION:%d", targetDuration),
+		fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d", mediaSequence),
+	}
+	for i := 0; i < count; i++ {
+		if discontinuity && i == 0 {
+			lines = append(lines, "#EXT-X-DISCONTINUITY")
+		}
+		lines = append(lines, "#EXTINF:2.000000,", fmt.Sprintf("segment%d.ts", mediaSequence+i))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestBuildSeamlessLivePlaylistCarriesDiscontinuitySequenceWhenSeamRollsOut(t *testing.T) {
+	m := &HLSManager{}
+	session := &HLSSession{ID: "discontinuity-sequence", IsLive: true}
+
+	m.buildSeamlessLivePlaylist(session, liveTestPlaylist(0, liveCompatibilityHLSListSize, 2, false))
+	playlist := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(10, 1, 2, true))
+	if !strings.Contains(playlist, "#EXT-X-DISCONTINUITY\n#EXTINF:2.000000,\nsegment10.ts") {
+		t.Fatalf("restart seam was not retained:\n%s", playlist)
+	}
+
+	for sequence := 11; sequence <= 20; sequence++ {
+		playlist = m.buildSeamlessLivePlaylist(session, liveTestPlaylist(sequence, 1, 2, false))
+	}
+	if !strings.Contains(playlist, "#EXT-X-MEDIA-SEQUENCE:11") {
+		t.Fatalf("rolling window has the wrong first media sequence:\n%s", playlist)
+	}
+	if !strings.Contains(playlist, "#EXT-X-DISCONTINUITY-SEQUENCE:1") {
+		t.Fatalf("removed seam did not advance discontinuity sequence:\n%s", playlist)
+	}
+	if strings.Contains(playlist, "#EXT-X-DISCONTINUITY\n") {
+		t.Fatalf("a rolled-out seam must not remain in the media entries:\n%s", playlist)
+	}
+}
+
+func TestBuildSeamlessLivePlaylistIgnoresAStaleConcurrentRead(t *testing.T) {
+	m := &HLSManager{}
+	session := &HLSSession{ID: "stale-read", IsLive: true}
+
+	stale := liveTestPlaylist(10, liveCompatibilityHLSListSize, 2, false)
+	m.buildSeamlessLivePlaylist(session, stale)
+	newer := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(20, 1, 2, false))
+	if !strings.Contains(newer, "#EXT-X-MEDIA-SEQUENCE:11") {
+		t.Fatalf("new segment did not advance the window:\n%s", newer)
+	}
+	afterStale := m.buildSeamlessLivePlaylist(session, stale)
+	if !strings.Contains(afterStale, "#EXT-X-MEDIA-SEQUENCE:11") || !strings.Contains(afterStale, "segment20.ts") {
+		t.Fatalf("stale read moved the playlist backwards:\n%s", afterStale)
+	}
+}
+
+func TestBuildSeamlessLivePlaylistKeepsTargetDurationStable(t *testing.T) {
+	m := &HLSManager{}
+	session := &HLSSession{ID: "stable-target", IsLive: true, PlaybackTarget: "native"}
+
+	m.buildSeamlessLivePlaylist(session, liveTestPlaylist(0, 1, 14, false))
+	playlist := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(1, 1, 2, false))
+	if !strings.Contains(playlist, "#EXT-X-TARGETDURATION:14") {
+		t.Fatalf("target duration changed across playlist updates:\n%s", playlist)
+	}
+}
+
+func TestLivePlaylistStartTagUsesThreeTargetDurations(t *testing.T) {
+	compat := liveTestPlaylist(0, 7, 2, false)
+	if got := livePlaylistStartTag(compat); got != "#EXT-X-START:TIME-OFFSET=-14,PRECISE=YES" {
+		t.Fatalf("compat start tag = %q", got)
+	}
+
+	shortNative := strings.Join([]string{
+		"#EXTM3U", "#EXT-X-TARGETDURATION:14", "#EXT-X-MEDIA-SEQUENCE:0",
+		"#EXTINF:11.633,", "segment0.ts",
+		"#EXTINF:8.750,", "segment1.ts",
+		"#EXTINF:8.967,", "segment2.ts",
+	}, "\n")
+	if got := livePlaylistStartTag(shortNative); got != "" {
+		t.Fatalf("short native playlist must omit an out-of-window start tag, got %q", got)
+	}
+
+	fullNative := shortNative + "\n#EXTINF:14.000,\nsegment3.ts"
+	if got := livePlaylistStartTag(fullNative); got != "#EXT-X-START:TIME-OFFSET=-42,PRECISE=YES" {
+		t.Fatalf("native start tag = %q", got)
+	}
+}
+
+func TestLiveStallTimeoutUsesPlaylistTargetDuration(t *testing.T) {
+	dir := t.TempDir()
+	if got := liveStallTimeoutForOutputDir(dir); got != liveStallTimeoutFloor {
+		t.Fatalf("missing playlist timeout = %v, want %v", got, liveStallTimeoutFloor)
+	}
+	// Output TARGETDURATION:4 should use the 45s floor to prevent false restarts on 14s broadcast gaps.
+	if err := os.WriteFile(filepath.Join(dir, "stream.m3u8"), []byte(liveTestPlaylist(0, 1, 4, false)), 0o600); err != nil {
+		t.Fatalf("write playlist: %v", err)
+	}
+	if got, want := liveStallTimeoutForOutputDir(dir), liveStallTimeoutFloor; got != want {
+		t.Fatalf("small target duration timeout = %v, want floor %v", got, want)
+	}
+	// Large TARGETDURATION:16 derives 16 * 3 = 48s (> floor).
+	if err := os.WriteFile(filepath.Join(dir, "stream.m3u8"), []byte(liveTestPlaylist(0, 1, 16, false)), 0o600); err != nil {
+		t.Fatalf("write playlist: %v", err)
+	}
+	if got, want := liveStallTimeoutForOutputDir(dir), 48*time.Second; got != want {
+		t.Fatalf("large target-derived timeout = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
### Summary
- **Initial Playout Pre-Buffer:** Pre-buffer at least 3 segments on live session startup before returning `stream.m3u8` to prevent Chromecast MSE playout buffer starvation on the initial chunk.
- **Extended Input Timeout:** Increase FFmpeg `-rw_timeout` from 4s to 30s (`30000000` microseconds) to accommodate 10–15s IPTV broadcaster chunk downloads without premature EOF disconnects.
- **Dynamic Watchdog Floor:** Derive live stall timeout dynamically from `EXT-X-TARGETDURATION` with a 45-second floor.
- **Seamless Restart Reconstruction:** Stitch playlists monotonically across restarts with continuous sequence numbering and discontinuity tags.