### PR TITLE
fix(hls): retain live cast segments until the player consumes them

### DIFF
--- a/backend/handlers/hls.go
+++ b/backend/handlers/hls.go
@@ -2923,18 +2923,17 @@ func isNativeLivePlaybackTarget(playbackTarget string) bool {
 	}
 }
 
-// Compatibility live is re-encoded on two-second boundaries; this is FFmpeg's on-disk window and
-// therefore also the largest stitched playlist that can safely advertise every URI.
-const liveCompatibilityHLSListSize = 10
-
-// liveNativeHLSListSize is the sliding playlist window for native transmux live.
-// Larger than web because stream-copy can emit segments faster than players fetch
-// them, and we intentionally do not use FFmpeg delete_segments for native.
+// liveNativeHLSListSize is the sliding playlist window for every live target: FFmpeg's
+// on-disk window and therefore also the largest stitched playlist that can safely
+// advertise every URI. No live path uses FFmpeg delete_segments — production is unpaced
+// and can advance the window faster than players fetch — so retention is consumption-paced
+// (deleteOldLiveTransmuxSegments) and the window must cover a lagging player's backlog.
+// Named for the native transmux path it was introduced for; compatibility live matches it.
 const liveNativeHLSListSize = 30
 
 // liveNativeSegmentKeepBehind is how many completed segment files to retain on disk
-// behind the highest served/requested index when cleaning up native live sessions.
-// ~2 minutes at 2s segments; covers playlist re-poll and ExoPlayer retry windows.
+// behind the highest served/requested index when cleaning up live sessions.
+// ~2 minutes at 2s segments; covers playlist re-poll and player retry windows.
 const liveNativeSegmentKeepBehind = 60
 
 // The watchdog must be derived from the media playlist, not -hls_time. Stream-copy can only cut
@@ -3012,9 +3011,9 @@ func liveHLSOutputArgs(playbackTarget, segmentPattern, playlistPath string, resu
 		resumeFrom = resume[0]
 	}
 	args := make([]string, 0, 44)
-	hlsFlags := "delete_segments+independent_segments+temp_file"
-	listSize := "10"
-
+	// Compatibility (cast/web) retention is the default; the native branch overrides.
+	hlsFlags := "independent_segments+temp_file"
+	listSize := strconv.Itoa(liveNativeHLSListSize)
 	if isNativeLivePlaybackTarget(playbackTarget) {
 		// Native apps (ExoPlayer / KSPlayer / MPV) demux/decode IPTV codecs themselves.
 		// Always transmux (copy) for those targets — never libx264/aac here. Web browser
@@ -3034,9 +3033,14 @@ func liveHLSOutputArgs(playbackTarget, segmentPattern, playlistPath string, resu
 		hlsFlags = "temp_file"
 		listSize = strconv.Itoa(liveNativeHLSListSize)
 	} else {
-		// Web and legacy callers retain the compatibility encode with a controlled
-		// keyframe cadence. delete_segments is safe here because re-encoding is slower
-		// than typical playlist/segment fetch cadence.
+		// Cast, web, and compatibility callers re-encode with controlled keyframes.
+		// No FFmpeg delete_segments: production is unpaced, so bursts advance the
+		// playlist window faster than the player fetches, and deleting scrolled-out
+		// segments 404s a lagging player (Chromecast starts ~14s behind the edge via
+		// EXT-X-START) whose pending fetches still need them. Retention is
+		// consumption-paced instead: ServeSegment prunes files behind the
+		// served/requested high-water mark with a keep-behind window — the same
+		// contract native live already runs on.
 		args = append(args,
 			"-c:v", "libx264",
 			"-preset", "veryfast",
@@ -6300,14 +6304,12 @@ func (m *HLSManager) ServeSegment(w http.ResponseWriter, r *http.Request, sessio
 	m.noteCastSegmentDelivery(session, r, servedSegmentNum, segmentSize, serveDuration)
 
 	// Clean up old segments to save disk space.
-	// Web live sessions use FFmpeg's delete_segments flag (transcode path).
-	// Native live transmux deliberately omits delete_segments (see liveHLSOutputArgs)
-	// so we prune served segment files ourselves with a fixed keep-behind window.
+	// No live session uses FFmpeg's delete_segments (see liveHLSOutputArgs), so every
+	// live target — native and compatibility alike — is pruned here, consumption-paced
+	// off the served/requested high-water mark with a fixed keep-behind window.
 	// VOD uses buffer-aware deleteOldSegments.
 	if session.IsLive {
-		if isNativeLivePlaybackTarget(session.PlaybackTarget) {
-			go m.deleteOldLiveTransmuxSegments(session, servedSegmentNum)
-		}
+		go m.deleteOldLiveTransmuxSegments(session, servedSegmentNum)
 	} else {
 		go m.deleteOldSegments(session, segmentName)
 	}
@@ -7158,10 +7160,8 @@ func (m *HLSManager) buildSeamlessLivePlaylist(session *HLSSession, onDiskConten
 			return session.livePlaylistWindow[i].MediaSequence < session.livePlaylistWindow[j].MediaSequence
 		})
 	}
-	maxEntries := liveCompatibilityHLSListSize
-	if isNativeLivePlaybackTarget(session.PlaybackTarget) {
-		maxEntries = liveNativeHLSListSize
-	}
+	// One window for every live target, matching what FFmpeg retains on disk.
+	maxEntries := liveNativeHLSListSize
 	if len(session.livePlaylistWindow) > maxEntries {
 		trimCount := len(session.livePlaylistWindow) - maxEntries
 		for _, removed := range session.livePlaylistWindow[:trimCount] {
@@ -7219,9 +7219,9 @@ func livePlaylistStartTag(content string) string {
 	return fmt.Sprintf("#EXT-X-START:TIME-OFFSET=-%d,PRECISE=YES", offset)
 }
 
-// deleteOldLiveTransmuxSegments removes native live .ts segment files that are far
-// behind the playback edge. Native live omits FFmpeg delete_segments so early
-// segments stay available for the player's first fetch; without this cleanup a long
+// deleteOldLiveTransmuxSegments removes live .ts segment files that are far behind
+// what the player has consumed. Live output omits FFmpeg delete_segments so segments
+// stay available for a lagging player's pending fetches; without this cleanup a long
 // session would accumulate every segment file ever written.
 func (m *HLSManager) deleteOldLiveTransmuxSegments(session *HLSSession, justServedSegment int) {
 	if session == nil || justServedSegment < 0 {

--- a/backend/handlers/hls_live_cast_test.go
+++ b/backend/handlers/hls_live_cast_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cast live runs the compatibility branch of liveHLSOutputArgs: it re-encodes, but production
+// is unpaced, so FFmpeg's production-paced delete_segments removes segments a lagging receiver
+// (Chromecast starts ~14s behind the edge via EXT-X-START) has not fetched yet. Cast must run
+// the native retention contract instead: wide window, no delete_segments, consumption-paced
+// pruning in ServeSegment.
+func TestLiveHLSOutputArgsCastUsesConsumptionPacedRetention(t *testing.T) {
+	args := liveHLSOutputArgs("cast", "/tmp/live/segment%d.ts", "/tmp/live/stream.m3u8")
+	joined := strings.Join(args, " ")
+
+	for _, expected := range []string{
+		"-c:v libx264",
+		"independent_segments+temp_file",
+		fmt.Sprintf("-hls_list_size %d", liveNativeHLSListSize),
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("cast live args %q missing %q", joined, expected)
+		}
+	}
+	if strings.Contains(joined, "delete_segments") {
+		t.Fatalf("cast live args must not use delete_segments: %q", joined)
+	}
+}
+
+// A starved-and-rebuilt Cast session continues the segment timeline rather than starting over,
+// and marks the seam so the receiver re-initialises instead of decoding across it.
+func TestLiveHLSOutputArgsCastResumeAdvancesAndMarksDiscontinuity(t *testing.T) {
+	resumed := strings.Join(liveHLSOutputArgs("cast", "/out/segment%d.ts", "/out/stream.m3u8", 207), " ")
+	if strings.Contains(resumed, "append_list") {
+		t.Fatalf("a cast restart must not use append_list on rolling live playlists: %s", resumed)
+	}
+	if !strings.Contains(resumed, "discont_start") {
+		t.Fatalf("a cast restart must mark the timeline cut with discont_start: %s", resumed)
+	}
+	if !strings.Contains(resumed, "-start_number 207") {
+		t.Fatalf("a cast restart must continue the segment numbering: %s", resumed)
+	}
+	if strings.Contains(resumed, "delete_segments") {
+		t.Fatalf("a cast restart must still avoid delete_segments: %s", resumed)
+	}
+}
+
+// Serving a segment prunes what the player has already consumed for every live target, not
+// just native: without FFmpeg delete_segments on the compat branch, this keep-behind window
+// is the only thing bounding a Cast live session's disk use while the player is watching.
+func TestServeSegmentPrunesConsumedSegmentsForCastLive(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i <= 80; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("segment%d.ts", i))
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	session := &HLSSession{
+		ID:                  "cast-live-prune",
+		OutputDir:           dir,
+		IsLive:              true,
+		PlaybackTarget:      "cast",
+		MaxSegmentRequested: -1,
+		LastSegmentServed:   -1,
+	}
+	m := &HLSManager{sessions: map[string]*HLSSession{session.ID: session}}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/hls/"+session.ID+"/segment80.ts", nil)
+	m.ServeSegment(recorder, request, session.ID, "segment80.ts")
+	if recorder.Code != 200 {
+		t.Fatalf("serving segment80.ts got status %d", recorder.Code)
+	}
+
+	// Pruning runs in a goroutine off the served high-water mark; wait for it.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(filepath.Join(dir, "segment0.ts")); os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// highWater=80, keepBehind=60 → cutoff=20: 0..20 pruned, 21..80 retained.
+	for i := 0; i <= 20; i++ {
+		if _, err := os.Stat(filepath.Join(dir, fmt.Sprintf("segment%d.ts", i))); !os.IsNotExist(err) {
+			t.Fatalf("segment%d.ts should have been pruned for a cast live session", i)
+		}
+	}
+	for i := 21; i <= 80; i++ {
+		if _, err := os.Stat(filepath.Join(dir, fmt.Sprintf("segment%d.ts", i))); err != nil {
+			t.Fatalf("segment%d.ts must survive the keep-behind window: %v", i, err)
+		}
+	}
+}

--- a/backend/handlers/hls_live_restart_test.go
+++ b/backend/handlers/hls_live_restart_test.go
@@ -144,16 +144,18 @@ func TestBuildSeamlessLivePlaylistCarriesDiscontinuitySequenceWhenSeamRollsOut(t
 	m := &HLSManager{}
 	session := &HLSSession{ID: "discontinuity-sequence", IsLive: true}
 
-	m.buildSeamlessLivePlaylist(session, liveTestPlaylist(0, liveCompatibilityHLSListSize, 2, false))
-	playlist := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(10, 1, 2, true))
-	if !strings.Contains(playlist, "#EXT-X-DISCONTINUITY\n#EXTINF:2.000000,\nsegment10.ts") {
+	m.buildSeamlessLivePlaylist(session, liveTestPlaylist(0, liveNativeHLSListSize, 2, false))
+	playlist := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(liveNativeHLSListSize, 1, 2, true))
+	seam := fmt.Sprintf("#EXT-X-DISCONTINUITY\n#EXTINF:2.000000,\nsegment%d.ts", liveNativeHLSListSize)
+	if !strings.Contains(playlist, seam) {
 		t.Fatalf("restart seam was not retained:\n%s", playlist)
 	}
 
-	for sequence := 11; sequence <= 20; sequence++ {
+	for sequence := liveNativeHLSListSize + 1; sequence <= 2*liveNativeHLSListSize; sequence++ {
 		playlist = m.buildSeamlessLivePlaylist(session, liveTestPlaylist(sequence, 1, 2, false))
 	}
-	if !strings.Contains(playlist, "#EXT-X-MEDIA-SEQUENCE:11") {
+	first := fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d", liveNativeHLSListSize+1)
+	if !strings.Contains(playlist, first) {
 		t.Fatalf("rolling window has the wrong first media sequence:\n%s", playlist)
 	}
 	if !strings.Contains(playlist, "#EXT-X-DISCONTINUITY-SEQUENCE:1") {
@@ -168,14 +170,15 @@ func TestBuildSeamlessLivePlaylistIgnoresAStaleConcurrentRead(t *testing.T) {
 	m := &HLSManager{}
 	session := &HLSSession{ID: "stale-read", IsLive: true}
 
-	stale := liveTestPlaylist(10, liveCompatibilityHLSListSize, 2, false)
+	stale := liveTestPlaylist(10, liveNativeHLSListSize, 2, false)
 	m.buildSeamlessLivePlaylist(session, stale)
-	newer := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(20, 1, 2, false))
+	newest := 10 + liveNativeHLSListSize
+	newer := m.buildSeamlessLivePlaylist(session, liveTestPlaylist(newest, 1, 2, false))
 	if !strings.Contains(newer, "#EXT-X-MEDIA-SEQUENCE:11") {
 		t.Fatalf("new segment did not advance the window:\n%s", newer)
 	}
 	afterStale := m.buildSeamlessLivePlaylist(session, stale)
-	if !strings.Contains(afterStale, "#EXT-X-MEDIA-SEQUENCE:11") || !strings.Contains(afterStale, "segment20.ts") {
+	if !strings.Contains(afterStale, "#EXT-X-MEDIA-SEQUENCE:11") || !strings.Contains(afterStale, fmt.Sprintf("segment%d.ts", newest)) {
 		t.Fatalf("stale read moved the playlist backwards:\n%s", afterStale)
 	}
 }

--- a/backend/handlers/hls_test.go
+++ b/backend/handlers/hls_test.go
@@ -856,8 +856,10 @@ func TestLiveHLSOutputArgsWebRetainsCompatibilityTranscode(t *testing.T) {
 		"-c:v libx264",
 		"-c:a aac",
 		"-force_key_frames expr:gte(t,n_forced*1)",
-		"delete_segments+independent_segments+temp_file",
-		"-hls_list_size 10",
+		// Same wide window and consumption-paced retention as native live:
+		// no delete_segments, pruned by ServeSegment behind the served high-water mark.
+		"independent_segments+temp_file",
+		fmt.Sprintf("-hls_list_size %d", liveNativeHLSListSize),
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("web live args %q missing %q", joined, expected)
@@ -865,6 +867,9 @@ func TestLiveHLSOutputArgsWebRetainsCompatibilityTranscode(t *testing.T) {
 	}
 	if strings.Contains(joined, "-c:v copy") {
 		t.Fatalf("web live args should re-encode, not copy: %q", joined)
+	}
+	if strings.Contains(joined, "delete_segments") {
+		t.Fatalf("web live args must not use delete_segments (unpaced production deletes unread segments): %q", joined)
 	}
 }
 


### PR DESCRIPTION
Cast and web live sessions ran the compatibility transcode with FFmpeg's `delete_segments` over a 10-segment window while production is unpaced: startup and reconnect bursts scroll the window faster than realtime, and a Chromecast told to start 14s behind the edge (`EXT-X-START`) had its pending segment fetches deleted under it — `ServeSegment` waited 15s, 404'd, and MPL gave up (`BUFFERING`, then `IDLE:ERROR`).

Compatibility live now matches the native contract that works:
- Use `independent_segments+temp_file` (omit `delete_segments`)
- Maintain a 30-segment window (`liveNativeHLSListSize`) on disk and in the stitched playlist
- Prune old segments through consumption-paced cleanup in `ServeSegment` off the served/requested high-water mark for every live target